### PR TITLE
Add GitHub Actions CI for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,102 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+      - "feature/**"
+      - "fix/**"
+      - "refactor/**"
+      - "docs/**"
+      - "integration/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows:
+    name: Windows MSVC
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Cache build
+        uses: actions/cache@v4
+        with:
+          path: build/ci-windows
+          key: ci-windows-${{ hashFiles('CMakeLists.txt', 'Src/CMakeLists.txt', 'Vendor/CMakeLists.txt', 'Tests/CMakeLists.txt') }}
+          restore-keys: ci-windows-
+
+      - name: Configure
+        run: cmake --preset ci-windows
+
+      - name: Build
+        run: cmake --build --preset build-ci-windows --parallel
+
+      - name: Test
+        run: ctest --preset test-ci-windows
+
+  linux:
+    name: Linux GCC
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build \
+            libgl-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+            libxkbcommon-dev libwayland-dev
+
+      - name: Cache build
+        uses: actions/cache@v4
+        with:
+          path: build/ci-linux
+          key: ci-linux-${{ hashFiles('CMakeLists.txt', 'Src/CMakeLists.txt', 'Vendor/CMakeLists.txt', 'Tests/CMakeLists.txt') }}
+          restore-keys: ci-linux-
+
+      - name: Configure
+        run: cmake --preset ci-linux
+
+      - name: Build
+        run: cmake --build --preset build-ci-linux --parallel
+
+      - name: Test
+        run: ctest --preset test-ci-linux
+
+  macos:
+    name: macOS Clang
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Ninja
+        run: brew install ninja
+
+      - name: Cache build
+        uses: actions/cache@v4
+        with:
+          path: build/ci-macos
+          key: ci-macos-${{ hashFiles('CMakeLists.txt', 'Src/CMakeLists.txt', 'Vendor/CMakeLists.txt', 'Tests/CMakeLists.txt') }}
+          restore-keys: ci-macos-
+
+      - name: Configure
+        run: cmake --preset ci-macos
+
+      - name: Build
+        run: cmake --build --preset build-ci-macos --parallel
+
+      - name: Test
+        run: ctest --preset test-ci-macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
     name: Windows MSVC
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Cache build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build/ci-windows
           key: ci-windows-${{ hashFiles('CMakeLists.txt', 'Src/CMakeLists.txt', 'Vendor/CMakeLists.txt', 'Tests/CMakeLists.txt') }}
@@ -47,7 +47,7 @@ jobs:
     name: Linux GCC
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -59,7 +59,7 @@ jobs:
             libxkbcommon-dev libwayland-dev
 
       - name: Cache build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build/ci-linux
           key: ci-linux-${{ hashFiles('CMakeLists.txt', 'Src/CMakeLists.txt', 'Vendor/CMakeLists.txt', 'Tests/CMakeLists.txt') }}
@@ -78,7 +78,7 @@ jobs:
     name: macOS Clang
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -86,7 +86,7 @@ jobs:
         run: brew install ninja
 
       - name: Cache build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build/ci-macos
           key: ci-macos-${{ hashFiles('CMakeLists.txt', 'Src/CMakeLists.txt', 'Vendor/CMakeLists.txt', 'Tests/CMakeLists.txt') }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -51,6 +51,42 @@
       }
     },
     {
+      "name": "ci-windows",
+      "displayName": "CI — Windows VS2022 Release",
+      "generator": "Visual Studio 17 2022",
+      "architecture": { "value": "x64", "strategy": "set" },
+      "binaryDir": "${sourceDir}/build/ci-windows",
+      "cacheVariables": {
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/ci-windows",
+        "GLAB_BUILD_TESTS": "ON",
+        "GLAB_ENABLE_WARNINGS": "ON"
+      }
+    },
+    {
+      "name": "ci-linux",
+      "displayName": "CI — Linux Ninja Release",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/ci-linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/ci-linux",
+        "GLAB_BUILD_TESTS": "ON",
+        "GLAB_ENABLE_WARNINGS": "ON"
+      }
+    },
+    {
+      "name": "ci-macos",
+      "displayName": "CI — macOS Ninja Release",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/ci-macos",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/ci-macos",
+        "GLAB_BUILD_TESTS": "ON",
+        "GLAB_ENABLE_WARNINGS": "ON"
+      }
+    },
+    {
       "name": "ninja-debug",
       "displayName": "Ninja Debug",
       "generator": "Ninja",
@@ -121,6 +157,19 @@
       "configuration": "Release"
     },
     {
+      "name": "build-ci-windows",
+      "configurePreset": "ci-windows",
+      "configuration": "Release"
+    },
+    {
+      "name": "build-ci-linux",
+      "configurePreset": "ci-linux"
+    },
+    {
+      "name": "build-ci-macos",
+      "configurePreset": "ci-macos"
+    },
+    {
       "name": "build-ninja-debug",
       "configurePreset": "ninja-debug"
     },
@@ -138,6 +187,22 @@
     }
   ],
   "testPresets": [
+    {
+      "name": "test-ci-windows",
+      "configurePreset": "ci-windows",
+      "configuration": "Release",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "test-ci-linux",
+      "configurePreset": "ci-linux",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "test-ci-macos",
+      "configurePreset": "ci-macos",
+      "output": { "outputOnFailure": true }
+    },
     {
       "name": "test-windows-debug",
       "configurePreset": "windows-vs-debug",


### PR DESCRIPTION
## Summary
- Add a GitHub Actions CI workflow under `.github/workflows/ci.yml`
- Run CI for pull requests targeting `main`
- Add CMake presets for GitHub Actions CI workflow

## Why
- The workflow requires `main` to remain stable and buildable
- Pull requests are the required review boundary for non-trivial changes, so CI should run at the PR stage

## Affected areas
- `.github/workflows/ci.yml`
- `CMakePresets.txt`

## Documentation
- [ ] No documentation needed
- [x] Documentation updated

## Testing
- Verified that the GitHub Actions workflow file is valid YAML
- Confirmed that the workflow is configured to run on pull requests to `main`

## Notes
- This PR intentionally focuses only on adding the initial CI workflow
- Required status checks in branch protection/rulesets should be enabled after this workflow has successfully run at least once