### PR TITLE
Fix resource system test failures

### DIFF
--- a/Tests/Contract/Core/TestFileSystem.cpp
+++ b/Tests/Contract/Core/TestFileSystem.cpp
@@ -145,7 +145,7 @@ TEST(FileSystemContractTests, ResolveReadPathUsesCatalogForExtensionlessProjectA
     const auto resolved = FileSystem::ResolveReadPath("/Project/Textures/Grassy_Square");
 
     ASSERT_TRUE(resolved.has_value());
-    EXPECT_EQ(*resolved, ProjectContentPath("textures/Grassy_Square.jpg"));
+    EXPECT_EQ(*resolved, ProjectContentPath("Textures/Grassy_Square.jpg"));
     EXPECT_TRUE(std::filesystem::exists(*resolved));
 }
 
@@ -155,7 +155,7 @@ TEST(FileSystemContractTests, ResolveReadPathCanSwitchBetweenSourceAndCookedProj
 
     const auto sourceResolved = FileSystem::ResolveReadPath("/Project/Textures/Grassy_Square");
     ASSERT_TRUE(sourceResolved.has_value());
-    EXPECT_EQ(*sourceResolved, ProjectContentPath("textures/Grassy_Square.jpg"));
+    EXPECT_EQ(*sourceResolved, ProjectContentPath("Textures/Grassy_Square.jpg"));
 
     const auto cookedRoot = FileSystem::GetCacheDir() / "Cooked" / "Project";
     const auto cookedArtifactPath = cookedRoot / "Textures" / "Grassy_Square.rtrtex";
@@ -197,7 +197,7 @@ TEST(FileSystemContractTests, ResolveReadPathCanSwitchBetweenSourceAndCookedProj
     FileSystem::RefreshCatalogs();
     const auto revertedResolved = FileSystem::ResolveReadPath("/Project/Textures/Grassy_Square");
     ASSERT_TRUE(revertedResolved.has_value());
-    EXPECT_EQ(*revertedResolved, ProjectContentPath("textures/Grassy_Square.jpg"));
+    EXPECT_EQ(*revertedResolved, ProjectContentPath("Textures/Grassy_Square.jpg"));
 
     test_support::RemoveTreeIfExists(FileSystem::GetCacheDir() / "Cooked");
 }
@@ -447,7 +447,7 @@ TEST(FileSystemContractTests, ResolveReadPathCanSwitchBetweenLooseAndPackagedArt
 
     const auto sourceProjectResolved = FileSystem::ResolveReadPath("/Project/Textures/Grassy_Square");
     ASSERT_TRUE(sourceProjectResolved.has_value());
-    EXPECT_EQ(*sourceProjectResolved, ProjectContentPath("textures/Grassy_Square.jpg"));
+    EXPECT_EQ(*sourceProjectResolved, ProjectContentPath("Textures/Grassy_Square.jpg"));
 
     const auto sourceEngineResolved = FileSystem::ResolveReadPath("/Engine/Defaults/Materials/Phase13PackagedMaterial");
     ASSERT_TRUE(sourceEngineResolved.has_value());
@@ -865,7 +865,7 @@ TEST(FileSystemContractTests, ResolveReadPathKeepsProjectAndPluginNamespacesSepa
 
     ASSERT_TRUE(projectResolved.has_value());
     ASSERT_TRUE(pluginResolved.has_value());
-    EXPECT_EQ(*projectResolved, ProjectContentPath("textures/Grassy_Square.jpg"));
+    EXPECT_EQ(*projectResolved, ProjectContentPath("Textures/Grassy_Square.jpg"));
     EXPECT_EQ(*pluginResolved, pluginArtifactPath);
 
     test_support::RemoveTreeIfExists(pluginRoot.parent_path().parent_path());
@@ -1052,7 +1052,7 @@ TEST(FileSystemContractTests, ResolveReadPathProjectCatalogStillWorksWhenAnother
     const auto resolved = FileSystem::ResolveReadPath("/Project/Textures/Grassy_Square");
 
     ASSERT_TRUE(resolved.has_value());
-    EXPECT_EQ(*resolved, ProjectContentPath("textures/Grassy_Square.jpg"));
+    EXPECT_EQ(*resolved, ProjectContentPath("Textures/Grassy_Square.jpg"));
 
     test_support::RemoveTreeIfExists(pluginRoot.parent_path().parent_path());
 }


### PR DESCRIPTION
## Summary
Update FileSystem path resolving tests assertions to match canonical `Textures` casing

## Why
- `FileSystemContractTests` expected `/Content/textures/Grassy_Square.jpg`, but the current source catalog and runtime-resolved physical path use `/Content/Textures/Grassy_Square.jpg`
- The failures were caused by stale string assertions in tests, not by incorrect runtime path resolution

## Affected areas
- `Tests/Contract/Core/TestFileSystem.cpp`
- `FileSystemContractTests` cases covering project asset path resolution in source, cooked fallback, packaged fallback, and project/plugin namespace separation scenarios

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Built `rtrlab_contract_tests` with `cmake --build build\windows-vs-debug --config Debug --target rtrlab_contract_tests`
- Ran `build\windows-vs-debug\bin\Debug\rtrlab_contract_tests.exe --gtest_filter=FileSystemContractTests.*`
- Result: 33/33 tests passed

## Notes
- No runtime code changed; this was a test expectation update only
- The resolved path now matches the actual catalog-generated and on-disk canonical directory casing