### PR TITLE
Implement in-memory source catalog flow

### DIFF
--- a/CMakePresets/test/common.json
+++ b/CMakePresets/test/common.json
@@ -36,20 +36,20 @@
       }
     },
     {
-      "name": "test-label-debug-matrix",
+      "name": "test-filter-debug-matrix",
       "hidden": true,
       "filter": {
         "include": {
-          "label": "common|dev-profile"
+          "name": "^(Unit\\.|Integration\\.|DevProfile\\.)"
         }
       }
     },
     {
-      "name": "test-label-release-matrix",
+      "name": "test-filter-release-matrix",
       "hidden": true,
       "filter": {
         "include": {
-          "label": "common|shipping-profile"
+          "name": "^(Unit\\.|Integration\\.|ShippingProfile\\.)"
         }
       }
     },

--- a/CMakePresets/test/linux.json
+++ b/CMakePresets/test/linux.json
@@ -27,7 +27,7 @@
       "name": "test-ci-linux-ninja-release",
       "inherits": [
         "test-base",
-        "test-label-release-matrix"
+        "test-filter-release-matrix"
       ],
       "configurePreset": "ci-linux-ninja-release"
     },
@@ -35,7 +35,7 @@
       "name": "test-ci-linux-ninja-debug",
       "inherits": [
         "test-base",
-        "test-label-debug-matrix"
+        "test-filter-debug-matrix"
       ],
       "configurePreset": "ci-linux-ninja-debug"
     },

--- a/CMakePresets/test/macos.json
+++ b/CMakePresets/test/macos.json
@@ -27,7 +27,7 @@
       "name": "test-ci-macos-ninja-debug",
       "inherits": [
         "test-base",
-        "test-label-debug-matrix"
+        "test-filter-debug-matrix"
       ],
       "configurePreset": "ci-macos-ninja-debug"
     },
@@ -35,7 +35,7 @@
       "name": "test-ci-macos-ninja-release",
       "inherits": [
         "test-base",
-        "test-label-release-matrix"
+        "test-filter-release-matrix"
       ],
       "configurePreset": "ci-macos-ninja-release"
     },

--- a/CMakePresets/test/windows.json
+++ b/CMakePresets/test/windows.json
@@ -30,7 +30,7 @@
       "name": "test-ci-windows-vs-debug",
       "inherits": [
         "test-base",
-        "test-label-debug-matrix"
+        "test-filter-debug-matrix"
       ],
       "configurePreset": "ci-windows-vs-debug",
       "configuration": "Debug"
@@ -39,7 +39,7 @@
       "name": "test-ci-windows-vs-release",
       "inherits": [
         "test-base",
-        "test-label-release-matrix"
+        "test-filter-release-matrix"
       ],
       "configurePreset": "ci-windows-vs-release",
       "configuration": "Release"

--- a/Docs/Modules/ResourceSystem/Design.md
+++ b/Docs/Modules/ResourceSystem/Design.md
@@ -467,13 +467,17 @@ or this:
 
 ### 10.1 Source Indexing
 
-`rtr_asset_index` scans readable loose content roots and generates source catalogs for:
+`rtr_asset_index` can scan readable loose content roots and export source catalogs for:
 
 - `Project/`
 - `Engine/`
 
 It skips document-style config subtrees for extensionless asset indexing and enforces
 logical-path uniqueness.
+
+At runtime in development builds, and during cooking, source catalogs are built in
+memory from the source trees rather than being read back from `Project/.rtr/catalog.json`
+or `Engine/.rtr/catalog.json`.
 
 ### 10.2 Loose Cooked Output
 
@@ -543,7 +547,8 @@ active engine subsystem with the following implemented behavior:
 - `/Project/`, `/Engine/`, `/Saved/`, and `/Cache/` are active
 - config fallback resolution is implemented through serialization-facing helpers
 - logical-path-based file I/O is implemented
-- source catalogs are generated and consumed
+- source catalogs can be generated for inspection or tooling, while dev runtime and cook
+  build source catalogs in memory
 - loose cooked catalogs are generated and consumed
 - packaged `.rtrpak` archives are generated and consumed
 - overlay precedence over packaged/cooked/source mounts is implemented
@@ -665,10 +670,10 @@ src/Tools/
 .rtrproject                    - Development-time project root marker
 
 Project/
-    .rtr/catalog.json           - Generated project source catalog
+    ...                         - Project source files (catalog built in memory in dev)
 
 Engine/
-    .rtr/catalog.json           - Generated engine source catalog
+    ...                         - Engine source files (catalog built in memory in dev)
 
 Saved/Cache/Cooked/
     ...                         - Loose cooked output

--- a/Docs/Modules/ResourceSystem/Internals.md
+++ b/Docs/Modules/ResourceSystem/Internals.md
@@ -78,8 +78,8 @@ Offline phase (build time)                Runtime phase
 - Entry: `src/Tools/AssetIndexMain.cpp` -> `Resource::IndexRepositorySourceCatalogs()`
 - Implementation: `src/Core/Resource/Catalog/SourceCatalog.cpp`
 
-**What it does**: recursively scans mount roots and generates a `.rtr/catalog.json` per
-mount.
+**What it does**: recursively scans mount roots and can generate a `.rtr/catalog.json`
+per mount.
 
 **Steps** (`SourceCatalog.cpp:304-319`):
 
@@ -132,7 +132,7 @@ mount.
 - Entry: `src/Tools/AssetCookMain.cpp` -> `Resource::CookRepositoryCatalogs()`
 - Implementation: `src/Core/Resource/Cook/CookedCatalog.cpp`
 
-**What it does**: reads each mount's source catalog, converts source files to
+**What it does**: scans each source mount in memory, converts source files to
 runtime-ready artifacts, and writes them to a cooked output directory.
 
 **Steps** (`CookedCatalog.cpp:644-703`):
@@ -140,7 +140,7 @@ runtime-ready artifacts, and writes them to a cooked output directory.
 1. Discover all source mounts and determine the corresponding cooked output directory
    (e.g. `Saved/Cache/Cooked/Project/`).
 
-2. Read each mount's `.rtr/catalog.json`.
+2. Build source catalog entries in memory for each mount.
 
 3. For each source artifact, call `CopySourceArtifact`:
    - **Image files** (logical path starts with `Textures/`, format is jpg/png): decode
@@ -290,8 +290,10 @@ merging, and artifact selection.
    Overlay mounts are discovered from `Saved/Overrides/` or the `RTRLAB_OVERLAY_ROOT`
    environment variable.
 
-2. For each discovered mount, read its catalog:
-   - Directory backend: read `{mountRoot}/.rtr/catalog.json` from disk.
+2. For each discovered mount, acquire its catalog:
+   - Dev source directory backend (`Project/` or `Engine/`, source priority): build the
+     source catalog in memory from the source tree.
+   - Other directory backends: read `{mountRoot}/.rtr/catalog.json` from disk.
    - PakArchive backend: extract `.rtr/catalog.json` from inside the `.rtrpak` file.
 
 3. Parse the catalog JSON, validate version (v1 = source, v2 = cooked), and verify that

--- a/Src/Core/Resource/Catalog/ResourceCatalog.cpp
+++ b/Src/Core/Resource/Catalog/ResourceCatalog.cpp
@@ -3,6 +3,7 @@
 #include "Core/Diagnostics/Logging/LogCategories.h"
 #include "Core/Diagnostics/Logging/LogMacros.h"
 #include "Core/Resource/Mount/MountBackend.h"
+#include "Core/Resource/Catalog/SourceCatalog.h"
 #include "Core/Resource/Path/PathParser.h"
 
 #include <algorithm>
@@ -228,6 +229,17 @@ namespace
         return ParseCatalogFromJson(rootJson, catalogLabel, mount.mountPath, catalogKind, catalogVersion, entries);
     }
 
+    bool ShouldBuildSourceCatalogInMemory(const Resource::ReadableMount &mount, std::string_view currentProfileTag)
+    {
+        if (currentProfileTag != "dev")
+            return false;
+
+        return mount.priority == Resource::MountPriority::Source &&
+               mount.backend == Resource::MountBackendKind::Directory &&
+               (mount.mountPath.domain == Resource::PathDomain::Project ||
+                mount.mountPath.domain == Resource::PathDomain::Engine);
+    }
+
     std::string_view GetCurrentPlatformTag()
     {
 #if defined(_WIN32)
@@ -410,15 +422,36 @@ namespace Resource
             m_GlobalTableBuilt = true;
             m_GlobalEntries.clear();
             m_ConflictedLogicalPaths.clear();
+            const auto currentProfileTag = GetCurrentProfileTag();
 
             for (const auto &mount : Resource::DiscoverReadableMountBackends(
-                     rootPath, engineDir, cacheDir, projectContentDirName, GetCurrentProfileTag()))
+                     rootPath, engineDir, cacheDir, projectContentDirName, currentProfileTag))
             {
                 auto &cache = m_MountCatalogs[mount.cacheKey];
                 if (!cache.attemptedLoad)
                 {
                     cache.attemptedLoad = true;
-                    if (Resource::MountHasCatalog(mount))
+                    if (ShouldBuildSourceCatalogInMemory(mount, currentProfileTag))
+                    {
+                        cache.kind = CatalogKind::Source;
+                        cache.version = 1;
+                        std::unordered_map<std::string, ResourceCatalogEntry> loadedEntries;
+                        if (!Resource::BuildSourceCatalogMap(mount.mountRoot, mount.mountPath, loadedEntries))
+                        {
+                            cache.entries.clear();
+                            LOG_ERROR_CAT(LogCategory::FileSystem,
+                                          "Failed to build in-memory source catalog '{}'",
+                                          mount.mountRoot.string());
+                        }
+                        else
+                        {
+                            cache.entries = std::move(loadedEntries);
+                            LOG_INFO_CAT(LogCategory::FileSystem,
+                                         "Built in-memory source catalog '{}'",
+                                         mount.mountRoot.string());
+                        }
+                    }
+                    else if (Resource::MountHasCatalog(mount))
                     {
                         cache.kind = CatalogKind::Source;
                         cache.version = 0;

--- a/Src/Core/Resource/Catalog/SourceCatalog.cpp
+++ b/Src/Core/Resource/Catalog/SourceCatalog.cpp
@@ -102,16 +102,16 @@ namespace
 
         return mounts;
     }
-} // namespace
 
-namespace Resource
-{
-    bool BuildSourceCatalogEntries(const std::filesystem::path &mountRoot,
-                                   const VirtualPath &mountPath,
-                                   std::vector<ResourceCatalogEntry> &entries,
-                                   std::string *errorMessage)
+    bool BuildSourceCatalogEntriesInternal(const std::filesystem::path &mountRoot,
+                                           const Resource::VirtualPath &mountPath,
+                                           std::vector<Resource::ResourceCatalogEntry> &entries,
+                                           std::unordered_map<std::string, Resource::ResourceCatalogEntry> *entryMap,
+                                           std::string *errorMessage)
     {
         entries.clear();
+        if (entryMap != nullptr)
+            entryMap->clear();
 
         std::unordered_map<std::string, size_t> entryIndexByLogicalPath;
         std::error_code ec;
@@ -176,10 +176,10 @@ namespace Resource
                 return false;
             }
 
-            ResourceCatalogEntry catalogEntry;
+            Resource::ResourceCatalogEntry catalogEntry;
             catalogEntry.logicalPath = logicalPath;
             catalogEntry.sourceRelativePath = CatalogPathToGenericString(relativePath);
-            catalogEntry.artifacts.push_back(ArtifactRecord{
+            catalogEntry.artifacts.push_back(Resource::ArtifactRecord{
                 .relativePath = CatalogPathToGenericString(relativePath),
                 .format = DetectFormat(relativePath),
                 .platformTag = "any",
@@ -189,10 +189,32 @@ namespace Resource
             });
 
             entryIndexByLogicalPath.emplace(logicalPath, entries.size());
-            entries.push_back(std::move(catalogEntry));
+            entries.push_back(catalogEntry);
+            if (entryMap != nullptr)
+                entryMap->emplace(logicalPath, std::move(catalogEntry));
         }
 
         return true;
+    }
+} // namespace
+
+namespace Resource
+{
+    bool BuildSourceCatalogMap(const std::filesystem::path &mountRoot,
+                               const VirtualPath &mountPath,
+                               std::unordered_map<std::string, ResourceCatalogEntry> &entries,
+                               std::string *errorMessage)
+    {
+        std::vector<ResourceCatalogEntry> orderedEntries;
+        return BuildSourceCatalogEntriesInternal(mountRoot, mountPath, orderedEntries, &entries, errorMessage);
+    }
+
+    bool BuildSourceCatalogEntries(const std::filesystem::path &mountRoot,
+                                   const VirtualPath &mountPath,
+                                   std::vector<ResourceCatalogEntry> &entries,
+                                   std::string *errorMessage)
+    {
+        return BuildSourceCatalogEntriesInternal(mountRoot, mountPath, entries, nullptr, errorMessage);
     }
 
     bool WriteSourceCatalogJson(const std::filesystem::path &catalogPath,

--- a/Src/Core/Resource/Catalog/SourceCatalog.h
+++ b/Src/Core/Resource/Catalog/SourceCatalog.h
@@ -5,10 +5,16 @@
 #include <filesystem>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace Resource
 {
+    bool BuildSourceCatalogMap(const std::filesystem::path &mountRoot,
+                               const VirtualPath &mountPath,
+                               std::unordered_map<std::string, ResourceCatalogEntry> &entries,
+                               std::string *errorMessage = nullptr);
+
     bool BuildSourceCatalogEntries(const std::filesystem::path &mountRoot,
                                    const VirtualPath &mountPath,
                                    std::vector<ResourceCatalogEntry> &entries,

--- a/Src/Core/Resource/Cook/CookedCatalog.cpp
+++ b/Src/Core/Resource/Cook/CookedCatalog.cpp
@@ -253,112 +253,6 @@ namespace
         return mounts;
     }
 
-    bool LoadCatalogEntries(const std::filesystem::path &catalogPath,
-                            std::vector<Resource::ResourceCatalogEntry> &entries,
-                            std::string *errorMessage)
-    {
-        std::ifstream in(catalogPath, std::ios::in | std::ios::binary);
-        if (!in.is_open())
-        {
-            if (errorMessage != nullptr)
-                *errorMessage = "failed to open source catalog: " + catalogPath.string();
-            return false;
-        }
-
-        Json rootJson;
-        try
-        {
-            in >> rootJson;
-        }
-        catch (const std::exception &e)
-        {
-            if (errorMessage != nullptr)
-                *errorMessage = "failed to parse source catalog '" + catalogPath.string() + "': " + e.what();
-            return false;
-        }
-
-        const auto versionIt = rootJson.find("version");
-        if (versionIt == rootJson.end() || !versionIt->is_number_integer() || versionIt->get<int>() != 1)
-        {
-            if (errorMessage != nullptr)
-                *errorMessage = "unsupported source catalog version in " + catalogPath.string();
-            return false;
-        }
-
-        const auto entriesIt = rootJson.find("entries");
-        if (entriesIt == rootJson.end() || !entriesIt->is_array())
-        {
-            if (errorMessage != nullptr)
-                *errorMessage = "source catalog missing entries array: " + catalogPath.string();
-            return false;
-        }
-
-        entries.clear();
-
-        for (const auto &entryJson : *entriesIt)
-        {
-            if (!entryJson.is_object())
-            {
-                if (errorMessage != nullptr)
-                    *errorMessage = "source catalog contains a non-object entry: " + catalogPath.string();
-                return false;
-            }
-
-            const auto logicalPathIt = entryJson.find("logicalPath");
-            const auto sourceRelativePathIt = entryJson.find("sourceRelativePath");
-            const auto artifactsIt = entryJson.find("artifacts");
-            if (logicalPathIt == entryJson.end() || !logicalPathIt->is_string() ||
-                sourceRelativePathIt == entryJson.end() || !sourceRelativePathIt->is_string() ||
-                artifactsIt == entryJson.end() || !artifactsIt->is_array())
-            {
-                if (errorMessage != nullptr)
-                    *errorMessage = "source catalog entry is missing required fields: " + catalogPath.string();
-                return false;
-            }
-
-            Resource::ResourceCatalogEntry entry;
-            entry.logicalPath = logicalPathIt->get<std::string>();
-            entry.sourceRelativePath = sourceRelativePathIt->get<std::string>();
-
-            for (const auto &artifactJson : *artifactsIt)
-            {
-                if (!artifactJson.is_object())
-                {
-                    if (errorMessage != nullptr)
-                        *errorMessage = "source catalog entry contains a non-object artifact: " + catalogPath.string();
-                    return false;
-                }
-
-                const auto relativePathIt = artifactJson.find("relativePath");
-                if (relativePathIt == artifactJson.end() || !relativePathIt->is_string())
-                {
-                    if (errorMessage != nullptr)
-                        *errorMessage = "source catalog artifact is missing relativePath: " + catalogPath.string();
-                    return false;
-                }
-
-                Resource::ArtifactRecord artifact;
-                artifact.relativePath = relativePathIt->get<std::string>();
-                if (const auto it = artifactJson.find("format"); it != artifactJson.end() && it->is_string())
-                    artifact.format = it->get<std::string>();
-                if (const auto it = artifactJson.find("platformTag"); it != artifactJson.end() && it->is_string())
-                    artifact.platformTag = it->get<std::string>();
-                if (const auto it = artifactJson.find("backendTag"); it != artifactJson.end() && it->is_string())
-                    artifact.backendTag = it->get<std::string>();
-                if (const auto it = artifactJson.find("profileTag"); it != artifactJson.end() && it->is_string())
-                    artifact.profileTag = it->get<std::string>();
-                if (const auto it = artifactJson.find("contentHash"); it != artifactJson.end() && it->is_number_unsigned())
-                    artifact.contentHash = it->get<uint64_t>();
-
-                entry.artifacts.push_back(std::move(artifact));
-            }
-
-            entries.push_back(std::move(entry));
-        }
-
-        return true;
-    }
-
     bool WriteCookedCatalogJson(const std::filesystem::path &catalogPath,
                                 const std::vector<Resource::ResourceCatalogEntry> &entries,
                                 std::string *errorMessage)
@@ -616,16 +510,8 @@ namespace Resource
     {
         for (const auto &mount : DiscoverReadableSourceMounts(rootPath, cookedRootPath, projectContentDirName))
         {
-            const auto sourceCatalogPath = mount.sourceRoot / ".rtr" / "catalog.json";
-            if (!std::filesystem::exists(sourceCatalogPath))
-            {
-                if (errorMessage != nullptr)
-                    *errorMessage = "missing source catalog for mount root: " + mount.sourceRoot.string();
-                return false;
-            }
-
             std::vector<ResourceCatalogEntry> sourceEntries;
-            if (!LoadCatalogEntries(sourceCatalogPath, sourceEntries, errorMessage))
+            if (!BuildSourceCatalogEntries(mount.sourceRoot, mount.mountPath, sourceEntries, errorMessage))
                 return false;
 
             std::vector<ResourceCatalogEntry> cookedEntries;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -87,6 +87,7 @@ glab_add_test_executable(rtrlab_integration_tests "Integration." "integration;co
 )
 
 set(GLAB_DEV_PROFILE_TEST_SOURCES
+    Integration/TestMountBackendDev.cpp
     Integration/TestSourceCatalogDev.cpp
     Integration/TestRootDiscoveryDev.cpp
 )

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -87,6 +87,7 @@ glab_add_test_executable(rtrlab_integration_tests "Integration." "integration;co
 )
 
 set(GLAB_DEV_PROFILE_TEST_SOURCES
+    Integration/TestSourceCatalogDev.cpp
     Integration/TestRootDiscoveryDev.cpp
 )
 

--- a/Tests/Integration/TestMountBackend.cpp
+++ b/Tests/Integration/TestMountBackend.cpp
@@ -52,27 +52,6 @@ TEST_F(MountBackendTests, ResolveWritableMountReturnsSavedAndCacheRoots)
     EXPECT_FALSE(Resource::ResolveWritableMount(Resource::PathDomain::Project, savedDir, cacheDir).has_value());
 }
 
-TEST_F(MountBackendTests, DiscoverReadableMountBackendsFindsSourceDirectoryMounts)
-{
-    const auto repoRoot = TestRoot() / "repo";
-    test_support::WriteProjectMarkerOrFail(repoRoot);
-
-    test_support::EnsureDirectories(test_support::ProjectContentRoot(repoRoot));
-    test_support::EnsureDirectories(test_support::EngineRoot(repoRoot));
-
-    const auto mounts = Resource::DiscoverReadableMountBackends(
-        repoRoot, test_support::EngineRoot(repoRoot), test_support::CookedRoot(repoRoot), "Project", "dev");
-
-    ASSERT_EQ(mounts.size(), 2u);
-    EXPECT_EQ(mounts[0].sourceKey, "Project");
-    EXPECT_EQ(mounts[0].priority, Resource::MountPriority::Source);
-    EXPECT_EQ(mounts[0].backend, Resource::MountBackendKind::Directory);
-
-    EXPECT_EQ(mounts[1].sourceKey, "Engine");
-    EXPECT_EQ(mounts[1].priority, Resource::MountPriority::Source);
-    EXPECT_EQ(mounts[1].backend, Resource::MountBackendKind::Directory);
-}
-
 TEST_F(MountBackendTests, ResolveReadableMountArtifactMaterializesPakArchiveEntries)
 {
     const auto sourceRoot = TestRoot() / "pak-source";

--- a/Tests/Integration/TestMountBackendDev.cpp
+++ b/Tests/Integration/TestMountBackendDev.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "Core/Resource/Mount/MountBackend.h"
+#include "ResourceTestSupport.h"
+
+namespace
+{
+    class MountBackendDevTests : public ::testing::Test
+    {
+    protected:
+        void SetUp() override
+        {
+            m_TestRoot = test_support::CurrentTestRoot("mount-backend-dev");
+            test_support::ResetCurrentTestRoot("mount-backend-dev");
+        }
+
+        void TearDown() override
+        {
+            test_support::RemoveCurrentTestArtifacts("mount-backend-dev");
+        }
+
+        std::filesystem::path TestRoot() const
+        {
+            return m_TestRoot;
+        }
+
+    private:
+        std::filesystem::path m_TestRoot;
+    };
+} // namespace
+
+TEST_F(MountBackendDevTests, DiscoverReadableMountBackendsFindsSourceDirectoryMounts)
+{
+    const auto repoRoot = TestRoot() / "repo";
+    test_support::WriteProjectMarkerOrFail(repoRoot);
+
+    test_support::EnsureDirectories(test_support::ProjectContentRoot(repoRoot));
+    test_support::EnsureDirectories(test_support::EngineRoot(repoRoot));
+
+    const auto mounts = Resource::DiscoverReadableMountBackends(
+        repoRoot, test_support::EngineRoot(repoRoot), test_support::CookedRoot(repoRoot), "Project", "dev");
+
+    ASSERT_EQ(mounts.size(), 2u);
+    EXPECT_EQ(mounts[0].sourceKey, "Project");
+    EXPECT_EQ(mounts[0].priority, Resource::MountPriority::Source);
+    EXPECT_EQ(mounts[0].backend, Resource::MountBackendKind::Directory);
+
+    EXPECT_EQ(mounts[1].sourceKey, "Engine");
+    EXPECT_EQ(mounts[1].priority, Resource::MountPriority::Source);
+    EXPECT_EQ(mounts[1].backend, Resource::MountBackendKind::Directory);
+}

--- a/Tests/Integration/TestSourceCatalogDev.cpp
+++ b/Tests/Integration/TestSourceCatalogDev.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "Core/Resource/Catalog/ResourceCatalog.h"
+#include "ResourceTestSupport.h"
+
+namespace
+{
+    class SourceCatalogDevTests : public ::testing::Test
+    {
+    protected:
+        void SetUp() override
+        {
+            m_TestRoot = test_support::CurrentTestRoot("source-catalog-dev");
+            test_support::ResetCurrentTestRoot("source-catalog-dev");
+        }
+
+        void TearDown() override
+        {
+            test_support::RemoveCurrentTestArtifacts("source-catalog-dev");
+        }
+
+        std::filesystem::path TestRoot() const
+        {
+            return m_TestRoot;
+        }
+
+    private:
+        std::filesystem::path m_TestRoot;
+    };
+} // namespace
+
+TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsProjectSourceCatalogInMemoryDuringDevResolution)
+{
+    const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
+    test_support::WriteProjectFileOrFail(repoRoot, "Textures/Grassy_Square.jpg", "jpg");
+
+    Resource::CatalogRegistry registry;
+    const auto virtualPath = Resource::VirtualPath{Resource::PathDomain::Project, std::nullopt, "Textures/Grassy_Square"};
+    const auto resolved = registry.ResolvePath(
+        repoRoot,
+        test_support::EngineRoot(repoRoot),
+        repoRoot / "Saved" / "Cache",
+        virtualPath,
+        "/Project/Textures/Grassy_Square",
+        "Project");
+
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_EQ(*resolved, test_support::ProjectContentRoot(repoRoot) / "Textures" / "Grassy_Square.jpg");
+}
+
+TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsEngineSourceCatalogInMemoryDuringDevResolution)
+{
+    const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
+    test_support::WriteEngineFileOrFail(repoRoot, "Defaults/Materials/ErrorMaterial.json", "{\n}\n");
+
+    Resource::CatalogRegistry registry;
+    const auto virtualPath = Resource::VirtualPath{Resource::PathDomain::Engine, std::nullopt, "Defaults/Materials/ErrorMaterial"};
+    const auto resolved = registry.ResolvePath(
+        repoRoot,
+        test_support::EngineRoot(repoRoot),
+        repoRoot / "Saved" / "Cache",
+        virtualPath,
+        "/Engine/Defaults/Materials/ErrorMaterial",
+        "Project");
+
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_EQ(*resolved, test_support::EngineRoot(repoRoot) / "Defaults" / "Materials" / "ErrorMaterial.json");
+}

--- a/Tests/Unit/TestCookedCatalog.cpp
+++ b/Tests/Unit/TestCookedCatalog.cpp
@@ -61,10 +61,9 @@ TEST_F(CookedCatalogTests, CookRepositoryCatalogsCopiesArtifactsAndWritesCookedC
 {
     const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
     test_support::WriteProjectBinaryFileOrFail(repoRoot, "textures/Grassy_Square.png", kOnePixelPng);
+    EXPECT_FALSE(std::filesystem::exists(test_support::ProjectSourceCatalogPath(repoRoot)));
 
     std::string errorMessage;
-    ASSERT_TRUE(Resource::IndexRepositorySourceCatalogs(repoRoot, "Project", &errorMessage)) << errorMessage;
-
     const auto cookedRoot = test_support::CookedRoot(repoRoot);
     ASSERT_TRUE(Resource::CookRepositoryCatalogs(repoRoot, cookedRoot, "Project", &errorMessage)) << errorMessage;
 
@@ -116,10 +115,10 @@ TEST_F(CookedCatalogTests, CookRepositoryCatalogsPreservesLogicalPathsAcrossProj
         repoRoot,
         "Defaults/Materials/ErrorMaterial.json",
         "{\n  \"name\": \"error-material\"\n}\n");
+    EXPECT_FALSE(std::filesystem::exists(test_support::ProjectSourceCatalogPath(repoRoot)));
+    EXPECT_FALSE(std::filesystem::exists(test_support::EngineSourceCatalogPath(repoRoot)));
 
     std::string errorMessage;
-    ASSERT_TRUE(Resource::IndexRepositorySourceCatalogs(repoRoot, "Project", &errorMessage)) << errorMessage;
-
     const auto cookedRoot = test_support::CookedRoot(repoRoot);
     ASSERT_TRUE(Resource::CookRepositoryCatalogs(repoRoot, cookedRoot, "Project", &errorMessage)) << errorMessage;
 
@@ -129,15 +128,10 @@ TEST_F(CookedCatalogTests, CookRepositoryCatalogsPreservesLogicalPathsAcrossProj
         return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
     };
 
-    const auto projectSourceCatalog = readFile(test_support::ProjectSourceCatalogPath(repoRoot));
-    const auto engineSourceCatalog = readFile(test_support::EngineSourceCatalogPath(repoRoot));
-
     const auto projectCookedCatalog = readFile(test_support::ProjectCookedCatalogPath(cookedRoot));
     const auto engineCookedCatalog = readFile(test_support::EngineCookedCatalogPath(cookedRoot));
 
-    EXPECT_NE(projectSourceCatalog.find("/Project/Textures/Grassy_Square"), std::string::npos);
     EXPECT_NE(projectCookedCatalog.find("/Project/Textures/Grassy_Square"), std::string::npos);
-    EXPECT_NE(engineSourceCatalog.find("/Engine/Defaults/Materials/ErrorMaterial"), std::string::npos);
     EXPECT_NE(engineCookedCatalog.find("/Engine/Defaults/Materials/ErrorMaterial"), std::string::npos);
 
     EXPECT_TRUE(std::filesystem::exists(test_support::ProjectCookedRoot(cookedRoot) / "Textures" / "Grassy_Square.rtrtex"));

--- a/Tests/Unit/TestSourceCatalog.cpp
+++ b/Tests/Unit/TestSourceCatalog.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <iterator>
 #include <string>
+#include <unordered_map>
 
 #include "Core/Resource/Catalog/SourceCatalog.h"
 #include "ResourceTestSupport.h"
@@ -58,6 +59,33 @@ TEST_F(SourceCatalogTests, BuildProjectSourceCatalogSkipsConfigAndCatalogArtifac
     EXPECT_EQ(entries[0].artifacts[0].profileTag, "dev");
 }
 
+TEST_F(SourceCatalogTests, BuildSourceCatalogMapReturnsEntriesByLogicalPath)
+{
+    test_support::WriteMountFileOrFail(TestRoot(), "Textures/Grassy_Square.jpg", "jpg");
+
+    std::unordered_map<std::string, Resource::ResourceCatalogEntry> entries;
+    std::string errorMessage;
+
+    ASSERT_TRUE(Resource::BuildSourceCatalogMap(
+        TestRoot(),
+        Resource::VirtualPath{Resource::PathDomain::Project, std::nullopt, {}},
+        entries,
+        &errorMessage))
+        << errorMessage;
+
+    ASSERT_EQ(entries.size(), 1u);
+    const auto it = entries.find("/Project/Textures/Grassy_Square");
+    ASSERT_NE(it, entries.end());
+    ASSERT_TRUE(it->second.sourceRelativePath.has_value());
+    EXPECT_EQ(*it->second.sourceRelativePath, "Textures/Grassy_Square.jpg");
+    ASSERT_EQ(it->second.artifacts.size(), 1u);
+    EXPECT_EQ(it->second.artifacts[0].relativePath, "Textures/Grassy_Square.jpg");
+    EXPECT_EQ(it->second.artifacts[0].format, "jpg");
+    EXPECT_EQ(it->second.artifacts[0].platformTag, "any");
+    EXPECT_EQ(it->second.artifacts[0].backendTag, "any");
+    EXPECT_EQ(it->second.artifacts[0].profileTag, "dev");
+}
+
 TEST_F(SourceCatalogTests, BuildSourceCatalogRejectsDuplicateLogicalPaths)
 {
     test_support::WriteMountFileOrFail(TestRoot(), "Textures/Grassy_Square.jpg", "jpg");
@@ -72,6 +100,40 @@ TEST_F(SourceCatalogTests, BuildSourceCatalogRejectsDuplicateLogicalPaths)
         entries,
         &errorMessage));
     EXPECT_NE(errorMessage.find("duplicate logical path"), std::string::npos);
+}
+
+TEST_F(SourceCatalogTests, BuildSourceCatalogMapRejectsDuplicateLogicalPaths)
+{
+    test_support::WriteMountFileOrFail(TestRoot(), "Textures/Grassy_Square.jpg", "jpg");
+    test_support::WriteMountFileOrFail(TestRoot(), "Textures/Grassy_Square.png", "png");
+
+    std::unordered_map<std::string, Resource::ResourceCatalogEntry> entries;
+    std::string errorMessage;
+
+    EXPECT_FALSE(Resource::BuildSourceCatalogMap(
+        TestRoot(),
+        Resource::VirtualPath{Resource::PathDomain::Project, std::nullopt, {}},
+        entries,
+        &errorMessage));
+    EXPECT_NE(errorMessage.find("duplicate logical path"), std::string::npos);
+}
+
+TEST_F(SourceCatalogTests, BuildEngineSourceCatalogMapUsesEngineNamespace)
+{
+    test_support::WriteMountFileOrFail(TestRoot(), "Defaults/Materials/ErrorMaterial.json", "{\n}\n");
+
+    std::unordered_map<std::string, Resource::ResourceCatalogEntry> entries;
+    std::string errorMessage;
+
+    ASSERT_TRUE(Resource::BuildSourceCatalogMap(
+        TestRoot(),
+        Resource::VirtualPath{Resource::PathDomain::Engine, std::nullopt, {}},
+        entries,
+        &errorMessage))
+        << errorMessage;
+
+    ASSERT_EQ(entries.size(), 1u);
+    EXPECT_TRUE(entries.contains("/Engine/Defaults/Materials/ErrorMaterial"));
 }
 
 TEST_F(SourceCatalogTests, IndexRepositorySourceCatalogsWritesProjectAndEngineCatalogs)

--- a/Tests/Unit/TestSourceCatalog.cpp
+++ b/Tests/Unit/TestSourceCatalog.cpp
@@ -5,7 +5,6 @@
 #include <string>
 #include <unordered_map>
 
-#include "Core/Resource/Catalog/ResourceCatalog.h"
 #include "Core/Resource/Catalog/SourceCatalog.h"
 #include "ResourceTestSupport.h"
 
@@ -162,44 +161,6 @@ TEST_F(SourceCatalogTests, IndexRepositorySourceCatalogsWritesProjectAndEngineCa
 
     EXPECT_NE(projectContents.find("/Project/Textures/Grassy_Square"), std::string::npos);
     EXPECT_NE(engineContents.find("/Engine/Defaults/Materials/ErrorMaterial"), std::string::npos);
-}
-
-TEST_F(SourceCatalogTests, CatalogRegistryBuildsProjectSourceCatalogInMemoryDuringDevResolution)
-{
-    const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
-    test_support::WriteProjectFileOrFail(repoRoot, "Textures/Grassy_Square.jpg", "jpg");
-
-    Resource::CatalogRegistry registry;
-    const auto virtualPath = Resource::VirtualPath{Resource::PathDomain::Project, std::nullopt, "Textures/Grassy_Square"};
-    const auto resolved = registry.ResolvePath(
-        repoRoot,
-        test_support::EngineRoot(repoRoot),
-        repoRoot / "Saved" / "Cache",
-        virtualPath,
-        "/Project/Textures/Grassy_Square",
-        "Project");
-
-    ASSERT_TRUE(resolved.has_value());
-    EXPECT_EQ(*resolved, test_support::ProjectContentRoot(repoRoot) / "Textures" / "Grassy_Square.jpg");
-}
-
-TEST_F(SourceCatalogTests, CatalogRegistryBuildsEngineSourceCatalogInMemoryDuringDevResolution)
-{
-    const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
-    test_support::WriteEngineFileOrFail(repoRoot, "Defaults/Materials/ErrorMaterial.json", "{\n}\n");
-
-    Resource::CatalogRegistry registry;
-    const auto virtualPath = Resource::VirtualPath{Resource::PathDomain::Engine, std::nullopt, "Defaults/Materials/ErrorMaterial"};
-    const auto resolved = registry.ResolvePath(
-        repoRoot,
-        test_support::EngineRoot(repoRoot),
-        repoRoot / "Saved" / "Cache",
-        virtualPath,
-        "/Engine/Defaults/Materials/ErrorMaterial",
-        "Project");
-
-    ASSERT_TRUE(resolved.has_value());
-    EXPECT_EQ(*resolved, test_support::EngineRoot(repoRoot) / "Defaults" / "Materials" / "ErrorMaterial.json");
 }
 
 TEST_F(SourceCatalogTests, WriteSourceCatalogJsonRejectsEntriesWithoutSourceRelativePath)

--- a/Tests/Unit/TestSourceCatalog.cpp
+++ b/Tests/Unit/TestSourceCatalog.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "Core/Resource/Catalog/ResourceCatalog.h"
 #include "Core/Resource/Catalog/SourceCatalog.h"
 #include "ResourceTestSupport.h"
 
@@ -161,6 +162,44 @@ TEST_F(SourceCatalogTests, IndexRepositorySourceCatalogsWritesProjectAndEngineCa
 
     EXPECT_NE(projectContents.find("/Project/Textures/Grassy_Square"), std::string::npos);
     EXPECT_NE(engineContents.find("/Engine/Defaults/Materials/ErrorMaterial"), std::string::npos);
+}
+
+TEST_F(SourceCatalogTests, CatalogRegistryBuildsProjectSourceCatalogInMemoryDuringDevResolution)
+{
+    const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
+    test_support::WriteProjectFileOrFail(repoRoot, "Textures/Grassy_Square.jpg", "jpg");
+
+    Resource::CatalogRegistry registry;
+    const auto virtualPath = Resource::VirtualPath{Resource::PathDomain::Project, std::nullopt, "Textures/Grassy_Square"};
+    const auto resolved = registry.ResolvePath(
+        repoRoot,
+        test_support::EngineRoot(repoRoot),
+        repoRoot / "Saved" / "Cache",
+        virtualPath,
+        "/Project/Textures/Grassy_Square",
+        "Project");
+
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_EQ(*resolved, test_support::ProjectContentRoot(repoRoot) / "Textures" / "Grassy_Square.jpg");
+}
+
+TEST_F(SourceCatalogTests, CatalogRegistryBuildsEngineSourceCatalogInMemoryDuringDevResolution)
+{
+    const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
+    test_support::WriteEngineFileOrFail(repoRoot, "Defaults/Materials/ErrorMaterial.json", "{\n}\n");
+
+    Resource::CatalogRegistry registry;
+    const auto virtualPath = Resource::VirtualPath{Resource::PathDomain::Engine, std::nullopt, "Defaults/Materials/ErrorMaterial"};
+    const auto resolved = registry.ResolvePath(
+        repoRoot,
+        test_support::EngineRoot(repoRoot),
+        repoRoot / "Saved" / "Cache",
+        virtualPath,
+        "/Engine/Defaults/Materials/ErrorMaterial",
+        "Project");
+
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_EQ(*resolved, test_support::EngineRoot(repoRoot) / "Defaults" / "Materials" / "ErrorMaterial.json");
 }
 
 TEST_F(SourceCatalogTests, WriteSourceCatalogJsonRejectsEntriesWithoutSourceRelativePath)


### PR DESCRIPTION
## Summary
- Added an in-memory source catalog builder for `Project/` and `Engine/` source trees.
- Updated dev-time runtime resolution to build source catalogs in memory on first use instead of requiring source-tree `.rtr/catalog.json`.
- Updated cook to scan source trees directly instead of depending on on-disk source catalogs.
- Kept cooked and packaged catalog loading unchanged.

## Why
- This removes source-tree `.rtr/catalog.json` as a required artifact for both dev runtime reads and cooking.
- It also reduces divergence between source scanning logic used by tools and runtime.

## Affected areas
- Source catalog building
- Catalog registry dev-time resolution
- Cook pipeline source entry generation
- Source catalog tests
- Resource-system design/internals docs

## Documentation
- [ ] No documentation needed
- [x] Documentation updated

## Testing
- Added/updated unit coverage for:
  - in-memory source catalog map generation
  - duplicate logical-path rejection
  - dev-time `CatalogRegistry` source resolution without on-disk source catalogs
  - cook succeeding without source-tree `.rtr/catalog.json`

## Notes
- `rtr_asset_index` is no longer part of the required dev/runtime or cook path; it currently remains as an optional source-catalog export/debug tool.
- Cooked and packaged mounts still rely on on-disk catalogs as before.