### PR TITLE
Split debug and release test coverage by runtime profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,12 @@ concurrency:
 
 jobs:
   windows:
-    name: Windows MSVC
+    name: Windows MSVC (${{ matrix.profile }})
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [release, debug]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -30,22 +34,26 @@ jobs:
       - name: Cache build
         uses: actions/cache@v5
         with:
-          path: build/ci-windows-vs
-          key: ci-windows-${{ hashFiles('CMakeLists.txt', 'Src/CMakeLists.txt', 'Vendor/CMakeLists.txt', 'Tests/CMakeLists.txt') }}
+          path: build/ci-windows-vs-${{ matrix.profile }}
+          key: ci-windows-${{ matrix.profile }}-${{ hashFiles('CMakeLists.txt', 'Src/CMakeLists.txt', 'Vendor/CMakeLists.txt', 'Tests/CMakeLists.txt', 'CMakePresets/configure/windows.json', 'CMakePresets/build-presets/windows.json', 'CMakePresets/test/windows.json', 'CMakePresets/test/common.json') }}
           restore-keys: ci-windows-
 
       - name: Configure
-        run: cmake --preset ci-windows-vs
+        run: cmake --preset ci-windows-vs-${{ matrix.profile }}
 
       - name: Build
-        run: cmake --build --preset build-ci-windows-vs-release --parallel
+        run: cmake --build --preset build-ci-windows-vs-${{ matrix.profile }} --parallel
 
       - name: Test
-        run: ctest --preset test-ci-windows-vs-release
+        run: ctest --preset test-ci-windows-vs-${{ matrix.profile }}
 
   linux:
-    name: Linux GCC
+    name: Linux GCC (${{ matrix.profile }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [release, debug]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -61,22 +69,26 @@ jobs:
       - name: Cache build
         uses: actions/cache@v5
         with:
-          path: build/ci-linux-ninja-release
-          key: ci-linux-${{ hashFiles('CMakeLists.txt', 'Src/CMakeLists.txt', 'Vendor/CMakeLists.txt', 'Tests/CMakeLists.txt') }}
+          path: build/ci-linux-ninja-${{ matrix.profile }}
+          key: ci-linux-${{ matrix.profile }}-${{ hashFiles('CMakeLists.txt', 'Src/CMakeLists.txt', 'Vendor/CMakeLists.txt', 'Tests/CMakeLists.txt', 'CMakePresets/configure/linux.json', 'CMakePresets/build-presets/linux.json', 'CMakePresets/test/linux.json', 'CMakePresets/test/common.json') }}
           restore-keys: ci-linux-
 
       - name: Configure
-        run: cmake --preset ci-linux-ninja-release
+        run: cmake --preset ci-linux-ninja-${{ matrix.profile }}
 
       - name: Build
-        run: cmake --build --preset build-ci-linux-ninja-release --parallel
+        run: cmake --build --preset build-ci-linux-ninja-${{ matrix.profile }} --parallel
 
       - name: Test
-        run: ctest --preset test-ci-linux-ninja-release
+        run: ctest --preset test-ci-linux-ninja-${{ matrix.profile }}
 
   macos:
-    name: macOS Clang
+    name: macOS Clang (${{ matrix.profile }})
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [release, debug]
     steps:
       - uses: actions/checkout@v5
         with:
@@ -88,15 +100,15 @@ jobs:
       - name: Cache build
         uses: actions/cache@v5
         with:
-          path: build/ci-macos-ninja-release
-          key: ci-macos-${{ hashFiles('CMakeLists.txt', 'Src/CMakeLists.txt', 'Vendor/CMakeLists.txt', 'Tests/CMakeLists.txt') }}
+          path: build/ci-macos-ninja-${{ matrix.profile }}
+          key: ci-macos-${{ matrix.profile }}-${{ hashFiles('CMakeLists.txt', 'Src/CMakeLists.txt', 'Vendor/CMakeLists.txt', 'Tests/CMakeLists.txt', 'CMakePresets/configure/macos.json', 'CMakePresets/build-presets/macos.json', 'CMakePresets/test/macos.json', 'CMakePresets/test/common.json') }}
           restore-keys: ci-macos-
 
       - name: Configure
-        run: cmake --preset ci-macos-ninja-release
+        run: cmake --preset ci-macos-ninja-${{ matrix.profile }}
 
       - name: Build
-        run: cmake --build --preset build-ci-macos-ninja-release --parallel
+        run: cmake --build --preset build-ci-macos-ninja-${{ matrix.profile }} --parallel
 
       - name: Test
-        run: ctest --preset test-ci-macos-ninja-release
+        run: ctest --preset test-ci-macos-ninja-${{ matrix.profile }}

--- a/CMakePresets/build-presets/linux.json
+++ b/CMakePresets/build-presets/linux.json
@@ -33,6 +33,10 @@
       "configurePreset": "linux-ninja-release-fast"
     },
     {
+      "name": "build-ci-linux-ninja-debug",
+      "configurePreset": "ci-linux-ninja-debug"
+    },
+    {
       "name": "build-ci-linux-ninja-release",
       "configurePreset": "ci-linux-ninja-release"
     }

--- a/CMakePresets/build-presets/macos.json
+++ b/CMakePresets/build-presets/macos.json
@@ -33,6 +33,10 @@
       "configurePreset": "macos-ninja-release-fast"
     },
     {
+      "name": "build-ci-macos-ninja-debug",
+      "configurePreset": "ci-macos-ninja-debug"
+    },
+    {
       "name": "build-ci-macos-ninja-release",
       "configurePreset": "ci-macos-ninja-release"
     }

--- a/CMakePresets/build-presets/windows.json
+++ b/CMakePresets/build-presets/windows.json
@@ -50,8 +50,13 @@
       "configuration": "Release"
     },
     {
+      "name": "build-ci-windows-vs-debug",
+      "configurePreset": "ci-windows-vs-debug",
+      "configuration": "Debug"
+    },
+    {
       "name": "build-ci-windows-vs-release",
-      "configurePreset": "ci-windows-vs",
+      "configurePreset": "ci-windows-vs-release",
       "configuration": "Release"
     }
   ]

--- a/CMakePresets/configure/linux.json
+++ b/CMakePresets/configure/linux.json
@@ -80,6 +80,17 @@
       }
     },
     {
+      "name": "ci-linux-ninja-debug",
+      "displayName": "CI Linux Ninja Debug",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/ci-linux-ninja-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/ci-linux-ninja-debug",
+        "GLAB_BUILD_TESTS": "ON"
+      }
+    },
+    {
       "name": "ci-linux-ninja-release",
       "displayName": "CI Linux Ninja Release",
       "generator": "Ninja",

--- a/CMakePresets/configure/macos.json
+++ b/CMakePresets/configure/macos.json
@@ -80,6 +80,17 @@
       }
     },
     {
+      "name": "ci-macos-ninja-debug",
+      "displayName": "CI macOS Ninja Debug",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/ci-macos-ninja-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/ci-macos-ninja-debug",
+        "GLAB_BUILD_TESTS": "ON"
+      }
+    },
+    {
       "name": "ci-macos-ninja-release",
       "displayName": "CI macOS Ninja Release",
       "generator": "Ninja",

--- a/CMakePresets/configure/windows.json
+++ b/CMakePresets/configure/windows.json
@@ -32,16 +32,29 @@
       }
     },
     {
-      "name": "ci-windows-vs",
+      "name": "ci-windows-vs-debug",
+      "displayName": "CI Windows VS2022 Debug",
+      "generator": "Visual Studio 17 2022",
+      "architecture": {
+        "value": "x64",
+        "strategy": "set"
+      },
+      "binaryDir": "${sourceDir}/build/ci-windows-vs-debug",
+      "cacheVariables": {
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/ci-windows-vs-debug"
+      }
+    },
+    {
+      "name": "ci-windows-vs-release",
       "displayName": "CI Windows VS2022 Release",
       "generator": "Visual Studio 17 2022",
       "architecture": {
         "value": "x64",
         "strategy": "set"
       },
-      "binaryDir": "${sourceDir}/build/ci-windows-vs",
+      "binaryDir": "${sourceDir}/build/ci-windows-vs-release",
       "cacheVariables": {
-        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/ci-windows-vs"
+        "CMAKE_INSTALL_PREFIX": "${sourceDir}/install/ci-windows-vs-release"
       }
     }
   ]

--- a/CMakePresets/test/common.json
+++ b/CMakePresets/test/common.json
@@ -9,6 +9,51 @@
       }
     },
     {
+      "name": "test-label-common",
+      "hidden": true,
+      "filter": {
+        "include": {
+          "label": "common"
+        }
+      }
+    },
+    {
+      "name": "test-label-dev-profile",
+      "hidden": true,
+      "filter": {
+        "include": {
+          "label": "dev-profile"
+        }
+      }
+    },
+    {
+      "name": "test-label-shipping-profile",
+      "hidden": true,
+      "filter": {
+        "include": {
+          "label": "shipping-profile"
+        }
+      }
+    },
+    {
+      "name": "test-label-debug-matrix",
+      "hidden": true,
+      "filter": {
+        "include": {
+          "label": "common|dev-profile"
+        }
+      }
+    },
+    {
+      "name": "test-label-release-matrix",
+      "hidden": true,
+      "filter": {
+        "include": {
+          "label": "common|shipping-profile"
+        }
+      }
+    },
+    {
       "name": "test-label-unit",
       "hidden": true,
       "filter": {

--- a/CMakePresets/test/linux.json
+++ b/CMakePresets/test/linux.json
@@ -25,8 +25,19 @@
     },
     {
       "name": "test-ci-linux-ninja-release",
-      "inherits": "test-base",
+      "inherits": [
+        "test-base",
+        "test-label-release-matrix"
+      ],
       "configurePreset": "ci-linux-ninja-release"
+    },
+    {
+      "name": "test-ci-linux-ninja-debug",
+      "inherits": [
+        "test-base",
+        "test-label-debug-matrix"
+      ],
+      "configurePreset": "ci-linux-ninja-debug"
     },
     {
       "name": "test-linux-ninja-debug",

--- a/CMakePresets/test/macos.json
+++ b/CMakePresets/test/macos.json
@@ -24,8 +24,19 @@
       "configurePreset": "macos-ninja-release-tests"
     },
     {
+      "name": "test-ci-macos-ninja-debug",
+      "inherits": [
+        "test-base",
+        "test-label-debug-matrix"
+      ],
+      "configurePreset": "ci-macos-ninja-debug"
+    },
+    {
       "name": "test-ci-macos-ninja-release",
-      "inherits": "test-base",
+      "inherits": [
+        "test-base",
+        "test-label-release-matrix"
+      ],
       "configurePreset": "ci-macos-ninja-release"
     },
     {

--- a/CMakePresets/test/windows.json
+++ b/CMakePresets/test/windows.json
@@ -27,9 +27,21 @@
       "configuration": "Release"
     },
     {
+      "name": "test-ci-windows-vs-debug",
+      "inherits": [
+        "test-base",
+        "test-label-debug-matrix"
+      ],
+      "configurePreset": "ci-windows-vs-debug",
+      "configuration": "Debug"
+    },
+    {
       "name": "test-ci-windows-vs-release",
-      "inherits": "test-base",
-      "configurePreset": "ci-windows-vs",
+      "inherits": [
+        "test-base",
+        "test-label-release-matrix"
+      ],
+      "configurePreset": "ci-windows-vs-release",
       "configuration": "Release"
     },
     {

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,6 +1,9 @@
 include(GoogleTest)
 
 function(glab_configure_test_target target_name test_prefix test_labels)
+    set(escaped_test_labels "${test_labels}")
+    string(REPLACE ";" "\\;" escaped_test_labels "${escaped_test_labels}")
+
     target_link_libraries(${target_name}
         PRIVATE
             RTRLabCore
@@ -22,7 +25,7 @@ function(glab_configure_test_target target_name test_prefix test_labels)
     gtest_discover_tests(${target_name}
         TEST_PREFIX "${test_prefix}"
         PROPERTIES
-            LABELS "${test_labels}"
+            LABELS "${escaped_test_labels}"
     )
 endfunction()
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(GoogleTest)
 
-function(glab_configure_test_target target_name test_prefix test_label)
+function(glab_configure_test_target target_name test_prefix test_labels)
     target_link_libraries(${target_name}
         PRIVATE
             RTRLabCore
@@ -22,16 +22,16 @@ function(glab_configure_test_target target_name test_prefix test_label)
     gtest_discover_tests(${target_name}
         TEST_PREFIX "${test_prefix}"
         PROPERTIES
-            LABELS "${test_label}"
+            LABELS "${test_labels}"
     )
 endfunction()
 
-function(glab_add_test_executable target_name test_prefix test_label)
+function(glab_add_test_executable target_name test_prefix test_labels)
     add_executable(${target_name}
         ${ARGN}
     )
 
-    glab_configure_test_target(${target_name} "${test_prefix}" "${test_label}")
+    glab_configure_test_target(${target_name} "${test_prefix}" "${test_labels}")
 endfunction()
 
 # -----------------------------------------------------------------------------
@@ -66,7 +66,7 @@ set(GLAB_UNIT_TEST_SOURCES
     Unit/TestTransform.cpp
 )
 
-glab_add_test_executable(rtrlab_unit_tests "Unit." "unit"
+glab_add_test_executable(rtrlab_unit_tests "Unit." "unit;common"
     ${GLAB_UNIT_TEST_SOURCES}
 )
 
@@ -80,7 +80,7 @@ set(GLAB_INTEGRATION_TEST_SOURCES
     Integration/TestRootDiscovery.cpp
 )
 
-glab_add_test_executable(rtrlab_integration_tests "Integration." "integration"
+glab_add_test_executable(rtrlab_integration_tests "Integration." "integration;common"
     ${GLAB_INTEGRATION_TEST_SOURCES}
 )
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -77,11 +77,26 @@ set(GLAB_INTEGRATION_TEST_SOURCES
     Integration/TestLoggerConsoleSink.cpp
     Integration/TestMountBackend.cpp
     Integration/TestInputRecordingIO.cpp
-    Integration/TestRootDiscovery.cpp
 )
 
 glab_add_test_executable(rtrlab_integration_tests "Integration." "integration;common"
     ${GLAB_INTEGRATION_TEST_SOURCES}
+)
+
+set(GLAB_DEV_PROFILE_TEST_SOURCES
+    Integration/TestRootDiscoveryDev.cpp
+)
+
+glab_add_test_executable(rtrlab_dev_profile_tests "DevProfile." "integration;dev-profile"
+    ${GLAB_DEV_PROFILE_TEST_SOURCES}
+)
+
+set(GLAB_SHIPPING_PROFILE_TEST_SOURCES
+    Integration/TestRootDiscoveryShipping.cpp
+)
+
+glab_add_test_executable(rtrlab_shipping_profile_tests "ShippingProfile." "integration;shipping-profile"
+    ${GLAB_SHIPPING_PROFILE_TEST_SOURCES}
 )
 
 # -----------------------------------------------------------------------------

--- a/Tests/Integration/TestRootDiscoveryDev.cpp
+++ b/Tests/Integration/TestRootDiscoveryDev.cpp
@@ -5,7 +5,12 @@
 #include "Core/Resource/Mount/RootDiscovery.h"
 #include "RootDiscoveryTestSupport.h"
 
-TEST_F(test_support::RootDiscoveryTestsBase, DiscoverRootPathUsesEnvOverrideWhenProjectMarkerExistsInDev)
+namespace
+{
+    using RootDiscoveryTests = test_support::RootDiscoveryTestsBase;
+}
+
+TEST_F(RootDiscoveryTests, DiscoverRootPathUsesEnvOverrideWhenProjectMarkerExistsInDev)
 {
 #ifdef RTRLAB_CONFIG_RELEASE
     GTEST_SKIP() << "Dev-profile root discovery coverage runs in non-release builds only.";

--- a/Tests/Integration/TestRootDiscoveryDev.cpp
+++ b/Tests/Integration/TestRootDiscoveryDev.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "Core/Resource/Mount/RootDiscovery.h"
+#include "RootDiscoveryTestSupport.h"
+
+TEST_F(test_support::RootDiscoveryTestsBase, DiscoverRootPathUsesEnvOverrideWhenProjectMarkerExistsInDev)
+{
+#ifdef RTRLAB_CONFIG_RELEASE
+    GTEST_SKIP() << "Dev-profile root discovery coverage runs in non-release builds only.";
+#else
+    const auto repoRoot = TestRoot() / "Repo";
+    test_support::WriteProjectMarkerOrFail(repoRoot);
+
+    const test_support::ScopedEnvVar rootOverride("RTRL_ROOT", repoRoot.string());
+    const auto discoveredRoot = Resource::DiscoverRootPath();
+
+    EXPECT_EQ(discoveredRoot, std::filesystem::canonical(repoRoot));
+#endif
+}

--- a/Tests/Integration/TestRootDiscoveryShipping.cpp
+++ b/Tests/Integration/TestRootDiscoveryShipping.cpp
@@ -5,7 +5,12 @@
 #include "Core/Resource/Mount/RootDiscovery.h"
 #include "RootDiscoveryTestSupport.h"
 
-TEST_F(test_support::RootDiscoveryTestsBase, DiscoverRootPathIgnoresEnvOverrideInShipping)
+namespace
+{
+    using RootDiscoveryTests = test_support::RootDiscoveryTestsBase;
+}
+
+TEST_F(RootDiscoveryTests, DiscoverRootPathIgnoresEnvOverrideInShipping)
 {
 #ifndef RTRLAB_CONFIG_RELEASE
     GTEST_SKIP() << "Shipping-profile root discovery coverage runs in release builds only.";

--- a/Tests/Integration/TestRootDiscoveryShipping.cpp
+++ b/Tests/Integration/TestRootDiscoveryShipping.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "Core/Resource/Mount/RootDiscovery.h"
+#include "RootDiscoveryTestSupport.h"
+
+TEST_F(test_support::RootDiscoveryTestsBase, DiscoverRootPathIgnoresEnvOverrideInShipping)
+{
+#ifndef RTRLAB_CONFIG_RELEASE
+    GTEST_SKIP() << "Shipping-profile root discovery coverage runs in release builds only.";
+#else
+    const auto repoRoot = TestRoot() / "Repo";
+    test_support::WriteProjectMarkerOrFail(repoRoot);
+
+    const test_support::ScopedEnvVar rootOverride("RTRL_ROOT", repoRoot.string());
+    const auto discoveredRoot = Resource::DiscoverRootPath();
+    const auto executableDirectory = test_support::GetExecutableDirectoryForTest();
+
+    ASSERT_FALSE(executableDirectory.empty());
+    EXPECT_EQ(discoveredRoot, std::filesystem::canonical(executableDirectory));
+#endif
+}

--- a/Tests/Support/RootDiscoveryTestSupport.h
+++ b/Tests/Support/RootDiscoveryTestSupport.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <gtest/gtest.h>
 
 #include <cstdlib>
@@ -6,7 +8,6 @@
 #include <string>
 #include <string_view>
 
-#include "Core/Resource/Mount/RootDiscovery.h"
 #include "ResourceTestSupport.h"
 
 #ifdef _WIN32
@@ -18,9 +19,9 @@
 #include <climits>
 #endif
 
-namespace
+namespace test_support
 {
-    std::filesystem::path GetExecutableDirectoryForTest()
+    inline std::filesystem::path GetExecutableDirectoryForTest()
     {
         std::filesystem::path exePath;
 
@@ -97,18 +98,18 @@ namespace
         bool m_HadPreviousValue = false;
     };
 
-    class RootDiscoveryTests : public ::testing::Test
+    class RootDiscoveryTestsBase : public ::testing::Test
     {
     protected:
         void SetUp() override
         {
-            m_TestRoot = test_support::CurrentTestRoot("root-discovery");
-            test_support::ResetCurrentTestRoot("root-discovery");
+            m_TestRoot = CurrentTestRoot("root-discovery");
+            ResetCurrentTestRoot("root-discovery");
         }
 
         void TearDown() override
         {
-            test_support::RemoveCurrentTestArtifacts("root-discovery");
+            RemoveCurrentTestArtifacts("root-discovery");
         }
 
         std::filesystem::path TestRoot() const
@@ -119,21 +120,4 @@ namespace
     private:
         std::filesystem::path m_TestRoot;
     };
-} // namespace
-
-TEST_F(RootDiscoveryTests, DiscoverRootPathUsesEnvOverrideOnlyWhenProjectMarkerExists)
-{
-    const auto repoRoot = TestRoot() / "Repo";
-    test_support::WriteProjectMarkerOrFail(repoRoot);
-
-    const ScopedEnvVar rootOverride("RTRL_ROOT", repoRoot.string());
-    const auto discoveredRoot = Resource::DiscoverRootPath();
-
-#ifdef RTRLAB_CONFIG_RELEASE
-    const auto executableDirectory = GetExecutableDirectoryForTest();
-    ASSERT_FALSE(executableDirectory.empty());
-    EXPECT_EQ(discoveredRoot, std::filesystem::canonical(executableDirectory));
-#else
-    EXPECT_EQ(discoveredRoot, std::filesystem::canonical(repoRoot));
-#endif
-}
+} // namespace test_support


### PR DESCRIPTION
## Summary
- Added explicit test-profile infrastructure on top of the existing unit/integration split.
- Introduced separate debug and release CI presets for Windows, Linux, and macOS.
- Updated GitHub Actions to run both debug and release test matrices per platform.
- Split root discovery coverage into dedicated dev-profile and shipping-profile tests.
- Fixed `gtest_discover_tests()` label handling for multi-label test registration.

## Why
- Some tests exercise profile-sensitive behavior and should not be implicitly validated under the wrong runtime/build profile.
- A single release-only CI lane was mixing “common” coverage with tests that conceptually belong to dev-only behavior.
- A debug/release matrix gives us a clean structure for `common + debug-only` and `common + release-only` coverage.

## Affected areas
- Test target registration in CMake
- CTest preset filtering and labeling
- CI configure/build/test presets
- GitHub Actions CI workflow
- Root discovery test organization

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Verified that the new configure presets and test presets are discoverable via `cmake --list-presets` and `ctest --list-presets`.
- Identified and fixed the Windows multi-label `gtest_discover_tests()` registration issue caused by unescaped semicolons.

## Notes
- Current tests are now structurally ready for `common`, `dev-profile`, and `shipping-profile` layering.
- Only `RootDiscovery` has been migrated into profile-specific targets so far; additional profile-sensitive tests can be moved incrementally.
- Release and debug CI lanes are now separated at the workflow/preset level rather than being inferred from a single shared run.