### PR TITLE
Reduce duplicate CI runs on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,6 @@ on:
   push:
     branches:
       - main
-      - "feature/**"
-      - "fix/**"
-      - "refactor/**"
-      - "docs/**"
-      - "integration/**"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Limit CI `push` runs to `main` only
- Keep CI running for pull requests targeting `main`
- Remove duplicate CI executions on PR branches caused by triggering both `push` and `pull_request`

## Why
- PR branches currently trigger the CI workflow twice: once from `push` and once from `pull_request`
- This creates duplicate checks, adds noise to the PR page, and wastes CI time
- The repository workflow treats pull requests as the main review boundary, so PR validation should primarily happen on `pull_request`, while `push` should still validate the merged result on `main`

## Affected areas
- `.github/workflows/ci.yml`

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Reviewed the workflow trigger configuration to confirm that PR branches no longer match the `push` trigger
- Verified that CI still runs for pull requests targeting `main`
- Verified that CI still runs on direct updates to `main`

## Notes
- This PR intentionally focuses only on reducing duplicate CI runs
- It does not change the build matrix, test commands, or required check policy