### PR TITLE
Unify Project/Engine reads through catalogs

### DIFF
--- a/Docs/Modules/ResourceSystem/Design.md
+++ b/Docs/Modules/ResourceSystem/Design.md
@@ -8,8 +8,8 @@ paths.
 > **Design Philosophy**: Public resource identity is logical, not physical. The same
 > logical path should work across loose source content, loose cooked output, packaged
 > archives, and higher-priority override layers. Config and other document-style files
-> remain first-class mounted resources, but they are intentionally distinct from
-> catalog-backed imported assets.
+> remain first-class mounted resources, but in the Project / Engine domains they are
+> now represented as catalog entries rather than bypassing the catalog at runtime.
 
 ---
 
@@ -25,8 +25,8 @@ paths.
     - [3.3 Path Syntax Contract](#33-path-syntax-contract)
   - [4. Resolution Model](#4-resolution-model)
     - [4.1 Read Domains and Write Domains](#41-read-domains-and-write-domains)
-    - [4.2 Document-Style Resolution](#42-document-style-resolution)
-    - [4.3 Catalog-Backed Resolution](#43-catalog-backed-resolution)
+    - [4.2 Unified Project / Engine Read Resolution](#42-unified-project--engine-read-resolution)
+    - [4.3 Writable Domain Resolution](#43-writable-domain-resolution)
     - [4.4 Mount Precedence](#44-mount-precedence)
   - [5. Catalog System](#5-catalog-system)
     - [5.1 Source Catalogs](#51-source-catalogs)
@@ -92,14 +92,14 @@ stay stable while the storage backend evolves.
              +------------+------------+
              |                         |
              v                         v
-      Document-style paths       Catalog-backed paths
-      (/Saved/Config/...)        (/Project/Textures/...)
+      Project / Engine reads      Saved / Cache reads
+      (catalog-backed)            (direct writable mounts)
              |                         |
              v                         v
-     Mounted directory roots    CatalogRegistry
-                                + artifact selection
-                                + mount precedence
-                                + backend resolution
+                         CatalogRegistry         Mounted directory roots
+                         + artifact selection
+                         + mount precedence
+                         + backend resolution
                                           |
                                 +---------+---------+
                                 |                   |
@@ -112,15 +112,16 @@ stay stable while the storage backend evolves.
 At a high level, the system has four cooperating pieces:
 
 1. **Logical path parsing**
-   Validates and classifies public paths such as `/Project/...` and `/Saved/...`.
+   Validates public paths such as `/Project/...` and `/Saved/...` and extracts the
+   logical domain.
 
-2. **Mounted filesystem resolution**
-   Handles document-style resources that map directly to files, especially config,
-   logs, save data, and cache data.
+2. **Unified catalog-backed read resolution**
+   Handles every Project / Engine read, including both extensionless asset paths and
+   extension-preserving document paths such as `/Project/Config/*.json`.
 
-3. **Catalog-backed asset resolution**
-   Handles extensionless asset paths by loading catalogs from active readable mounts and
-   selecting the best artifact for the current runtime.
+3. **Mounted writable-domain resolution**
+   Handles `/Saved/...` and `/Cache/...` reads/writes by mapping them directly to
+   writable roots.
 
 4. **Tooling**
    Generates source catalogs, loose cooked output, and packaged `.rtrpak` archives so
@@ -168,8 +169,9 @@ filenames and extensions:
 /Saved/logs/RTRLab.log
 ```
 
-These resolve through mounted backends directly and do not participate in extensionless
-asset lookup.
+These retain explicit filenames and extensions. In the Project / Engine domains, they
+are represented as document entries in the source/cooked catalog. In the Saved / Cache
+domains, they resolve through writable mounts directly.
 
 ### 3.3 Path Syntax Contract
 
@@ -201,9 +203,40 @@ That means:
 
 This rule is enforced centrally by the resource system rather than by each caller.
 
-### 4.2 Document-Style Resolution
+### 4.2 Unified Project / Engine Read Resolution
 
-Document-style paths resolve through mounted backends directly.
+`/Project/...` and `/Engine/...` reads are resolved uniformly through the catalog
+system, regardless of whether the logical path is an extensionless asset path or an
+extension-preserving document path.
+
+That means:
+
+- `/Project/Textures/Grassy_Square` resolves through a catalog entry whose selected
+  artifact may be a source file, cooked file, packaged archive entry, or overlay
+- `/Project/Config/Graphics.json` also resolves through a catalog entry, but keeps its
+  explicit filename and extension
+- the runtime no longer branches on "has extension" versus "no extension" when deciding
+  whether to use the catalog
+
+The catalog entry type is decided at **source catalog build time**:
+
+- **asset entries** strip the source extension from the logical path
+- **document entries** preserve the logical filename and extension and use a single
+  artifact with `format="document"`
+
+This builder-time classification is based primarily on content role:
+
+- `Config/` files are documents
+- plain-text support files such as `.ini`, `.txt`, `.xml`, and `.toml` may also be
+  treated as documents
+- content directories such as `Textures/`, `Shaders/`, `Materials/`, `Scenes/`, and
+  `Defaults/` remain assets even if the source representation is text-based, such as
+  `.json`
+
+### 4.3 Writable Domain Resolution
+
+`/Saved/...` and `/Cache/...` are not catalog-backed. They resolve through mounted
+writable roots directly.
 
 In the current repository layout:
 
@@ -223,9 +256,9 @@ The current config chain is layered on top of those mounts:
 Missing saved overrides may be auto-seeded from project or engine defaults, but shipped
 defaults are never modified in place.
 
-### 4.3 Catalog-Backed Resolution
+### 4.4 Mount Precedence
 
-Catalog-backed logical paths resolve in two stages:
+Catalog-backed Project / Engine logical paths resolve in two stages:
 
 1. **Catalog lookup**
    Find a `ResourceCatalogEntry` for the requested logical path in the merged global
@@ -243,8 +276,6 @@ The caller never sees whether the chosen artifact came from:
 - a higher-priority overlay directory
 
 The public path stays the same.
-
-### 4.4 Mount Precedence
 
 Readable mounts are merged with explicit precedence. For the current implementation,
 the order is:
@@ -264,8 +295,9 @@ next available lower layer.
 
 ### 5.1 Source Catalogs
 
-Source catalogs describe loose authoring-time content. They are generated under each
-mount root as `.rtr/catalog.json`.
+Source catalogs describe loose authoring-time content. At runtime in development builds,
+they are built in memory from the source tree. `rtr_asset_index` can also emit them as
+`.rtr/catalog.json` for inspection or tooling.
 
 Current source catalogs:
 
@@ -376,7 +408,7 @@ focused on public API behavior.
 Key public responsibilities:
 
 - initialize root discovery and writable roots
-- parse and classify logical paths
+- parse logical paths and dispatch by domain
 - resolve read and write paths
 - expose logical-path-based `Exists`, `ReadText`, `ReadBinary`, `WriteText`,
   and `WriteBinary`
@@ -403,13 +435,14 @@ the public `FileSystem` facade.
 
 ## 8. Config Integration
 
-Config files are treated as mounted documents, not imported assets.
+Config files are treated as mounted documents, not extensionless imported assets.
 
 That means:
 
 - they keep their explicit filenames and extensions
-- they resolve directly through mounted filesystems
-- they participate in override order, not extensionless catalog lookup
+- Project / Engine defaults are represented as document entries in the catalog
+- Saved overrides resolve directly through writable mounts
+- they participate in override order, not extensionless asset lookup
 
 Current config locations:
 
@@ -472,8 +505,8 @@ or this:
 - `Project/`
 - `Engine/`
 
-It skips document-style config subtrees for extensionless asset indexing and enforces
-logical-path uniqueness.
+It applies the same builder-time content-role classification used by the runtime source
+catalog builder and enforces logical-path uniqueness.
 
 At runtime in development builds, and during cooking, source catalogs are built in
 memory from the source trees rather than being read back from `Project/.rtr/catalog.json`
@@ -542,13 +575,15 @@ active engine subsystem with the following implemented behavior:
 
 - `src/Core/Resource/` is the home of the module
 - `FileSystem` is the public facade
-- logical path parsing and classification are implemented
+- logical path parsing and domain dispatch are implemented
 - read/write domain enforcement is implemented
 - `/Project/`, `/Engine/`, `/Saved/`, and `/Cache/` are active
 - config fallback resolution is implemented through serialization-facing helpers
 - logical-path-based file I/O is implemented
 - source catalogs can be generated for inspection or tooling, while dev runtime and cook
   build source catalogs in memory
+- Project / Engine reads now share a single catalog-driven path for both assets and
+  document entries
 - loose cooked catalogs are generated and consumed
 - packaged `.rtrpak` archives are generated and consumed
 - overlay precedence over packaged/cooked/source mounts is implemented
@@ -654,7 +689,7 @@ src/Core/Resource/
     Catalog/
         AssetPath.h             - Validated serialized asset reference type
         ResourceCatalog.h / .cpp - Catalog registry, merge logic, artifact selection
-        SourceCatalog.h / .cpp  - Source catalog indexing and generation
+        SourceCatalog.h / .cpp  - Source catalog indexing, generation, and document/asset classification
     Cook/
         CookedCatalog.h / .cpp  - Loose cook output + `.rtrtex` helpers
     Package/
@@ -700,7 +735,9 @@ runtime lottery.
 
 Config files are consumed as documents, not imported as opaque runtime artifacts. Their
 format is part of their contract, so keeping explicit filenames and extensions is more
-useful than pretending they are catalog-backed assets.
+useful than pretending they are catalog-backed extensionless assets. In the current
+architecture they still participate in the Project / Engine catalog path, but they do
+so as explicit document entries rather than as extensionless assets.
 
 ### Why source and cooked catalogs are separate schemas
 

--- a/Docs/Modules/ResourceSystem/Internals.md
+++ b/Docs/Modules/ResourceSystem/Internals.md
@@ -24,9 +24,9 @@ industry context.
       - [2.3 Packaging (rtr\_asset\_pack)](#23-packaging-rtr_asset_pack)
     - [3. Runtime Resolution](#3-runtime-resolution)
       - [3.1 Initialization](#31-initialization)
-      - [3.2 Path Classification](#32-path-classification)
-      - [3.3 Document Path Resolution](#33-document-path-resolution)
-      - [3.4 Catalog-Backed Path Resolution](#34-catalog-backed-path-resolution)
+      - [3.2 Path Parsing and Domain Dispatch](#32-path-parsing-and-domain-dispatch)
+      - [3.3 Unified Project--Engine Read Resolution](#33-unified-project--engine-read-resolution)
+      - [3.4 Writable Domain Resolution](#34-writable-domain-resolution)
       - [3.5 Write Path Resolution](#35-write-path-resolution)
     - [4. Runtime Data Flow Walkthrough](#4-runtime-data-flow-walkthrough)
     - [5. Key Implementation Details](#5-key-implementation-details)
@@ -58,15 +58,15 @@ Offline phase (build time)                Runtime phase
        |                                            |
        v                                            v
 +---------------+                        +----------------------+
-| rtr_asset_    |  decode images->.rtrtex | Is path document     |-> direct physical join
-|   cook        |-> generate cooked cat   | or catalog-backed?   |
+| rtr_asset_    |  decode images->.rtrtex | Which domain?        |
+|   cook        |-> generate cooked cat   | Project/Engine       |
 +---------------+                        +----------+-----------+
-       |                                            | catalog-backed
+       |                                            |
        v                                            v
-+---------------+                        +----------------------+
-| rtr_asset_    |  bundle into .rtrpak   | CatalogRegistry      |-> global table lookup
-|   pack        |-> binary archive       | ::ResolvePath         |   + artifact selection
-+---------------+                        +----------------------+
++---------------+                +----------------------+  +----------------------+
+| rtr_asset_    |  bundle into   | CatalogRegistry      |  | Writable mounts      |
+|   pack        |  .rtrpak       | ::ResolvePath        |  | Saved / Cache roots  |
++---------------+                +----------------------+  +----------------------+
 ```
 
 ---
@@ -86,15 +86,19 @@ per mount.
 1. **Discover mounts**: scan for `Project/` and `Engine/` and collect each existing
    directory as a source mount.
 
-2. **Scan files** (`SourceCatalog.cpp:167-191`): for each mount root, run a
-   `recursive_directory_iterator`. Skip the `.rtr/` metadata directory and any top-level
-   `Config/` subtree (config files are documents, not catalog-backed assets).
+2. **Scan files**: for each mount root, run a `recursive_directory_iterator`. Skip the
+   `.rtr/` metadata directory.
 
-3. **Derive logical paths** (`SourceCatalog.cpp:44-89`):
-   - take each file's relative path, strip the extension
-   - normalize known directory names to canonical casing (`textures` -> `Textures`,
-     `shaders` -> `Shaders`, etc.)
-   - prepend the domain prefix:
+3. **Classify content role and derive logical paths**:
+   - files under `Config/` become **document entries**
+   - plain-text support files such as `.ini`, `.txt`, `.xml`, and `.toml` may also
+     become document entries
+   - asset-oriented directories such as `Textures/`, `Shaders/`, `Materials/`,
+     `Scenes/`, and `Defaults/` remain **asset entries** even when the source file is
+     text-based such as `.json`
+   - document entries keep the logical filename and extension:
+     `Project/Config/Graphics.json` -> `/Project/Config/Graphics.json`
+   - asset entries strip the source extension:
      `Project/Textures/Grassy_Square.jpg` -> `/Project/Textures/Grassy_Square`
 
 4. **Enforce uniqueness**: if two source files generate the same logical path (e.g.
@@ -229,11 +233,11 @@ use platform-specific user data paths:
 - macOS: `~/Library/Application Support/RTRLab/Saved` and `~/Library/Caches/RTRLab`
 - Linux: `$XDG_DATA_HOME/RTRLab/Saved` and `$XDG_CACHE_HOME/RTRLab`
 
-#### 3.2 Path Classification
+#### 3.2 Path Parsing and Domain Dispatch
 
 When `ResolveReadPath("/Project/Textures/Grassy_Square")` is called:
 
-**Step 1: Parse the virtual path** (`PathParser.cpp:66-140`)
+**Step 1: Parse the virtual path**
 - Validate: must start with `/`, must not contain `\`, must not contain `.` or `..`
   segments.
 - Split into segments, collapse consecutive `/`.
@@ -241,35 +245,36 @@ When `ResolveReadPath("/Project/Textures/Grassy_Square")` is called:
 
 Result: `VirtualPath { domain=Project, mountName=nullopt, relativePath="Textures/Grassy_Square" }`
 
-**Step 2: Classify as document or catalog-backed** (`PathParser.cpp:142-167`)
-- `Saved` / `Cache` domain: never catalog-backed.
-- `Project` / `Engine` domain: check whether the relative path has a file extension.
-  - Has extension (e.g. `.json`): document path, resolved via direct physical join.
-  - No extension: catalog-backed, resolved through catalog lookup.
+**Step 2: Dispatch by domain**
+- `Project` / `Engine`: always resolve through `CatalogRegistry::ResolvePath()`
+- `Saved` / `Cache`: resolve through writable mounts directly
 
-This implements the design contract: **extensionless = asset, has extension = document**.
+The runtime no longer branches on "has extension" versus "no extension". Document vs
+asset classification now exists only inside the source catalog builder.
 
-#### 3.3 Document Path Resolution
+#### 3.3 Unified Project / Engine Read Resolution
 
-`FileSystem.cpp:76-78` -> `Resource::ResolvePhysicalPath()`
+`FileSystem.cpp` routes every Project / Engine read through `CatalogRegistry::ResolvePath()`.
 
-Direct domain-to-directory mapping:
+This includes both kinds of logical path:
 
 ```
-/Project/Config/input/Foo.json  ->  {root}/Project/Config/input/Foo.json
-/Engine/Config/Foo.json         ->  {root}/Engine/Config/Foo.json
-/Saved/Config/imgui.ini         ->  {savedDir}/Config/imgui.ini
+/Project/Textures/Grassy_Square  -> catalog entry -> selected artifact
+/Project/Config/Graphics.json    -> document catalog entry -> selected artifact
+/Engine/Defaults/Materials/ErrorMaterial -> asset catalog entry -> selected artifact
 ```
 
-#### 3.4 Catalog-Backed Path Resolution
+The resolution path is the same for both asset and document entries. The difference is
+how the source catalog entry was synthesized:
 
-`FileSystem.cpp:66-73` -> `CatalogRegistry::ResolvePath()`
+- asset entries are extensionless logical paths and may later grow multiple artifacts
+- document entries keep their explicit filename/extension and currently carry a single
+  artifact with `format="document"`
 
-This is the most complex path, involving mount discovery, catalog loading, global table
-merging, and artifact selection.
+Once the entry is in the merged catalog table, runtime resolution does not care which
+builder-time rule produced it.
 
-**Step A: Lazily build the global table** (first call only,
-`ResourceCatalog.cpp:412-445`)
+**Step A: Lazily build the global table** (first call only)
 
 1. Call `DiscoverReadableMountBackends()` to discover all readable mounts. This function
    decides which backends to register based on the current profile:
@@ -297,7 +302,8 @@ merging, and artifact selection.
    - PakArchive backend: extract `.rtr/catalog.json` from inside the `.rtrpak` file.
 
 3. Parse the catalog JSON, validate version (v1 = source, v2 = cooked), and verify that
-   every entry's `logicalPath` belongs to the mount's domain.
+   every entry's `logicalPath` belongs to the mount's domain. Both extensionless asset
+   paths and extension-preserving document paths are valid for Project / Engine mounts.
 
 4. **Merge into global table** (`ResourceCatalog.cpp:334-388`):
    - A higher-priority mount's entry replaces a lower-priority one
@@ -342,6 +348,16 @@ Runtime tag sources:
   `{cacheDir}/PackagedExtracted/{sanitizedKey}/{relativePath}`, and return the extracted
   physical path.
 
+#### 3.4 Writable Domain Resolution
+
+`/Saved/...` and `/Cache/...` reads do not go through the catalog. They resolve by
+joining the parsed relative path onto the selected writable root:
+
+```
+/Saved/Config/imgui.ini  ->  {savedDir}/Config/imgui.ini
+/Cache/Shaders/foo.bin   ->  {cacheDir}/Shaders/foo.bin
+```
+
 #### 3.5 Write Path Resolution
 
 `FileSystem.cpp:80-96`:
@@ -358,7 +374,7 @@ returning the resolved path.
 User calls: FileSystem::ReadBinary("/Project/Textures/Grassy_Square")
   |
   +- ParseVirtualPath -> {Project, "Textures/Grassy_Square"}
-  +- IsCatalogBackedPath -> true (no extension + not Saved/Cache)
+  +- Domain dispatch -> Project => catalog path
   |
   +- CatalogRegistry::ResolvePath
        |
@@ -389,7 +405,8 @@ User calls: FileSystem::ReadBinary("/Project/Textures/Grassy_Square")
 
 | Mechanism | Implementation Location | Key Point |
 |-----------|------------------------|-----------|
-| Extension = document, no extension = asset | `PathParser::HasDocumentExtension` | The sole criterion that routes to document vs catalog resolution |
+| Project / Engine reads are always catalog-backed | `FileSystem::ResolveReadPath` | Runtime dispatch is by domain, not by filename extension |
+| Document vs asset classification is builder-time | `SourceCatalog.cpp` | Source catalog synthesis decides whether a logical path keeps its extension |
 | Overlay overrides everything | `MountPriority::Overlay = 300` | Development-time `Saved/Overrides/` can replace any resource |
 | Equal-priority conflict = removal | `MergeMountEntriesIntoGlobalTable` | No implicit choice; the path becomes unavailable |
 | Catalog is lazily built | `m_GlobalTableBuilt` flag | All mounts are scanned on the first `ResolvePath` call |

--- a/Docs/Modules/ResourceSystem/Plan.md
+++ b/Docs/Modules/ResourceSystem/Plan.md
@@ -119,9 +119,14 @@ state, not content.
   - **Document files** (config, text, JSON) → logical path keeps the extension;
     the entry holds a single artifact with `format="document"`. Artifact selection
     is trivial (single artifact always wins).
-  The classification rule is a **builder-time convention** (e.g. files under
-  `Config/` or with extensions in `{.json, .ini, .txt, .xml, .toml}` are
-  documents), not a runtime branch.
+  The classification rule is a **builder-time convention** based primarily on
+  content role, not merely file extension. Files under `Config/` are documents.
+  Plain-text support files such as `{.ini, .txt, .xml, .toml}` may also be
+  treated as documents where appropriate. Engine / Project content entries under
+  asset-oriented directories such as `Textures/`, `Shaders/`, `Materials/`,
+  `Scenes/`, and `Defaults/` remain assets even when their source representation
+  uses a text format such as `.json`. This classification remains a builder-time
+  rule, not a runtime branch.
 - On `FileSystem::Init`, dev builds catalogs **in memory** for Engine and Project
   source trees and installs them into `CatalogRegistry` alongside any on-disk
   cooked / packaged catalogs that exist.

--- a/Src/Core/Resource/Catalog/AssetPath.h
+++ b/Src/Core/Resource/Catalog/AssetPath.h
@@ -15,7 +15,26 @@ namespace Resource
 
         static bool IsValid(std::string_view path)
         {
-            return !path.empty() && IsCatalogBackedPath(path);
+            const auto parsed = ParseVirtualPath(path);
+            if (!parsed.has_value() || parsed->relativePath.empty() || parsed->mountName.has_value())
+                return false;
+
+            switch (parsed->domain)
+            {
+            case PathDomain::Project:
+            case PathDomain::Engine:
+                break;
+            case PathDomain::Saved:
+            case PathDomain::Cache:
+                return false;
+            }
+
+            const size_t slashPos = parsed->relativePath.find_last_of('/');
+            const std::string_view fileName = slashPos == std::string_view::npos
+                                                  ? std::string_view(parsed->relativePath)
+                                                  : std::string_view(parsed->relativePath).substr(slashPos + 1);
+            const size_t dotPos = fileName.find_last_of('.');
+            return dotPos == std::string_view::npos || dotPos == 0 || dotPos + 1 == fileName.size();
         }
 
         static std::optional<AssetPath> TryCreate(std::string_view path)

--- a/Src/Core/Resource/Catalog/ResourceCatalog.cpp
+++ b/Src/Core/Resource/Catalog/ResourceCatalog.cpp
@@ -46,6 +46,27 @@ namespace
         return catalogPath.domain == requestedPath.domain;
     }
 
+    bool IsCatalogLogicalPathForMount(const Resource::VirtualPath &catalogPath, const Resource::VirtualPath &mountPath)
+    {
+        if (!DomainMatchesMount(catalogPath, mountPath))
+            return false;
+
+        if (catalogPath.mountName.has_value() || catalogPath.relativePath.empty())
+            return false;
+
+        switch (catalogPath.domain)
+        {
+        case Resource::PathDomain::Project:
+        case Resource::PathDomain::Engine:
+            return true;
+        case Resource::PathDomain::Saved:
+        case Resource::PathDomain::Cache:
+            return false;
+        }
+
+        return false;
+    }
+
     std::optional<Resource::ArtifactRecord> ParseArtifactRecord(const Json &artifactJson)
     {
         if (!artifactJson.is_object())
@@ -132,8 +153,7 @@ namespace
 
             const std::string logicalPath = logicalPathIt->get<std::string>();
             const auto parsedLogicalPath = Resource::ParseVirtualPath(logicalPath);
-            if (!parsedLogicalPath.has_value() || !Resource::IsCatalogBackedPath(logicalPath) ||
-                !DomainMatchesMount(*parsedLogicalPath, mountPath))
+            if (!parsedLogicalPath.has_value() || !IsCatalogLogicalPathForMount(*parsedLogicalPath, mountPath))
             {
                 LOG_ERROR_CAT(LogCategory::FileSystem,
                               "Catalog '{}' contains invalid mount-scoped logical path '{}'",

--- a/Src/Core/Resource/Catalog/SourceCatalog.cpp
+++ b/Src/Core/Resource/Catalog/SourceCatalog.cpp
@@ -6,6 +6,7 @@
 #include <cctype>
 #include <fstream>
 #include <json.hpp>
+#include <unordered_set>
 #include <unordered_map>
 
 namespace
@@ -27,21 +28,17 @@ namespace
 
     bool IsExcludedRelativePath(const std::filesystem::path &relativePath)
     {
-        bool firstSegment = true;
         for (const auto &segment : relativePath)
         {
             const auto segmentText = segment.generic_string();
             if (segmentText == ".rtr")
                 return true;
-            if (firstSegment && segmentText == "Config")
-                return true;
-            firstSegment = false;
         }
 
         return false;
     }
 
-    std::string MakeLogicalPath(const Resource::VirtualPath &mountPath, const std::filesystem::path &relativeWithoutExtension)
+    std::string MakeLogicalPath(const Resource::VirtualPath &mountPath, const std::filesystem::path &logicalRelativePath)
     {
         static const std::unordered_map<std::string, std::string> kCanonicalSegmentNames{
             {"textures", "Textures"},
@@ -54,7 +51,7 @@ namespace
         };
 
         std::filesystem::path canonicalRelative;
-        for (const auto &segment : relativeWithoutExtension)
+        for (const auto &segment : logicalRelativePath)
         {
             const auto segmentText = segment.generic_string();
             const auto lookupIt = kCanonicalSegmentNames.find(ToLowerAscii(segmentText));
@@ -84,6 +81,43 @@ namespace
         if (!extension.empty() && extension.front() == '.')
             extension.erase(extension.begin());
         return ToLowerAscii(extension);
+    }
+
+    bool RelativePathStartsWith(const std::filesystem::path &relativePath, std::string_view firstSegment)
+    {
+        const auto it = relativePath.begin();
+        return it != relativePath.end() && ToLowerAscii(it->generic_string()) == ToLowerAscii(std::string(firstSegment));
+    }
+
+    bool RelativePathContainsAssetDirectory(const std::filesystem::path &relativePath)
+    {
+        static const std::unordered_set<std::string> kAssetDirectories{
+            "textures",
+            "shaders",
+            "materials",
+            "scenes",
+            "defaults",
+        };
+
+        for (const auto &segment : relativePath)
+        {
+            if (kAssetDirectories.contains(ToLowerAscii(segment.generic_string())))
+                return true;
+        }
+
+        return false;
+    }
+
+    bool IsDocumentPath(const std::filesystem::path &relativePath)
+    {
+        if (RelativePathStartsWith(relativePath, "Config"))
+            return true;
+
+        if (RelativePathContainsAssetDirectory(relativePath))
+            return false;
+
+        const auto extension = DetectFormat(relativePath);
+        return extension == "ini" || extension == "txt" || extension == "xml" || extension == "toml";
     }
 
     std::vector<std::pair<Resource::VirtualPath, std::filesystem::path>> DiscoverReadableSourceMounts(
@@ -156,7 +190,8 @@ namespace
 
         for (const auto &relativePath : files)
         {
-            const auto logicalRelativePath = relativePath.parent_path() / relativePath.stem();
+            const bool isDocument = IsDocumentPath(relativePath);
+            const auto logicalRelativePath = isDocument ? relativePath : (relativePath.parent_path() / relativePath.stem());
             const auto logicalPath = MakeLogicalPath(mountPath, logicalRelativePath);
 
             if (logicalPath.empty())
@@ -181,7 +216,7 @@ namespace
             catalogEntry.sourceRelativePath = CatalogPathToGenericString(relativePath);
             catalogEntry.artifacts.push_back(Resource::ArtifactRecord{
                 .relativePath = CatalogPathToGenericString(relativePath),
-                .format = DetectFormat(relativePath),
+                .format = isDocument ? "document" : DetectFormat(relativePath),
                 .platformTag = "any",
                 .backendTag = "any",
                 .profileTag = "dev",

--- a/Src/Core/Resource/FileSystem.cpp
+++ b/Src/Core/Resource/FileSystem.cpp
@@ -46,24 +46,16 @@ std::optional<FileSystem::VirtualPath> FileSystem::ParseVirtualPath(std::string_
     return Resource::ParseVirtualPath(path);
 }
 
-bool FileSystem::IsCatalogBackedPath(std::string_view path)
-{
-    return Resource::IsCatalogBackedPath(path);
-}
-
-bool FileSystem::IsDocumentPath(std::string_view path)
-{
-    return Resource::IsDocumentPath(path);
-}
-
 std::optional<std::filesystem::path> FileSystem::ResolveReadPath(std::string_view virtualPathString)
 {
     const auto virtualPath = Resource::ParseVirtualPath(virtualPathString);
     if (!virtualPath.has_value())
         return std::nullopt;
 
-    if (Resource::IsCatalogBackedPath(virtualPathString))
+    switch (virtualPath->domain)
     {
+    case Resource::PathDomain::Project:
+    case Resource::PathDomain::Engine:
         if (const auto resolved = s_CatalogRegistry.ResolvePath(
                 s_RootPath, s_EngineDir, GetCacheDir(), *virtualPath, virtualPathString, kProjectContentDirName))
         {
@@ -71,10 +63,19 @@ std::optional<std::filesystem::path> FileSystem::ResolveReadPath(std::string_vie
         }
 
         return std::nullopt;
+    case Resource::PathDomain::Saved:
+    case Resource::PathDomain::Cache:
+    {
+        const auto writableMount = Resource::ResolveWritableMount(virtualPath->domain, GetSavedDir(), GetCacheDir());
+        if (!writableMount.has_value())
+            return std::nullopt;
+
+        const auto relativePath = Resource::GetPhysicalRelativePath(*virtualPath);
+        return relativePath.empty() ? writableMount->rootPath : writableMount->rootPath / relativePath;
+    }
     }
 
-    return Resource::ResolvePhysicalPath(
-        s_RootPath, s_EngineDir, GetSavedDir(), GetCacheDir(), *virtualPath, kProjectContentDirName);
+    return std::nullopt;
 }
 
 std::optional<std::filesystem::path> FileSystem::ResolveWritePath(std::string_view virtualPathString)

--- a/Src/Core/Resource/FileSystem.h
+++ b/Src/Core/Resource/FileSystem.h
@@ -26,8 +26,6 @@ public:
 
     static bool IsVirtualPath(std::string_view path);
     static std::optional<VirtualPath> ParseVirtualPath(std::string_view path);
-    static bool IsCatalogBackedPath(std::string_view path);
-    static bool IsDocumentPath(std::string_view path);
 
     static std::optional<std::filesystem::path> ResolveReadPath(std::string_view virtualPath);
     static std::optional<std::filesystem::path> ResolveWritePath(std::string_view virtualPath);

--- a/Src/Core/Resource/Mount/MountResolver.cpp
+++ b/Src/Core/Resource/Mount/MountResolver.cpp
@@ -67,48 +67,8 @@ namespace Resource
         return writableRoots;
     }
 
-    std::filesystem::path GetDomainBasePath(const std::filesystem::path &rootPath,
-                                            const std::filesystem::path &engineDir,
-                                            const std::filesystem::path &savedDir,
-                                            const std::filesystem::path &cacheDir,
-                                            const VirtualPath &virtualPath,
-                                            std::string_view assetDirName)
-    {
-        switch (virtualPath.domain)
-        {
-        case PathDomain::Project:
-            return rootPath / assetDirName;
-        case PathDomain::Engine:
-            return engineDir;
-        case PathDomain::Saved:
-            return savedDir;
-        case PathDomain::Cache:
-            return cacheDir;
-        }
-
-        return {};
-    }
-
     std::filesystem::path GetPhysicalRelativePath(const VirtualPath &virtualPath)
     {
         return std::filesystem::path(virtualPath.relativePath);
-    }
-
-    std::optional<std::filesystem::path> ResolvePhysicalPath(const std::filesystem::path &rootPath,
-                                                             const std::filesystem::path &engineDir,
-                                                             const std::filesystem::path &savedDir,
-                                                             const std::filesystem::path &cacheDir,
-                                                             const VirtualPath &virtualPath,
-                                                             std::string_view assetDirName)
-    {
-        const auto basePath = GetDomainBasePath(rootPath, engineDir, savedDir, cacheDir, virtualPath, assetDirName);
-        if (basePath.empty())
-            return std::nullopt;
-
-        const auto relativePath = GetPhysicalRelativePath(virtualPath);
-        if (relativePath.empty())
-            return basePath;
-
-        return basePath / relativePath;
     }
 } // namespace Resource

--- a/Src/Core/Resource/Mount/MountResolver.h
+++ b/Src/Core/Resource/Mount/MountResolver.h
@@ -15,17 +15,5 @@ namespace Resource
     };
 
     WritableRoots ResolveWritableRoots(const std::filesystem::path &rootPath, std::string_view appName);
-    std::filesystem::path GetDomainBasePath(const std::filesystem::path &rootPath,
-                                            const std::filesystem::path &engineDir,
-                                            const std::filesystem::path &savedDir,
-                                            const std::filesystem::path &cacheDir,
-                                            const VirtualPath &virtualPath,
-                                            std::string_view assetDirName);
     std::filesystem::path GetPhysicalRelativePath(const VirtualPath &virtualPath);
-    std::optional<std::filesystem::path> ResolvePhysicalPath(const std::filesystem::path &rootPath,
-                                                             const std::filesystem::path &engineDir,
-                                                             const std::filesystem::path &savedDir,
-                                                             const std::filesystem::path &cacheDir,
-                                                             const VirtualPath &virtualPath,
-                                                             std::string_view assetDirName);
 } // namespace Resource

--- a/Src/Core/Resource/Path/PathParser.cpp
+++ b/Src/Core/Resource/Path/PathParser.cpp
@@ -17,19 +17,6 @@ namespace
 
         return joined;
     }
-
-    bool HasDocumentExtension(std::string_view relativePath)
-    {
-        const size_t slashPos = relativePath.find_last_of('/');
-        const std::string_view fileName = slashPos == std::string_view::npos
-                                              ? relativePath
-                                              : relativePath.substr(slashPos + 1);
-        if (fileName.empty())
-            return false;
-
-        const size_t dotPos = fileName.find_last_of('.');
-        return dotPos != std::string_view::npos && dotPos > 0 && dotPos + 1 < fileName.size();
-    }
 } // namespace
 
 namespace Resource
@@ -102,30 +89,5 @@ namespace Resource
         }
 
         return std::nullopt;
-    }
-
-    bool IsCatalogBackedPath(std::string_view path)
-    {
-        const auto virtualPath = ParseVirtualPath(path);
-        if (!virtualPath.has_value())
-            return false;
-
-        switch (virtualPath->domain)
-        {
-        case PathDomain::Project:
-        case PathDomain::Engine:
-            return !virtualPath->relativePath.empty() && !IsDocumentPath(path);
-        case PathDomain::Saved:
-        case PathDomain::Cache:
-            return false;
-        }
-
-        return false;
-    }
-
-    bool IsDocumentPath(std::string_view path)
-    {
-        const auto virtualPath = ParseVirtualPath(path);
-        return virtualPath.has_value() && HasDocumentExtension(virtualPath->relativePath);
     }
 } // namespace Resource

--- a/Src/Core/Resource/Path/PathParser.h
+++ b/Src/Core/Resource/Path/PathParser.h
@@ -9,6 +9,4 @@ namespace Resource
 {
     bool IsVirtualPath(std::string_view path);
     std::optional<VirtualPath> ParseVirtualPath(std::string_view path);
-    bool IsCatalogBackedPath(std::string_view path);
-    bool IsDocumentPath(std::string_view path);
 } // namespace Resource

--- a/Tests/Integration/TestSourceCatalogDev.cpp
+++ b/Tests/Integration/TestSourceCatalogDev.cpp
@@ -50,6 +50,25 @@ TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsProjectSourceCatalogInMemoryD
     EXPECT_EQ(*resolved, test_support::ProjectContentRoot(repoRoot) / "Textures" / "Grassy_Square.jpg");
 }
 
+TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsProjectConfigDocumentEntriesInMemoryDuringDevResolution)
+{
+    const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
+    test_support::WriteProjectFileOrFail(repoRoot, "Config/Graphics.json", "{\n  \"vsync\": true\n}\n");
+
+    Resource::CatalogRegistry registry;
+    const auto virtualPath = Resource::VirtualPath{Resource::PathDomain::Project, std::nullopt, "Config/Graphics.json"};
+    const auto resolved = registry.ResolvePath(
+        repoRoot,
+        test_support::EngineRoot(repoRoot),
+        repoRoot / "Saved" / "Cache",
+        virtualPath,
+        "/Project/Config/Graphics.json",
+        "Project");
+
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_EQ(*resolved, test_support::ProjectContentRoot(repoRoot) / "Config" / "Graphics.json");
+}
+
 TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsEngineSourceCatalogInMemoryDuringDevResolution)
 {
     const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());

--- a/Tests/Unit/TestBuiltinTraits.cpp
+++ b/Tests/Unit/TestBuiltinTraits.cpp
@@ -142,6 +142,18 @@ TEST(BuiltinTraitsTests, AssetPathRoundTrip)
     EXPECT_EQ(output.String(), "/Project/Textures/Grassy_Square");
 }
 
+TEST(BuiltinTraitsTests, AssetPathTryCreateAcceptsContentPathsWithoutExtensions)
+{
+    EXPECT_TRUE(Resource::AssetPath::TryCreate("/Project/Textures/Grassy_Square").has_value());
+    EXPECT_TRUE(Resource::AssetPath::TryCreate("/Engine/Defaults/Materials/ErrorMaterial").has_value());
+}
+
+TEST(BuiltinTraitsTests, AssetPathTryCreateRejectsConfigDocumentPaths)
+{
+    EXPECT_FALSE(Resource::AssetPath::TryCreate("/Project/Config/Graphics.json").has_value());
+    EXPECT_FALSE(Resource::AssetPath::TryCreate("/Engine/Config/Graphics.json").has_value());
+}
+
 TEST(BuiltinTraitsTests, AssetPathDeserializeRejectsAbsoluteFilesystemPathAndLeavesOutputUnchanged)
 {
     const auto original = Resource::AssetPath::TryCreate("/Project/Textures/Original");

--- a/Tests/Unit/TestFileSystemVirtualPaths.cpp
+++ b/Tests/Unit/TestFileSystemVirtualPaths.cpp
@@ -28,16 +28,24 @@ TEST(FileSystemVirtualPathTests, ParseRejectsBackslashes)
     EXPECT_FALSE(FileSystem::ParseVirtualPath("/Project\\Textures\\Wood").has_value());
 }
 
-TEST(FileSystemVirtualPathTests, DocumentPathDetectionRequiresExplicitExtension)
+TEST(FileSystemVirtualPathTests, IsVirtualPathAcceptsReadableAndWritableDomains)
 {
-    EXPECT_TRUE(FileSystem::IsDocumentPath("/Saved/Config/imgui.ini"));
-    EXPECT_TRUE(FileSystem::IsDocumentPath("/Project/Config/input/DebugCameraControl.json"));
-    EXPECT_FALSE(FileSystem::IsDocumentPath("/Project/Textures/Grassy_Square"));
+    EXPECT_TRUE(FileSystem::IsVirtualPath("/Project/Config/input/DebugCameraControl.json"));
+    EXPECT_TRUE(FileSystem::IsVirtualPath("/Engine/Defaults/Materials/ErrorMaterial"));
+    EXPECT_TRUE(FileSystem::IsVirtualPath("/Saved/Config/imgui.ini"));
+    EXPECT_TRUE(FileSystem::IsVirtualPath("/Cache/Shaders/bootstrap.bin"));
 }
 
-TEST(FileSystemVirtualPathTests, CatalogBackedDetectionOnlyAppliesToReadDomainsWithoutExtensions)
+TEST(FileSystemVirtualPathTests, ParseRecognizesSavedAndCacheDomains)
 {
-    EXPECT_TRUE(FileSystem::IsCatalogBackedPath("/Project/Textures/Grassy_Square"));
-    EXPECT_FALSE(FileSystem::IsCatalogBackedPath("/Project/Config/input/DebugCameraControl.json"));
-    EXPECT_FALSE(FileSystem::IsCatalogBackedPath("/Saved/Logs/RTRLab.log"));
+    const auto saved = FileSystem::ParseVirtualPath("/Saved/Logs/RTRLab.log");
+    const auto cache = FileSystem::ParseVirtualPath("/Cache/Shaders/bootstrap.bin");
+
+    ASSERT_TRUE(saved.has_value());
+    EXPECT_EQ(saved->domain, FileSystem::PathDomain::Saved);
+    EXPECT_EQ(saved->relativePath, "Logs/RTRLab.log");
+
+    ASSERT_TRUE(cache.has_value());
+    EXPECT_EQ(cache->domain, FileSystem::PathDomain::Cache);
+    EXPECT_EQ(cache->relativePath, "Shaders/bootstrap.bin");
 }

--- a/Tests/Unit/TestSourceCatalog.cpp
+++ b/Tests/Unit/TestSourceCatalog.cpp
@@ -33,7 +33,7 @@ namespace
     };
 } // namespace
 
-TEST_F(SourceCatalogTests, BuildProjectSourceCatalogSkipsConfigAndCatalogArtifacts)
+TEST_F(SourceCatalogTests, BuildProjectSourceCatalogIncludesConfigDocumentsAndSkipsCatalogArtifacts)
 {
     test_support::WriteMountFileOrFail(TestRoot(), "textures/Grassy_Square.jpg", "jpg");
     test_support::WriteMountFileOrFail(TestRoot(), "Config/input/DebugCameraControl.json", "{}");
@@ -49,14 +49,35 @@ TEST_F(SourceCatalogTests, BuildProjectSourceCatalogSkipsConfigAndCatalogArtifac
         &errorMessage))
         << errorMessage;
 
-    ASSERT_EQ(entries.size(), 1u);
-    EXPECT_EQ(entries[0].logicalPath, "/Project/Textures/Grassy_Square");
-    ASSERT_TRUE(entries[0].sourceRelativePath.has_value());
-    EXPECT_EQ(*entries[0].sourceRelativePath, "textures/Grassy_Square.jpg");
-    ASSERT_EQ(entries[0].artifacts.size(), 1u);
-    EXPECT_EQ(entries[0].artifacts[0].relativePath, "textures/Grassy_Square.jpg");
-    EXPECT_EQ(entries[0].artifacts[0].format, "jpg");
-    EXPECT_EQ(entries[0].artifacts[0].profileTag, "dev");
+    ASSERT_EQ(entries.size(), 2u);
+
+    const auto findEntry = [&](std::string_view logicalPath) -> const Resource::ResourceCatalogEntry * {
+        for (const auto &entry : entries)
+        {
+            if (entry.logicalPath == logicalPath)
+                return &entry;
+        }
+
+        return nullptr;
+    };
+
+    const auto *textureEntry = findEntry("/Project/Textures/Grassy_Square");
+    ASSERT_NE(textureEntry, nullptr);
+    ASSERT_TRUE(textureEntry->sourceRelativePath.has_value());
+    EXPECT_EQ(*textureEntry->sourceRelativePath, "textures/Grassy_Square.jpg");
+    ASSERT_EQ(textureEntry->artifacts.size(), 1u);
+    EXPECT_EQ(textureEntry->artifacts[0].relativePath, "textures/Grassy_Square.jpg");
+    EXPECT_EQ(textureEntry->artifacts[0].format, "jpg");
+    EXPECT_EQ(textureEntry->artifacts[0].profileTag, "dev");
+
+    const auto *configEntry = findEntry("/Project/Config/input/DebugCameraControl.json");
+    ASSERT_NE(configEntry, nullptr);
+    ASSERT_TRUE(configEntry->sourceRelativePath.has_value());
+    EXPECT_EQ(*configEntry->sourceRelativePath, "Config/input/DebugCameraControl.json");
+    ASSERT_EQ(configEntry->artifacts.size(), 1u);
+    EXPECT_EQ(configEntry->artifacts[0].relativePath, "Config/input/DebugCameraControl.json");
+    EXPECT_EQ(configEntry->artifacts[0].format, "document");
+    EXPECT_EQ(configEntry->artifacts[0].profileTag, "dev");
 }
 
 TEST_F(SourceCatalogTests, BuildSourceCatalogMapReturnsEntriesByLogicalPath)
@@ -136,10 +157,34 @@ TEST_F(SourceCatalogTests, BuildEngineSourceCatalogMapUsesEngineNamespace)
     EXPECT_TRUE(entries.contains("/Engine/Defaults/Materials/ErrorMaterial"));
 }
 
+TEST_F(SourceCatalogTests, BuildSourceCatalogTreatsPlainTextSupportFilesAsDocuments)
+{
+    test_support::WriteMountFileOrFail(TestRoot(), "Docs/Readme.txt", "hello");
+
+    std::unordered_map<std::string, Resource::ResourceCatalogEntry> entries;
+    std::string errorMessage;
+
+    ASSERT_TRUE(Resource::BuildSourceCatalogMap(
+        TestRoot(),
+        Resource::VirtualPath{Resource::PathDomain::Project, std::nullopt, {}},
+        entries,
+        &errorMessage))
+        << errorMessage;
+
+    const auto it = entries.find("/Project/Docs/Readme.txt");
+    ASSERT_NE(it, entries.end());
+    ASSERT_TRUE(it->second.sourceRelativePath.has_value());
+    EXPECT_EQ(*it->second.sourceRelativePath, "Docs/Readme.txt");
+    ASSERT_EQ(it->second.artifacts.size(), 1u);
+    EXPECT_EQ(it->second.artifacts[0].relativePath, "Docs/Readme.txt");
+    EXPECT_EQ(it->second.artifacts[0].format, "document");
+}
+
 TEST_F(SourceCatalogTests, IndexRepositorySourceCatalogsWritesProjectAndEngineCatalogs)
 {
     const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
     test_support::WriteProjectFileOrFail(repoRoot, "Textures/Grassy_Square.jpg", "jpg");
+    test_support::WriteProjectFileOrFail(repoRoot, "Config/Graphics.json", "{\n}\n");
     test_support::WriteEngineFileOrFail(repoRoot, "Defaults/Materials/ErrorMaterial.json", "{\n}\n");
 
     std::string errorMessage;
@@ -160,6 +205,8 @@ TEST_F(SourceCatalogTests, IndexRepositorySourceCatalogsWritesProjectAndEngineCa
     const std::string engineContents((std::istreambuf_iterator<char>(engineCatalog)), std::istreambuf_iterator<char>());
 
     EXPECT_NE(projectContents.find("/Project/Textures/Grassy_Square"), std::string::npos);
+    EXPECT_NE(projectContents.find("/Project/Config/Graphics.json"), std::string::npos);
+    EXPECT_NE(projectContents.find("\"format\": \"document\""), std::string::npos);
     EXPECT_NE(engineContents.find("/Engine/Defaults/Materials/ErrorMaterial"), std::string::npos);
 }
 


### PR DESCRIPTION
## Summary
- Route all `/Project/...` and `/Engine/...` reads through `CatalogRegistry` instead of splitting runtime behavior by “document path” vs “catalog-backed path”.
- Keep `/Saved/...` and `/Cache/...` as direct writable-mount domains.
- Move document-vs-asset handling into `SourceCatalogBuilder` as a builder-time classification rule.
- Classify `Config/*` and plain-text support files as document entries, while keeping content directories like `Textures/`, `Materials/`, `Scenes/`, and `Defaults/` as asset entries even when source files are text-based.

## Why
- Make development and shipping exercise the same Project/Engine read path.
- Remove the old runtime bifurcation based on filename extensions.
- Keep config/document behavior explicit without treating every text-formatted resource as a document.
- Align implementation and docs with the approved Phase 4 plan.

## Affected areas
- `Src/Core/Resource/FileSystem.*`
- `Src/Core/Resource/Path/PathParser.*`
- `Src/Core/Resource/Mount/MountResolver.*`
- `Src/Core/Resource/Catalog/ResourceCatalog.cpp`
- `Src/Core/Resource/Catalog/AssetPath.h`
- `Src/Core/Resource/Catalog/SourceCatalog.cpp`
- `Tests/Unit/TestFileSystemVirtualPaths.cpp`
- `Tests/Unit/TestSourceCatalog.cpp`
- `Tests/Unit/TestBuiltinTraits.cpp`
- `Tests/Integration/TestSourceCatalogDev.cpp`
- `Docs/Modules/ResourceSystem/Design.md`
- `Docs/Modules/ResourceSystem/Internals.md`

## Documentation
- [ ] No documentation needed
- [x] Documentation updated

## Testing
- Built `rtrlab_unit_tests` and `rtrlab_dev_profile_tests` in `build/ci-windows-vs-debug`
- Ran targeted `FileSystemVirtualPath`, `AssetPath`, and `SourceCatalogDev` tests after the read-path changes
- Ran targeted `SourceCatalog`, `CookedCatalog`, and `SourceCatalogDev` tests after source-entry classification changes
- Ran targeted `AssetPath` tests after the final validation-test updates

## Notes
- Config/default documents in Project/Engine now participate in the catalog path as document entries rather than bypassing the catalog at runtime.
- `/Saved/...` and `/Cache/...` remain the only direct writable domains.