### PR TITLE
Replace path-based reads with data and stream APIs

### DIFF
--- a/Docs/Modules/ResourceSystem/Design.md
+++ b/Docs/Modules/ResourceSystem/Design.md
@@ -49,7 +49,7 @@ paths.
     - [Why logical paths are case-sensitive on every platform](#why-logical-paths-are-case-sensitive-on-every-platform)
     - [Why config files are mounted documents, not extensionless assets](#why-config-files-are-mounted-documents-not-extensionless-assets)
     - [Why source and cooked catalogs are separate schemas](#why-source-and-cooked-catalogs-are-separate-schemas)
-    - [Why packaged archives materialize into cache-backed files today](#why-packaged-archives-materialize-into-cache-backed-files-today)
+    - [Why packaged archives return data and streams instead of temporary files](#why-packaged-archives-return-data-and-streams-instead-of-temporary-files)
 
 ---
 
@@ -197,7 +197,7 @@ Read APIs may accept any logical domain, but write APIs only accept `/Saved/` an
 
 That means:
 
-- `FileSystem::ResolveReadPath("/Project/Textures/Grassy_Square")` is valid
+- `FileSystem::ReadBinary("/Project/Textures/Grassy_Square")` is valid
 - `FileSystem::ResolveWritePath("/Saved/Config/input/Foo.json")` is valid
 - `FileSystem::ResolveWritePath("/Project/Config/Foo.json")` is rejected
 
@@ -392,8 +392,8 @@ The backend layer is responsible for:
 - discovering readable mounts for the current profile
 - checking whether a mount exposes a catalog
 - reading mount-local catalog bytes
-- resolving a selected artifact to a physical file path
-- materializing pak entries when the runtime still expects a file path
+- resolving a selected artifact to a readable descriptor
+- serving bytes or streams for directory-backed and pak-backed artifacts
 - resolving writable mount roots for `/Saved/` and `/Cache/`
 
 This keeps `ResourceCatalog` focused on catalog semantics and keeps `FileSystem`
@@ -409,9 +409,9 @@ Key public responsibilities:
 
 - initialize root discovery and writable roots
 - parse logical paths and dispatch by domain
-- resolve read and write paths
-- expose logical-path-based `Exists`, `ReadText`, `ReadBinary`, `WriteText`,
-  and `WriteBinary`
+- resolve writable paths
+- expose logical-path-based `Exists`, `ReadText`, `ReadBinary`,
+  `OpenReadStream`, `WriteText`, and `WriteBinary`
 - refresh the catalog registry when mount state changes
 
 Current root discovery behavior is now:
@@ -422,9 +422,9 @@ Current root discovery behavior is now:
 
 The facade is now fully logical-path-first. Runtime systems are expected to use:
 
-- `ResolveReadPath()` / `ResolveWritePath()`
+- `ResolveWritePath()` for writable-domain path creation
 - `Exists()`
-- `ReadText()` / `ReadBinary()`
+- `ReadText()` / `ReadBinary()` / `OpenReadStream()`
 - `WriteText()` / `WriteBinary()`
 
 Low-level physical I/O still exists in `Resource::ReadTextFile()` and
@@ -663,14 +663,16 @@ Near-term plan:
 
 ### 12.5 Streaming versus materialized archive entries
 
-Packaged archive entries currently materialize into cache-backed files so the rest of
-the runtime can keep consuming physical file paths.
+Packaged archive entries no longer materialize into cache-backed files as part of the
+normal read path. The resource system now resolves a readable artifact descriptor and
+serves text, bytes, or streams directly from either a directory-backed file or a
+pak-backed entry.
 
 Near-term plan:
 
-- keep materialization because it minimizes churn for current systems
-- revisit direct stream-style resource access only when higher-level runtime loaders are
-  in place and the cost of temporary extraction becomes meaningful
+- keep `ReadText()` / `ReadBinary()` / `OpenReadStream()` as the primary read surface
+- migrate more high-level runtime consumers toward stream-friendly loading where it
+  meaningfully reduces memory spikes for large payloads
 
 ---
 
@@ -745,8 +747,10 @@ Source catalogs need provenance like `sourceRelativePath`; cooked catalogs do no
 Keeping the schemas separate prevents runtime code from accidentally depending on
 authoring-only details and makes the transition to richer cooked metadata cleaner.
 
-### Why packaged archives materialize into cache-backed files today
+### Why packaged archives return data and streams instead of temporary files
 
-Most of the current runtime still wants a physical file path after resource resolution.
-Materializing pak entries into cache-backed files lets packaged mounts participate in
-the same path-based consumers without forcing a larger streaming/IO API redesign first.
+The current resource API is data-first: callers are expected to consume text, binary
+buffers, or `istream` objects instead of asking the resource system for a physical file
+path. That lets packaged mounts read directly from `.rtrpak` entries without extracting
+temporary files into a cache directory first, and it keeps directory-backed and
+pak-backed reads behind the same public contract.

--- a/Docs/Modules/ResourceSystem/Internals.md
+++ b/Docs/Modules/ResourceSystem/Internals.md
@@ -53,7 +53,7 @@ The system operates in two phases: an **offline toolchain** (index, cook, pack) 
 Offline phase (build time)                Runtime phase
 +---------------+                        +----------------------+
 | rtr_asset_    |  scan source files     | FileSystem::         |
-|   index       |-> generate catalog.json| ResolveReadPath      |
+|   index       |-> generate catalog.json| ReadText / ReadBinary|
 +---------------+                        +----------+-----------+
        |                                            |
        v                                            v
@@ -235,7 +235,7 @@ use platform-specific user data paths:
 
 #### 3.2 Path Parsing and Domain Dispatch
 
-When `ResolveReadPath("/Project/Textures/Grassy_Square")` is called:
+When `ReadBinary("/Project/Textures/Grassy_Square")` is called:
 
 **Step 1: Parse the virtual path**
 - Validate: must start with `/`, must not contain `\`, must not contain `.` or `..`
@@ -246,7 +246,7 @@ When `ResolveReadPath("/Project/Textures/Grassy_Square")` is called:
 Result: `VirtualPath { domain=Project, mountName=nullopt, relativePath="Textures/Grassy_Square" }`
 
 **Step 2: Dispatch by domain**
-- `Project` / `Engine`: always resolve through `CatalogRegistry::ResolvePath()`
+- `Project` / `Engine`: always resolve through `CatalogRegistry::ResolveArtifact()`
 - `Saved` / `Cache`: resolve through writable mounts directly
 
 The runtime no longer branches on "has extension" versus "no extension". Document vs
@@ -254,7 +254,7 @@ asset classification now exists only inside the source catalog builder.
 
 #### 3.3 Unified Project / Engine Read Resolution
 
-`FileSystem.cpp` routes every Project / Engine read through `CatalogRegistry::ResolvePath()`.
+`FileSystem.cpp` routes every Project / Engine read through `CatalogRegistry::ResolveArtifact()`.
 
 This includes both kinds of logical path:
 
@@ -341,12 +341,15 @@ Runtime tag sources:
   compile-time default (`dev` / `shipping`). For packaged/shipping profiles, the
   artifact profile tag is mapped to `"cooked"`.
 
-**Step D: Artifact physical path resolution** (`MountBackend.cpp:395-408`)
+**Step D: Artifact descriptor resolution** (`MountBackend.cpp`)
 
-- Directory backend: return `mountRoot / artifact.relativePath`.
-- PakArchive backend: extract the entry from the pak to
-  `{cacheDir}/PackagedExtracted/{sanitizedKey}/{relativePath}`, and return the extracted
-  physical path.
+- Directory backend: return a descriptor with `backend=Directory`,
+  `mountRoot`, and `relativePath`.
+- PakArchive backend: return a descriptor with `backend=PakArchive`,
+  `mountRoot`, and `relativePath`.
+- `FileSystem::ReadText`, `ReadBinary`, and `OpenReadStream` consume that
+  descriptor directly. Directory-backed reads use normal file I/O; pak-backed
+  reads use `ReadPakEntry()` or an in-memory stream wrapper.
 
 #### 3.4 Writable Domain Resolution
 
@@ -376,7 +379,7 @@ User calls: FileSystem::ReadBinary("/Project/Textures/Grassy_Square")
   +- ParseVirtualPath -> {Project, "Textures/Grassy_Square"}
   +- Domain dispatch -> Project => catalog path
   |
-  +- CatalogRegistry::ResolvePath
+  +- CatalogRegistry::ResolveArtifact
        |
        +- [first call] DiscoverReadableMountBackends
        |    +- Project/ exists           -> register Source:Project    (priority=0)
@@ -393,10 +396,13 @@ User calls: FileSystem::ReadBinary("/Project/Textures/Grassy_Square")
        |    e.g. {relativePath: "Textures/Grassy_Square.rtrtex", profileTag: "cooked"}
        |
        +- ResolveReadableMountArtifact
-            +- Directory backend -> return mountRoot/Textures/Grassy_Square.rtrtex
-            +- PakArchive backend -> extract from .rtrpak to cache -> return extracted path
+            +- Directory backend -> {mountRoot, relativePath}
+            +- PakArchive backend -> {pak archive path, relativePath}
 
-  ReadBinary receives the physical path, calls Resource::ReadBinaryFile, returns bytes.
+  ReadBinary consumes the descriptor:
+    +- Directory backend -> Resource::ReadBinaryFile(mountRoot / relativePath)
+    +- PakArchive backend -> Resource::ReadPakEntry(pakPath, relativePath)
+  -> returns bytes.
 ```
 
 ---
@@ -405,12 +411,12 @@ User calls: FileSystem::ReadBinary("/Project/Textures/Grassy_Square")
 
 | Mechanism | Implementation Location | Key Point |
 |-----------|------------------------|-----------|
-| Project / Engine reads are always catalog-backed | `FileSystem::ResolveReadPath` | Runtime dispatch is by domain, not by filename extension |
+| Project / Engine reads are always catalog-backed | `FileSystem::ReadText` / `ReadBinary` / `OpenReadStream` | Runtime dispatch is by domain, not by filename extension |
 | Document vs asset classification is builder-time | `SourceCatalog.cpp` | Source catalog synthesis decides whether a logical path keeps its extension |
 | Overlay overrides everything | `MountPriority::Overlay = 300` | Development-time `Saved/Overrides/` can replace any resource |
 | Equal-priority conflict = removal | `MergeMountEntriesIntoGlobalTable` | No implicit choice; the path becomes unavailable |
-| Catalog is lazily built | `m_GlobalTableBuilt` flag | All mounts are scanned on the first `ResolvePath` call |
-| Pak entries materialize to cache | `MaterializePakEntry` | Runtime still works with physical file paths, avoiding consumer changes |
+| Catalog is lazily built | `m_GlobalTableBuilt` flag | All mounts are scanned on the first Project / Engine read |
+| Pak entries are read directly | `ReadPakEntry` / `OpenReadableArtifactStream` | No extraction cache or temp-file materialization remains in the normal read path |
 | Profile determines mount registration order | `DiscoverReadableMountBackends` | `dev` prefers source; `shipping` prefers packaged |
 | Writable dirs are lazily resolved | `FileSystem::ResolveWritableDirs` | First call to `GetSavedDir()` / `GetCacheDir()` triggers resolution |
 | Dev root discovery walks up from executable | `FindRootFromExecutable` | Up to 5 parent directories, looking for `.rtrproject` |
@@ -545,7 +551,7 @@ support or runtime content downloads.
 | Alignment | **None** | Configurable (sector-aligned for HDD/SSD) | Yes | None |
 | Index location | End of file | End of file | Header | End of file |
 | Single-entry read | Re-opens file + re-reads full index every time | Index resident in memory, direct seek+read | Resident | Index resident |
-| Streaming | Materialize to cache, then read file | Direct stream from pak | Direct stream | Direct stream |
+| Streaming | Direct stream from resolved artifact | Direct stream from pak | Direct stream | Direct stream |
 
 **Analysis**:
 
@@ -559,11 +565,11 @@ large storage sizes. This is acceptable with only a few textures but grows linea
 and keeps it resident; subsequent reads require only a single seek+read. RTRLab reopens
 the file and reads the full header+index on every `FindPakEntry` call.
 
-**c) Materialization vs streaming**. RTRLab extracts pak entries to cache-backed physical
-files and then lets consumers read those files. Unreal and Unity support streaming
-directly from inside the pak without materialization. The design document (section 12.5)
-explicitly acknowledges this as an intentional trade-off: current runtime consumers
-expect physical file paths, and materialization avoids rewriting all consumers.
+**c) Data-returning reads vs streaming**. RTRLab now resolves readable artifacts into a
+small descriptor and lets the `FileSystem` facade serve bytes or streams directly from
+directory-backed files or pak-backed entries. Unreal and Unity also support direct
+streaming from archives; RTRLab now follows the same broad direction, though its higher-
+level runtime consumers are still largely synchronous.
 
 ### 11. Mechanisms Present in Mature Engines but Absent in RTRLab
 

--- a/Docs/Modules/SerializationSystem/Internals.md
+++ b/Docs/Modules/SerializationSystem/Internals.md
@@ -67,13 +67,13 @@ The serialization system is organized as a four-layer stack. Each layer has a si
 responsibility and depends only on the layer below it:
 
 ```
-Layer 3 — File I/O Integration        Serialization.h
-           ↕ (filesystem paths)
-Layer 2 — Format Backends              IFormatBackend.h, JsonBackend.h/.cpp
-           ↕ (string ↔ PropertyTree)
-Layer 1 — Serialization Traits         SerializationTraits.h, BuiltinTraits.h
-           ↕ (T ↔ PropertyTree)
-Layer 0 — Intermediate Representation  PropertyTree.h/.cpp
+Layer 3 -- File I/O Integration        Serialization.h
+           -> (logical paths + text I/O)
+Layer 2 -- Format Backends             IFormatBackend.h, JsonBackend.h/.cpp
+           -> (string -> PropertyTree)
+Layer 1 -- Serialization Traits        SerializationTraits.h, BuiltinTraits.h
+           -> (T -> PropertyTree)
+Layer 0 -- Intermediate Representation PropertyTree.h/.cpp
 ```
 
 Data flows bidirectionally through the stack:
@@ -524,11 +524,12 @@ not enforced by the `Serializable` concept — it is an implicit requirement of
 `SaveToVirtualPath` and `LoadFromVirtualPath` bridge the serialization system with
 the Resource System's logical path model:
 
-- Save: `FileSystem::ResolveWritePath(virtualPath)` → physical path → `SaveToFile`
-- Load: `FileSystem::ResolveReadPath(virtualPath)` → physical path → `LoadFromFile`
+- Save: `FileSystem::ResolveWritePath(virtualPath)` -> physical path -> `SaveToFile`
+- Load: `FileSystem::ReadText(virtualPath)` -> backend parse -> deserialize
 
-Both come in two overloads: explicit backend and auto-detect (which resolves write
-path then delegates to `SaveToFile`/`LoadFromFile` with extension-based detection).
+Both come in two overloads: explicit backend and auto-detect. Save still resolves a
+writable physical path before delegating to `SaveToFile`, while load uses the resource
+system's text-returning API and deserializes directly from the returned string.
 
 #### 5.4 Config Path Fallback Chain
 
@@ -538,46 +539,46 @@ The config path functions implement a three-tier fallback for configuration file
 LoadFromConfigPath("input/ShadowMapping.json")
 
     1. Try /Saved/Config/input/ShadowMapping.json
-       → if exists: return (user has saved config)
+       -> if readable: return its text (user has saved config)
 
     2. Try /Project/Config/input/ShadowMapping.json
-       → if exists: copy to /Saved/Config/..., return saved copy
+       -> if readable: write the same text to /Saved/Config/... and return the text
        (auto-seeding: project defaults become user-editable saved configs)
 
     3. Try /Engine/Config/input/ShadowMapping.json
-       → if exists: copy to /Saved/Config/..., return saved copy
+       -> if readable: write the same text to /Saved/Config/... and return the text
        (engine defaults as last resort)
 
     4. All three miss: return false
 ```
 
 **Auto-seeding**: When a config is found in Project or Engine but not in Saved, the
-system automatically copies it to the Saved directory. This means:
+system automatically writes the resolved text to the Saved directory. This means:
 
-- First run: engine defaults are copied to Saved, where users can edit them
+- First run: engine defaults are copied into Saved, where users can edit them
 - Subsequent runs: the Saved copy is used directly
 - The Project/Engine originals are never modified
 
-`SaveToConfigPath` always writes to `/Saved/Config/...` — the Project and Engine tiers
+`SaveToConfigPath` always writes to `/Saved/Config/...` -- the Project and Engine tiers
 are read-only sources.
 
-The implementation lives in `detail::ResolveConfigReadPath()`, which encapsulates the
-three-tier lookup and seeding logic. The `seedToSaved` lambda handles the copy with
-error handling:
+The implementation lives in `detail::ResolveConfigReadText()`, which encapsulates the
+three-tier lookup and seeding logic. The `seedToSaved` lambda handles the Saved write
+with error handling:
 
 ```cpp
 auto seedToSaved = [&](std::string_view sourceVirtualPath, std::string_view label)
-    -> std::optional<std::filesystem::path>
+    -> std::optional<std::string>
 {
-    // Resolve source and target paths
-    // copy_file with error handling
-    // Return saved path on success, source path on copy failure
+    // Read source text via FileSystem::ReadText
+    // Write the same text to /Saved/Config/... via FileSystem::WriteText
+    // Return the source text either way
 };
 ```
 
-If the copy fails (e.g., permissions), the function falls back to reading from the
-source directly and logs a warning. This ensures the system degrades gracefully rather
-than failing outright.
+If the Saved write fails (e.g., permissions), the function still returns the source
+text and logs a warning. This ensures the system degrades gracefully rather than
+failing outright.
 
 ---
 
@@ -589,25 +590,25 @@ Tracing `Serialization::SaveToConfigPath(inputMap, "input/ShadowMapping.json")`:
 
 ```
 1. SaveToConfigPath
-   → builds virtualPath = "/Saved/Config/input/ShadowMapping.json"
-   → calls SaveToVirtualPath(inputMap, virtualPath)
+   -> builds virtualPath = "/Saved/Config/input/ShadowMapping.json"
+   -> calls SaveToVirtualPath(inputMap, virtualPath)
 
 2. SaveToVirtualPath
-   → FileSystem::ResolveWritePath("/Saved/Config/input/ShadowMapping.json")
-   → returns e.g. "C:/Users/name/AppData/Local/RTRLab/Saved/Config/input/ShadowMapping.json"
-   → calls SaveToFile(inputMap, resolvedPath)
+   -> FileSystem::ResolveWritePath("/Saved/Config/input/ShadowMapping.json")
+   -> returns e.g. "C:/Users/name/AppData/Local/RTRLab/Saved/Config/input/ShadowMapping.json"
+   -> calls SaveToFile(inputMap, resolvedPath)
 
 3. SaveToFile
-   → Serialize(tree, inputMap)
-     → InputActionSerialization.h Serialize trait runs
-     → builds PropertyTree::Object{} with "actions" and "axes" subtrees
-     → each InputSource serializes its Type (magic_enum) and Code (InputNames.h)
-   → GetBackendForExtension(".json") → JsonBackend instance
-   → JsonBackend::WriteToString(tree)
-     → TreeToJson: recursive std::visit converts PropertyTree → nlohmann::json
-     → nlohmann::json::dump(2): produces pretty-printed JSON string
-   → create_directories for parent path
-   → write string to file via ofstream
+   -> Serialize(tree, inputMap)
+      -> InputActionSerialization.h Serialize trait runs
+      -> builds PropertyTree::Object{} with "actions" and "axes" subtrees
+      -> each InputSource serializes its Type (magic_enum) and Code (InputNames.h)
+   -> GetBackendForExtension(".json") -> JsonBackend instance
+   -> JsonBackend::WriteToString(tree)
+      -> TreeToJson: recursive std::visit converts PropertyTree -> nlohmann::json
+      -> nlohmann::json::dump(2): produces pretty-printed JSON string
+   -> create_directories for parent path
+   -> write string to file via ofstream
 ```
 
 #### 6.2 Load Path
@@ -616,26 +617,25 @@ Tracing `Serialization::LoadFromConfigPath(inputMap, "input/ShadowMapping.json")
 
 ```
 1. LoadFromConfigPath
-   → detail::ResolveConfigReadPath("input/ShadowMapping.json")
-   → tries /Saved/Config/input/ShadowMapping.json — found
-   → calls LoadFromFile(inputMap, resolvedPath)
+   -> detail::ResolveConfigReadText("input/ShadowMapping.json")
+   -> tries /Saved/Config/input/ShadowMapping.json -> found
+   -> returns file contents as text
 
-2. LoadFromFile
-   → read entire file into string via ifstream + ostringstream
-   → GetBackendForExtension(".json") → JsonBackend instance
-   → JsonBackend::ReadFromString(data, tree)
-     → nlohmann::json::parse(data): tokenize + parse JSON
-     → JsonToTree: recursive switch converts nlohmann::json → PropertyTree
-     → uint64 overflow check for large unsigned integers
-   → InputActionMap temp{};  // default-constructed temporary
-   → Deserialize(tree, temp)
-     → InputActionSerialization.h Deserialize trait runs
-     → reads "actions" object: for each action name, tries each array
-       element as ChordBinding then InputSource
-     → reads "axes" object: switches on "kind" string ("KeyPair",
-       "MouseAxis", "GamepadAxis")
-     → unknown entries produce LOG_WARN and continue (not fail)
-   → inputMap = std::move(temp);  // atomic commit
+2. LoadFromConfigPath
+   -> GetBackendForExtension(".json") -> JsonBackend instance
+   -> JsonBackend::ReadFromString(data, tree)
+      -> nlohmann::json::parse(data): tokenize + parse JSON
+      -> JsonToTree: recursive switch converts nlohmann::json -> PropertyTree
+      -> uint64 overflow check for large unsigned integers
+   -> InputActionMap temp{};  // default-constructed temporary
+   -> Deserialize(tree, temp)
+      -> InputActionSerialization.h Deserialize trait runs
+      -> reads "actions" object: for each action name, tries each array
+         element as ChordBinding then InputSource
+      -> reads "axes" object: switches on "kind" string ("KeyPair",
+         "MouseAxis", "GamepadAxis")
+      -> unknown entries produce LOG_WARN and continue (not fail)
+   -> inputMap = std::move(temp);  // atomic commit
 ```
 
 ---

--- a/Src/Core/Resource/Catalog/ResourceCatalog.cpp
+++ b/Src/Core/Resource/Catalog/ResourceCatalog.cpp
@@ -94,11 +94,11 @@ namespace
     }
 
     bool ParseCatalogFromJson(const Json &rootJson,
-                             const std::string &catalogLabel,
-                             const Resource::VirtualPath &mountPath,
-                             Resource::CatalogKind &catalogKind,
-                             int &catalogVersion,
-                             std::unordered_map<std::string, Resource::ResourceCatalogEntry> &entries)
+                              const std::string &catalogLabel,
+                              const Resource::VirtualPath &mountPath,
+                              Resource::CatalogKind &catalogKind,
+                              int &catalogVersion,
+                              std::unordered_map<std::string, Resource::ResourceCatalogEntry> &entries)
     {
         const auto versionIt = rootJson.find("version");
         if (versionIt == rootJson.end() || !versionIt->is_number_integer())
@@ -219,9 +219,9 @@ namespace
     }
 
     bool LoadCatalogFromMount(const Resource::ReadableMount &mount,
-                             Resource::CatalogKind &catalogKind,
-                             int &catalogVersion,
-                             std::unordered_map<std::string, Resource::ResourceCatalogEntry> &entries)
+                              Resource::CatalogKind &catalogKind,
+                              int &catalogVersion,
+                              std::unordered_map<std::string, Resource::ResourceCatalogEntry> &entries)
     {
         std::vector<uint8_t> bytes;
         std::string errorMessage;
@@ -382,7 +382,6 @@ namespace
                         mount.priority,
                         mount.backend,
                         mount.mountRoot,
-                        mount.materializedRoot,
                         mount.sourceKey,
                     };
                     continue;
@@ -409,7 +408,6 @@ namespace
                                       mount.priority,
                                       mount.backend,
                                       mount.mountRoot,
-                                      mount.materializedRoot,
                                       mount.sourceKey,
                                   });
         }
@@ -513,7 +511,6 @@ namespace Resource
             .priority = entryIt->second.priority,
             .backend = entryIt->second.backend,
             .mountRoot = entryIt->second.mountRoot,
-            .materializedRoot = entryIt->second.materializedRoot,
         };
 
         std::string errorMessage;
@@ -528,30 +525,5 @@ namespace Resource
         }
 
         return resolvedArtifact;
-    }
-
-    std::optional<std::filesystem::path> CatalogRegistry::ResolvePath(const std::filesystem::path &rootPath,
-                                                                      const std::filesystem::path &engineDir,
-                                                                      const std::filesystem::path &cacheDir,
-                                                                      const VirtualPath &virtualPath,
-                                                                      std::string_view logicalPath,
-                                                                      std::string_view projectContentDirName)
-    {
-        const auto artifact = ResolveArtifact(rootPath, engineDir, cacheDir, virtualPath, logicalPath, projectContentDirName);
-        if (!artifact.has_value())
-            return std::nullopt;
-
-        std::string errorMessage;
-        const auto path = MaterializeReadableArtifact(*artifact, &errorMessage);
-        if (!path.has_value() && !errorMessage.empty())
-        {
-            LOG_ERROR_CAT(LogCategory::FileSystem,
-                          "Failed to materialize resolved artifact '{}' from mount '{}': {}",
-                          artifact->relativePath.generic_string(),
-                          artifact->mountRoot.string(),
-                          errorMessage);
-        }
-
-        return path;
     }
 } // namespace Resource

--- a/Src/Core/Resource/Catalog/ResourceCatalog.cpp
+++ b/Src/Core/Resource/Catalog/ResourceCatalog.cpp
@@ -426,12 +426,12 @@ namespace Resource
         m_ConflictedLogicalPaths.clear();
     }
 
-    std::optional<std::filesystem::path> CatalogRegistry::ResolvePath(const std::filesystem::path &rootPath,
-                                                                      const std::filesystem::path &engineDir,
-                                                                      const std::filesystem::path &cacheDir,
-                                                                      const VirtualPath &virtualPath,
-                                                                      std::string_view logicalPath,
-                                                                      std::string_view projectContentDirName)
+    std::optional<ResolvedReadableArtifact> CatalogRegistry::ResolveArtifact(const std::filesystem::path &rootPath,
+                                                                             const std::filesystem::path &engineDir,
+                                                                             const std::filesystem::path &cacheDir,
+                                                                             const VirtualPath &virtualPath,
+                                                                             std::string_view logicalPath,
+                                                                             std::string_view projectContentDirName)
     {
         const auto mountRoot = GetMountRoot(rootPath, engineDir, virtualPath, projectContentDirName);
         if (mountRoot.empty())
@@ -528,5 +528,30 @@ namespace Resource
         }
 
         return resolvedArtifact;
+    }
+
+    std::optional<std::filesystem::path> CatalogRegistry::ResolvePath(const std::filesystem::path &rootPath,
+                                                                      const std::filesystem::path &engineDir,
+                                                                      const std::filesystem::path &cacheDir,
+                                                                      const VirtualPath &virtualPath,
+                                                                      std::string_view logicalPath,
+                                                                      std::string_view projectContentDirName)
+    {
+        const auto artifact = ResolveArtifact(rootPath, engineDir, cacheDir, virtualPath, logicalPath, projectContentDirName);
+        if (!artifact.has_value())
+            return std::nullopt;
+
+        std::string errorMessage;
+        const auto path = MaterializeReadableArtifact(*artifact, &errorMessage);
+        if (!path.has_value() && !errorMessage.empty())
+        {
+            LOG_ERROR_CAT(LogCategory::FileSystem,
+                          "Failed to materialize resolved artifact '{}' from mount '{}': {}",
+                          artifact->relativePath.generic_string(),
+                          artifact->mountRoot.string(),
+                          errorMessage);
+        }
+
+        return path;
     }
 } // namespace Resource

--- a/Src/Core/Resource/Catalog/ResourceCatalog.h
+++ b/Src/Core/Resource/Catalog/ResourceCatalog.h
@@ -50,6 +50,14 @@ namespace Resource
         std::vector<ArtifactRecord> artifacts;
     };
 
+    struct ResolvedReadableArtifact
+    {
+        MountBackendKind backend = MountBackendKind::Directory;
+        std::filesystem::path mountRoot;
+        std::filesystem::path relativePath;
+        std::filesystem::path materializedRoot;
+    };
+
     class CatalogRegistry
     {
     public:
@@ -74,6 +82,13 @@ namespace Resource
         };
 
         void Reset();
+
+        std::optional<ResolvedReadableArtifact> ResolveArtifact(const std::filesystem::path &rootPath,
+                                                                const std::filesystem::path &engineDir,
+                                                                const std::filesystem::path &cacheDir,
+                                                                const VirtualPath &virtualPath,
+                                                                std::string_view logicalPath,
+                                                                std::string_view projectContentDirName);
 
         std::optional<std::filesystem::path> ResolvePath(const std::filesystem::path &rootPath,
                                                          const std::filesystem::path &engineDir,

--- a/Src/Core/Resource/Catalog/ResourceCatalog.h
+++ b/Src/Core/Resource/Catalog/ResourceCatalog.h
@@ -55,7 +55,6 @@ namespace Resource
         MountBackendKind backend = MountBackendKind::Directory;
         std::filesystem::path mountRoot;
         std::filesystem::path relativePath;
-        std::filesystem::path materializedRoot;
     };
 
     class CatalogRegistry
@@ -77,7 +76,6 @@ namespace Resource
             MountPriority priority = MountPriority::Source;
             MountBackendKind backend = MountBackendKind::Directory;
             std::filesystem::path mountRoot;
-            std::filesystem::path materializedRoot;
             std::string sourceMountKey;
         };
 
@@ -89,13 +87,6 @@ namespace Resource
                                                                 const VirtualPath &virtualPath,
                                                                 std::string_view logicalPath,
                                                                 std::string_view projectContentDirName);
-
-        std::optional<std::filesystem::path> ResolvePath(const std::filesystem::path &rootPath,
-                                                         const std::filesystem::path &engineDir,
-                                                         const std::filesystem::path &cacheDir,
-                                                         const VirtualPath &virtualPath,
-                                                         std::string_view logicalPath,
-                                                         std::string_view projectContentDirName);
 
     private:
         bool m_GlobalTableBuilt = false;

--- a/Src/Core/Resource/FileSystem.cpp
+++ b/Src/Core/Resource/FileSystem.cpp
@@ -68,7 +68,7 @@ std::optional<Resource::ResolvedReadableArtifact> FileSystem::ResolveCatalogArti
     return std::nullopt;
 }
 
-std::optional<std::filesystem::path> FileSystem::ResolveReadPath(std::string_view virtualPathString)
+std::optional<std::filesystem::path> FileSystem::ResolveWritableReadPath(std::string_view virtualPathString)
 {
     const auto virtualPath = Resource::ParseVirtualPath(virtualPathString);
     if (!virtualPath.has_value())
@@ -76,14 +76,6 @@ std::optional<std::filesystem::path> FileSystem::ResolveReadPath(std::string_vie
 
     switch (virtualPath->domain)
     {
-    case Resource::PathDomain::Project:
-    case Resource::PathDomain::Engine:
-        if (const auto artifact = ResolveCatalogArtifact(virtualPathString))
-        {
-            return Resource::MaterializeReadableArtifact(*artifact);
-        }
-
-        return std::nullopt;
     case Resource::PathDomain::Saved:
     case Resource::PathDomain::Cache:
     {
@@ -94,6 +86,9 @@ std::optional<std::filesystem::path> FileSystem::ResolveReadPath(std::string_vie
         const auto relativePath = Resource::GetPhysicalRelativePath(*virtualPath);
         return relativePath.empty() ? writableMount->rootPath : writableMount->rootPath / relativePath;
     }
+    case Resource::PathDomain::Project:
+    case Resource::PathDomain::Engine:
+        return std::nullopt;
     }
 
     return std::nullopt;
@@ -130,7 +125,7 @@ bool FileSystem::Exists(std::string_view virtualPath)
         }
     }
 
-    const auto resolved = ResolveReadPath(virtualPath);
+    const auto resolved = ResolveWritableReadPath(virtualPath);
     return resolved.has_value() && std::filesystem::exists(*resolved);
 }
 
@@ -139,7 +134,7 @@ std::optional<std::string> FileSystem::ReadText(std::string_view virtualPath)
     if (const auto artifact = ResolveCatalogArtifact(virtualPath))
         return Resource::ReadReadableArtifactText(*artifact);
 
-    const auto resolved = ResolveReadPath(virtualPath);
+    const auto resolved = ResolveWritableReadPath(virtualPath);
     if (!resolved.has_value())
         return std::nullopt;
 
@@ -151,7 +146,7 @@ std::optional<std::vector<uint8_t>> FileSystem::ReadBinary(std::string_view virt
     if (const auto artifact = ResolveCatalogArtifact(virtualPath))
         return Resource::ReadReadableArtifactBinary(*artifact);
 
-    const auto resolved = ResolveReadPath(virtualPath);
+    const auto resolved = ResolveWritableReadPath(virtualPath);
     if (!resolved.has_value())
         return std::nullopt;
 
@@ -163,7 +158,7 @@ std::unique_ptr<std::istream> FileSystem::OpenReadStream(std::string_view virtua
     if (const auto artifact = ResolveCatalogArtifact(virtualPath))
         return Resource::OpenReadableArtifactStream(*artifact);
 
-    const auto resolved = ResolveReadPath(virtualPath);
+    const auto resolved = ResolveWritableReadPath(virtualPath);
     if (!resolved.has_value())
         return nullptr;
 

--- a/Src/Core/Resource/FileSystem.cpp
+++ b/Src/Core/Resource/FileSystem.cpp
@@ -117,6 +117,17 @@ std::optional<std::filesystem::path> FileSystem::ResolveWritePath(std::string_vi
 
 bool FileSystem::Exists(std::string_view virtualPath)
 {
+    if (const auto artifact = ResolveCatalogArtifact(virtualPath))
+    {
+        switch (artifact->backend)
+        {
+        case Resource::MountBackendKind::Directory:
+            return std::filesystem::exists(artifact->mountRoot / artifact->relativePath);
+        case Resource::MountBackendKind::PakArchive:
+            return true;
+        }
+    }
+
     const auto resolved = ResolveReadPath(virtualPath);
     return resolved.has_value() && std::filesystem::exists(*resolved);
 }

--- a/Src/Core/Resource/FileSystem.cpp
+++ b/Src/Core/Resource/FileSystem.cpp
@@ -46,6 +46,26 @@ std::optional<FileSystem::VirtualPath> FileSystem::ParseVirtualPath(std::string_
     return Resource::ParseVirtualPath(path);
 }
 
+std::optional<Resource::ResolvedReadableArtifact> FileSystem::ResolveCatalogArtifact(std::string_view virtualPathString)
+{
+    const auto virtualPath = Resource::ParseVirtualPath(virtualPathString);
+    if (!virtualPath.has_value())
+        return std::nullopt;
+
+    switch (virtualPath->domain)
+    {
+    case Resource::PathDomain::Project:
+    case Resource::PathDomain::Engine:
+        return s_CatalogRegistry.ResolveArtifact(
+            s_RootPath, s_EngineDir, GetCacheDir(), *virtualPath, virtualPathString, kProjectContentDirName);
+    case Resource::PathDomain::Saved:
+    case Resource::PathDomain::Cache:
+        return std::nullopt;
+    }
+
+    return std::nullopt;
+}
+
 std::optional<std::filesystem::path> FileSystem::ResolveReadPath(std::string_view virtualPathString)
 {
     const auto virtualPath = Resource::ParseVirtualPath(virtualPathString);
@@ -56,10 +76,9 @@ std::optional<std::filesystem::path> FileSystem::ResolveReadPath(std::string_vie
     {
     case Resource::PathDomain::Project:
     case Resource::PathDomain::Engine:
-        if (const auto resolved = s_CatalogRegistry.ResolvePath(
-                s_RootPath, s_EngineDir, GetCacheDir(), *virtualPath, virtualPathString, kProjectContentDirName))
+        if (const auto artifact = ResolveCatalogArtifact(virtualPathString))
         {
-            return resolved;
+            return Resource::MaterializeReadableArtifact(*artifact);
         }
 
         return std::nullopt;
@@ -104,6 +123,9 @@ bool FileSystem::Exists(std::string_view virtualPath)
 
 std::optional<std::string> FileSystem::ReadText(std::string_view virtualPath)
 {
+    if (const auto artifact = ResolveCatalogArtifact(virtualPath))
+        return Resource::ReadReadableArtifactText(*artifact);
+
     const auto resolved = ResolveReadPath(virtualPath);
     if (!resolved.has_value())
         return std::nullopt;
@@ -113,6 +135,9 @@ std::optional<std::string> FileSystem::ReadText(std::string_view virtualPath)
 
 std::optional<std::vector<uint8_t>> FileSystem::ReadBinary(std::string_view virtualPath)
 {
+    if (const auto artifact = ResolveCatalogArtifact(virtualPath))
+        return Resource::ReadReadableArtifactBinary(*artifact);
+
     const auto resolved = ResolveReadPath(virtualPath);
     if (!resolved.has_value())
         return std::nullopt;

--- a/Src/Core/Resource/FileSystem.cpp
+++ b/Src/Core/Resource/FileSystem.cpp
@@ -9,6 +9,8 @@
 #include "Core/Resource/Mount/RootDiscovery.h"
 #include "Core/Resource/Path/PathParser.h"
 
+#include <fstream>
+
 std::filesystem::path FileSystem::s_RootPath;
 std::filesystem::path FileSystem::s_EngineDir;
 std::filesystem::path FileSystem::s_SavedDir;
@@ -154,6 +156,22 @@ std::optional<std::vector<uint8_t>> FileSystem::ReadBinary(std::string_view virt
         return std::nullopt;
 
     return Resource::ReadBinaryFile(*resolved);
+}
+
+std::unique_ptr<std::istream> FileSystem::OpenReadStream(std::string_view virtualPath)
+{
+    if (const auto artifact = ResolveCatalogArtifact(virtualPath))
+        return Resource::OpenReadableArtifactStream(*artifact);
+
+    const auto resolved = ResolveReadPath(virtualPath);
+    if (!resolved.has_value())
+        return nullptr;
+
+    auto fileStream = std::make_unique<std::ifstream>(*resolved, std::ios::binary);
+    if (!fileStream->is_open())
+        return nullptr;
+
+    return std::unique_ptr<std::istream>(std::move(fileStream));
 }
 
 bool FileSystem::WriteText(std::string_view virtualPath, std::string_view data)

--- a/Src/Core/Resource/FileSystem.h
+++ b/Src/Core/Resource/FileSystem.h
@@ -29,7 +29,6 @@ public:
     static bool IsVirtualPath(std::string_view path);
     static std::optional<VirtualPath> ParseVirtualPath(std::string_view path);
 
-    static std::optional<std::filesystem::path> ResolveReadPath(std::string_view virtualPath);
     static std::optional<std::filesystem::path> ResolveWritePath(std::string_view virtualPath);
     static bool Exists(std::string_view virtualPath);
     static std::optional<std::string> ReadText(std::string_view virtualPath);
@@ -53,5 +52,6 @@ private:
     static bool s_WritableDirsResolved;
 
     static std::optional<Resource::ResolvedReadableArtifact> ResolveCatalogArtifact(std::string_view virtualPath);
+    static std::optional<std::filesystem::path> ResolveWritableReadPath(std::string_view virtualPath);
     static void ResolveWritableDirs();
 };

--- a/Src/Core/Resource/FileSystem.h
+++ b/Src/Core/Resource/FileSystem.h
@@ -49,5 +49,6 @@ private:
     static bool s_Initialized;
     static bool s_WritableDirsResolved;
 
+    static std::optional<Resource::ResolvedReadableArtifact> ResolveCatalogArtifact(std::string_view virtualPath);
     static void ResolveWritableDirs();
 };

--- a/Src/Core/Resource/FileSystem.h
+++ b/Src/Core/Resource/FileSystem.h
@@ -9,6 +9,8 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <istream>
+#include <memory>
 #include <optional>
 #include <span>
 #include <string>
@@ -32,6 +34,7 @@ public:
     static bool Exists(std::string_view virtualPath);
     static std::optional<std::string> ReadText(std::string_view virtualPath);
     static std::optional<std::vector<uint8_t>> ReadBinary(std::string_view virtualPath);
+    static std::unique_ptr<std::istream> OpenReadStream(std::string_view virtualPath);
     static bool WriteText(std::string_view virtualPath, std::string_view data);
     static bool WriteBinary(std::string_view virtualPath, std::span<const uint8_t> data);
 

--- a/Src/Core/Resource/Mount/MountBackend.cpp
+++ b/Src/Core/Resource/Mount/MountBackend.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iterator>
+#include <sstream>
 
 namespace
 {
@@ -391,6 +392,39 @@ namespace Resource
         }
 
         return std::nullopt;
+    }
+
+    std::unique_ptr<std::istream> OpenReadableArtifactStream(const ResolvedReadableArtifact &artifact,
+                                                             std::string *errorMessage)
+    {
+        switch (artifact.backend)
+        {
+        case MountBackendKind::Directory:
+        {
+            auto stream = std::make_unique<std::ifstream>(artifact.mountRoot / artifact.relativePath, std::ios::binary);
+            if (!stream->is_open())
+            {
+                if (errorMessage != nullptr)
+                    *errorMessage = "failed to open readable artifact stream: " + (artifact.mountRoot / artifact.relativePath).string();
+                return nullptr;
+            }
+
+            return stream;
+        }
+        case MountBackendKind::PakArchive:
+        {
+            const auto bytes = ReadPakEntry(artifact.mountRoot, artifact.relativePath, errorMessage);
+            if (!bytes.has_value())
+                return nullptr;
+
+            auto stream = std::make_unique<std::istringstream>(
+                std::string(reinterpret_cast<const char *>(bytes->data()), bytes->size()),
+                std::ios::in | std::ios::binary);
+            return stream;
+        }
+        }
+
+        return nullptr;
     }
 
     std::optional<WritableMount> ResolveWritableMount(PathDomain domain,

--- a/Src/Core/Resource/Mount/MountBackend.cpp
+++ b/Src/Core/Resource/Mount/MountBackend.cpp
@@ -11,23 +11,6 @@
 #include <iterator>
 #include <sstream>
 
-namespace
-{
-    std::string SanitizeMountKeyForPath(std::string_view key)
-    {
-        std::string sanitized;
-        sanitized.reserve(key.size());
-        for (const char c : key)
-        {
-            if (std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-')
-                sanitized.push_back(c);
-            else
-                sanitized.push_back('_');
-        }
-        return sanitized;
-    }
-} // namespace
-
 namespace Resource
 {
     std::vector<ReadableMount> DiscoverReadableMountBackends(const std::filesystem::path &rootPath,
@@ -68,7 +51,8 @@ namespace Resource
         packagedRootSearchOrder.push_back(rootPath / "build" / "Packaged");
         overlayRootSearchOrder.push_back(rootPath / "Saved" / "Overrides");
 
-        auto findCookedMountRoot = [&](const std::filesystem::path &mountRelativePath) -> std::filesystem::path {
+        auto findCookedMountRoot = [&](const std::filesystem::path &mountRelativePath) -> std::filesystem::path
+        {
             for (const auto &cookedRoot : cookedRootSearchOrder)
             {
                 const auto candidate = cookedRoot / mountRelativePath;
@@ -79,7 +63,8 @@ namespace Resource
             return {};
         };
 
-        auto findPackagedMountArchive = [&](const std::filesystem::path &archiveRelativePath) -> std::filesystem::path {
+        auto findPackagedMountArchive = [&](const std::filesystem::path &archiveRelativePath) -> std::filesystem::path
+        {
             for (const auto &packagedRoot : packagedRootSearchOrder)
             {
                 const auto candidate = packagedRoot / archiveRelativePath;
@@ -91,7 +76,8 @@ namespace Resource
             return {};
         };
 
-        auto findOverlayMountRoot = [&](const std::filesystem::path &mountRelativePath) -> std::filesystem::path {
+        auto findOverlayMountRoot = [&](const std::filesystem::path &mountRelativePath) -> std::filesystem::path
+        {
             for (const auto &overlayRoot : overlayRootSearchOrder)
             {
                 const auto candidate = overlayRoot / mountRelativePath;
@@ -107,8 +93,8 @@ namespace Resource
                                              const VirtualPath &mountPath,
                                              const MountPriority priority,
                                              const MountBackendKind backend,
-                                             const std::filesystem::path &mountRoot,
-                                             const std::filesystem::path &materializedRoot) {
+                                             const std::filesystem::path &mountRoot)
+        {
             if (mountRoot.empty())
                 return;
 
@@ -119,7 +105,6 @@ namespace Resource
                 priority,
                 backend,
                 mountRoot,
-                materializedRoot,
             });
         };
 
@@ -127,7 +112,8 @@ namespace Resource
                                           const VirtualPath &mountPath,
                                           const std::filesystem::path &sourceRoot,
                                           const std::filesystem::path &cookedMountRelativePath,
-                                          const std::filesystem::path &packagedArchiveRelativePath) {
+                                          const std::filesystem::path &packagedArchiveRelativePath)
+        {
             const auto overlayRoot = findOverlayMountRoot(cookedMountRelativePath);
             const auto cookedRoot = findCookedMountRoot(cookedMountRelativePath);
             const auto packagedArchive = findPackagedMountArchive(packagedArchiveRelativePath);
@@ -135,7 +121,6 @@ namespace Resource
             const bool hasCookedCatalog = !cookedRoot.empty();
             const bool hasPackagedCatalog = !packagedArchive.empty();
             const bool hasSourceRoot = std::filesystem::exists(sourceRoot);
-            const auto materializedRoot = cacheDir / "PackagedExtracted" / SanitizeMountKeyForPath(sourceKey);
 
             if (hasOverlayCatalog)
             {
@@ -144,8 +129,7 @@ namespace Resource
                                     mountPath,
                                     MountPriority::Overlay,
                                     MountBackendKind::Directory,
-                                    overlayRoot,
-                                    {});
+                                    overlayRoot);
             }
 
             if (preferPackagedArtifacts)
@@ -157,8 +141,7 @@ namespace Resource
                                         mountPath,
                                         MountPriority::Packaged,
                                         MountBackendKind::PakArchive,
-                                        packagedArchive,
-                                        materializedRoot);
+                                        packagedArchive);
                 }
                 if (hasCookedCatalog)
                 {
@@ -167,8 +150,7 @@ namespace Resource
                                         mountPath,
                                         MountPriority::Cooked,
                                         MountBackendKind::Directory,
-                                        cookedRoot,
-                                        {});
+                                        cookedRoot);
                 }
                 if (hasSourceRoot)
                 {
@@ -177,8 +159,7 @@ namespace Resource
                                         mountPath,
                                         MountPriority::Source,
                                         MountBackendKind::Directory,
-                                        sourceRoot,
-                                        {});
+                                        sourceRoot);
                 }
                 return;
             }
@@ -192,8 +173,7 @@ namespace Resource
                                         mountPath,
                                         MountPriority::Cooked,
                                         MountBackendKind::Directory,
-                                        cookedRoot,
-                                        {});
+                                        cookedRoot);
                 }
                 if (hasSourceRoot)
                 {
@@ -202,8 +182,7 @@ namespace Resource
                                         mountPath,
                                         MountPriority::Source,
                                         MountBackendKind::Directory,
-                                        sourceRoot,
-                                        {});
+                                        sourceRoot);
                 }
                 return;
             }
@@ -215,8 +194,7 @@ namespace Resource
                                     mountPath,
                                     MountPriority::Source,
                                     MountBackendKind::Directory,
-                                    sourceRoot,
-                                    {});
+                                    sourceRoot);
                 return;
             }
 
@@ -227,8 +205,7 @@ namespace Resource
                                     mountPath,
                                     MountPriority::Packaged,
                                     MountBackendKind::PakArchive,
-                                    packagedArchive,
-                                    materializedRoot);
+                                    packagedArchive);
             }
             if (hasCookedCatalog)
             {
@@ -237,8 +214,7 @@ namespace Resource
                                     mountPath,
                                     MountPriority::Cooked,
                                     MountBackendKind::Directory,
-                                    cookedRoot,
-                                    {});
+                                    cookedRoot);
             }
         };
 
@@ -322,29 +298,13 @@ namespace Resource
                 .backend = mount.backend,
                 .mountRoot = mount.mountRoot,
                 .relativePath = artifact.relativePath,
-                .materializedRoot = {},
             };
         case MountBackendKind::PakArchive:
             return ResolvedReadableArtifact{
                 .backend = mount.backend,
                 .mountRoot = mount.mountRoot,
                 .relativePath = artifact.relativePath,
-                .materializedRoot = mount.materializedRoot,
             };
-        }
-
-        return std::nullopt;
-    }
-
-    std::optional<std::filesystem::path> MaterializeReadableArtifact(const ResolvedReadableArtifact &artifact,
-                                                                     std::string *errorMessage)
-    {
-        switch (artifact.backend)
-        {
-        case MountBackendKind::Directory:
-            return artifact.mountRoot / artifact.relativePath;
-        case MountBackendKind::PakArchive:
-            return MaterializePakEntry(artifact.mountRoot, artifact.relativePath, artifact.materializedRoot, errorMessage);
         }
 
         return std::nullopt;

--- a/Src/Core/Resource/Mount/MountBackend.cpp
+++ b/Src/Core/Resource/Mount/MountBackend.cpp
@@ -1,5 +1,6 @@
 #include "Core/Resource/Mount/MountBackend.h"
 
+#include "Core/Resource/IO/PhysicalIO.h"
 #include "Core/Resource/Package/PakArchive.h"
 #include "Core/Resource/Path/PathParser.h"
 
@@ -307,16 +308,86 @@ namespace Resource
         return false;
     }
 
-    std::optional<std::filesystem::path> ResolveReadableMountArtifact(const ReadableMount &mount,
-                                                                      const ArtifactRecord &artifact,
-                                                                      std::string *errorMessage)
+    std::optional<ResolvedReadableArtifact> ResolveReadableMountArtifact(const ReadableMount &mount,
+                                                                         const ArtifactRecord &artifact,
+                                                                         std::string *errorMessage)
     {
+        (void)errorMessage;
+
         switch (mount.backend)
         {
         case MountBackendKind::Directory:
-            return mount.mountRoot / artifact.relativePath;
+            return ResolvedReadableArtifact{
+                .backend = mount.backend,
+                .mountRoot = mount.mountRoot,
+                .relativePath = artifact.relativePath,
+                .materializedRoot = {},
+            };
         case MountBackendKind::PakArchive:
-            return MaterializePakEntry(mount.mountRoot, artifact.relativePath, mount.materializedRoot, errorMessage);
+            return ResolvedReadableArtifact{
+                .backend = mount.backend,
+                .mountRoot = mount.mountRoot,
+                .relativePath = artifact.relativePath,
+                .materializedRoot = mount.materializedRoot,
+            };
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<std::filesystem::path> MaterializeReadableArtifact(const ResolvedReadableArtifact &artifact,
+                                                                     std::string *errorMessage)
+    {
+        switch (artifact.backend)
+        {
+        case MountBackendKind::Directory:
+            return artifact.mountRoot / artifact.relativePath;
+        case MountBackendKind::PakArchive:
+            return MaterializePakEntry(artifact.mountRoot, artifact.relativePath, artifact.materializedRoot, errorMessage);
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<std::string> ReadReadableArtifactText(const ResolvedReadableArtifact &artifact,
+                                                        std::string *errorMessage)
+    {
+        switch (artifact.backend)
+        {
+        case MountBackendKind::Directory:
+        {
+            const auto text = ReadTextFile(artifact.mountRoot / artifact.relativePath);
+            if (!text.has_value() && errorMessage != nullptr)
+                *errorMessage = "failed to read text file: " + (artifact.mountRoot / artifact.relativePath).string();
+            return text;
+        }
+        case MountBackendKind::PakArchive:
+        {
+            const auto bytes = ReadPakEntry(artifact.mountRoot, artifact.relativePath, errorMessage);
+            if (!bytes.has_value())
+                return std::nullopt;
+
+            return std::string(bytes->begin(), bytes->end());
+        }
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<std::vector<uint8_t>> ReadReadableArtifactBinary(const ResolvedReadableArtifact &artifact,
+                                                                   std::string *errorMessage)
+    {
+        switch (artifact.backend)
+        {
+        case MountBackendKind::Directory:
+        {
+            const auto bytes = ReadBinaryFile(artifact.mountRoot / artifact.relativePath);
+            if (!bytes.has_value() && errorMessage != nullptr)
+                *errorMessage = "failed to read binary file: " + (artifact.mountRoot / artifact.relativePath).string();
+            return bytes;
+        }
+        case MountBackendKind::PakArchive:
+            return ReadPakEntry(artifact.mountRoot, artifact.relativePath, errorMessage);
         }
 
         return std::nullopt;

--- a/Src/Core/Resource/Mount/MountBackend.h
+++ b/Src/Core/Resource/Mount/MountBackend.h
@@ -20,7 +20,6 @@ namespace Resource
         MountPriority priority = MountPriority::Source;
         MountBackendKind backend = MountBackendKind::Directory;
         std::filesystem::path mountRoot;
-        std::filesystem::path materializedRoot;
     };
 
     struct WritableMount
@@ -44,9 +43,6 @@ namespace Resource
     std::optional<ResolvedReadableArtifact> ResolveReadableMountArtifact(const ReadableMount &mount,
                                                                          const ArtifactRecord &artifact,
                                                                          std::string *errorMessage = nullptr);
-
-    std::optional<std::filesystem::path> MaterializeReadableArtifact(const ResolvedReadableArtifact &artifact,
-                                                                     std::string *errorMessage = nullptr);
 
     std::optional<std::string> ReadReadableArtifactText(const ResolvedReadableArtifact &artifact,
                                                         std::string *errorMessage = nullptr);

--- a/Src/Core/Resource/Mount/MountBackend.h
+++ b/Src/Core/Resource/Mount/MountBackend.h
@@ -3,6 +3,8 @@
 #include "Core/Resource/Catalog/ResourceCatalog.h"
 
 #include <filesystem>
+#include <istream>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -51,6 +53,9 @@ namespace Resource
 
     std::optional<std::vector<uint8_t>> ReadReadableArtifactBinary(const ResolvedReadableArtifact &artifact,
                                                                    std::string *errorMessage = nullptr);
+
+    std::unique_ptr<std::istream> OpenReadableArtifactStream(const ResolvedReadableArtifact &artifact,
+                                                             std::string *errorMessage = nullptr);
 
     std::optional<WritableMount> ResolveWritableMount(PathDomain domain,
                                                       const std::filesystem::path &savedDir,

--- a/Src/Core/Resource/Mount/MountBackend.h
+++ b/Src/Core/Resource/Mount/MountBackend.h
@@ -39,9 +39,18 @@ namespace Resource
                                std::vector<uint8_t> &bytes,
                                std::string *errorMessage = nullptr);
 
-    std::optional<std::filesystem::path> ResolveReadableMountArtifact(const ReadableMount &mount,
-                                                                      const ArtifactRecord &artifact,
-                                                                      std::string *errorMessage = nullptr);
+    std::optional<ResolvedReadableArtifact> ResolveReadableMountArtifact(const ReadableMount &mount,
+                                                                         const ArtifactRecord &artifact,
+                                                                         std::string *errorMessage = nullptr);
+
+    std::optional<std::filesystem::path> MaterializeReadableArtifact(const ResolvedReadableArtifact &artifact,
+                                                                     std::string *errorMessage = nullptr);
+
+    std::optional<std::string> ReadReadableArtifactText(const ResolvedReadableArtifact &artifact,
+                                                        std::string *errorMessage = nullptr);
+
+    std::optional<std::vector<uint8_t>> ReadReadableArtifactBinary(const ResolvedReadableArtifact &artifact,
+                                                                   std::string *errorMessage = nullptr);
 
     std::optional<WritableMount> ResolveWritableMount(PathDomain domain,
                                                       const std::filesystem::path &savedDir,

--- a/Src/Core/Resource/Package/PakArchive.cpp
+++ b/Src/Core/Resource/Package/PakArchive.cpp
@@ -147,28 +147,14 @@ namespace
             return std::nullopt;
 
         const auto wantedPath = PakPathToGenericString(relativePath);
-        const auto it = std::find_if(entries.begin(), entries.end(), [&](const PakIndexEntry &entry) {
-            return entry.relativePath == wantedPath;
-        });
+        const auto it = std::find_if(entries.begin(), entries.end(), [&](const PakIndexEntry &entry)
+                                     { return entry.relativePath == wantedPath; });
         if (it == entries.end())
             return std::nullopt;
 
         return *it;
     }
 
-    std::string SanitizeKeyForPath(std::string_view key)
-    {
-        std::string sanitized;
-        sanitized.reserve(key.size());
-        for (const char c : key)
-        {
-            if (std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-')
-                sanitized.push_back(c);
-            else
-                sanitized.push_back('_');
-        }
-        return sanitized;
-    }
 } // namespace
 
 namespace Resource
@@ -222,9 +208,8 @@ namespace Resource
             files.push_back(relativePath);
         }
 
-        std::sort(files.begin(), files.end(), [](const auto &lhs, const auto &rhs) {
-            return lhs.generic_string() < rhs.generic_string();
-        });
+        std::sort(files.begin(), files.end(), [](const auto &lhs, const auto &rhs)
+                  { return lhs.generic_string() < rhs.generic_string(); });
 
         std::filesystem::create_directories(pakPath.parent_path(), ec);
         if (ec)
@@ -351,50 +336,13 @@ namespace Resource
         return FindPakEntry(pakPath, relativePath, errorMessage).has_value();
     }
 
-    std::optional<std::filesystem::path> MaterializePakEntry(const std::filesystem::path &pakPath,
-                                                             const std::filesystem::path &relativePath,
-                                                             const std::filesystem::path &outputRoot,
-                                                             std::string *errorMessage)
-    {
-        const auto bytes = ReadPakEntry(pakPath, relativePath, errorMessage);
-        if (!bytes.has_value())
-            return std::nullopt;
-
-        const auto outputPath = outputRoot / relativePath;
-        std::error_code ec;
-        std::filesystem::create_directories(outputPath.parent_path(), ec);
-        if (ec)
-        {
-            if (errorMessage != nullptr)
-                *errorMessage = "failed to create pak extraction directory: " + ec.message();
-            return std::nullopt;
-        }
-
-        std::ofstream out(outputPath, std::ios::binary | std::ios::trunc);
-        if (!out.is_open())
-        {
-            if (errorMessage != nullptr)
-                *errorMessage = "failed to open extracted pak entry for writing: " + outputPath.string();
-            return std::nullopt;
-        }
-
-        out.write(reinterpret_cast<const char *>(bytes->data()), static_cast<std::streamsize>(bytes->size()));
-        if (!out.good())
-        {
-            if (errorMessage != nullptr)
-                *errorMessage = "failed to write extracted pak entry: " + outputPath.string();
-            return std::nullopt;
-        }
-
-        return outputPath;
-    }
-
     bool PackageCookedRepositoryCatalogs(const std::filesystem::path &cookedRootPath,
                                          const std::filesystem::path &packagedRootPath,
                                          std::string *errorMessage)
     {
         const auto packageMountIfPresent = [&](const std::filesystem::path &mountRoot,
-                                               const std::filesystem::path &pakPath) -> bool {
+                                               const std::filesystem::path &pakPath) -> bool
+        {
             if (!std::filesystem::exists(mountRoot))
                 return true;
 

--- a/Src/Core/Resource/Package/PakArchive.h
+++ b/Src/Core/Resource/Package/PakArchive.h
@@ -26,11 +26,6 @@ namespace Resource
                         const std::filesystem::path &relativePath,
                         std::string *errorMessage = nullptr);
 
-    std::optional<std::filesystem::path> MaterializePakEntry(const std::filesystem::path &pakPath,
-                                                             const std::filesystem::path &relativePath,
-                                                             const std::filesystem::path &outputRoot,
-                                                             std::string *errorMessage = nullptr);
-
     bool PackageCookedRepositoryCatalogs(const std::filesystem::path &cookedRootPath,
                                          const std::filesystem::path &packagedRootPath,
                                          std::string *errorMessage = nullptr);

--- a/Src/Core/Serialization/Serialization.h
+++ b/Src/Core/Serialization/Serialization.h
@@ -28,50 +28,63 @@ namespace Serialization
             return std::string(mountRoot) + "/" + std::string(relativePath);
         }
 
-        inline std::optional<std::filesystem::path> ResolveConfigReadPath(std::string_view relativePath)
+        template <Serializable T>
+        bool LoadValueFromString(T &value,
+                                 const std::string &data,
+                                 const IFormatBackend &backend,
+                                 std::string_view sourceLabel)
+        {
+            PropertyTree tree;
+            if (!backend.ReadFromString(data, tree))
+            {
+                LOG_ERROR_CAT(LogCategory::Serialization, "Serialization: failed to parse '{}'", sourceLabel);
+                return false;
+            }
+
+            T temp{};
+            if (!Deserialize(tree, temp))
+            {
+                LOG_ERROR_CAT(LogCategory::Serialization, "Serialization: failed to deserialize '{}'", sourceLabel);
+                return false;
+            }
+
+            value = std::move(temp);
+            return true;
+        }
+
+        inline std::optional<std::string> ResolveConfigReadText(std::string_view relativePath)
         {
             const std::string savedVirtualPath = MakeConfigVirtualPath("/Saved/Config", relativePath);
             const std::string projectVirtualPath = MakeConfigVirtualPath("/Project/Config", relativePath);
             const std::string engineVirtualPath = MakeConfigVirtualPath("/Engine/Config", relativePath);
 
-            if (const auto savedPath = FileSystem::ResolveReadPath(savedVirtualPath);
-                savedPath.has_value() && std::filesystem::exists(*savedPath))
-            {
-                return savedPath;
-            }
+            if (const auto savedText = FileSystem::ReadText(savedVirtualPath); savedText.has_value())
+                return savedText;
 
             const auto seedToSaved = [&](std::string_view sourceVirtualPath, std::string_view sourceLabel)
-                -> std::optional<std::filesystem::path>
+                -> std::optional<std::string>
             {
-                const auto sourcePath = FileSystem::ResolveReadPath(sourceVirtualPath);
-                if (!sourcePath.has_value() || !std::filesystem::exists(*sourcePath))
+                const auto sourceText = FileSystem::ReadText(sourceVirtualPath);
+                if (!sourceText.has_value())
                     return std::nullopt;
 
-                const auto savedPath = FileSystem::ResolveWritePath(savedVirtualPath);
-                if (!savedPath.has_value())
-                    return sourcePath;
-
-                std::error_code ec;
-                std::filesystem::copy_file(*sourcePath, *savedPath, ec);
-                if (ec)
+                if (!FileSystem::WriteText(savedVirtualPath, *sourceText))
                 {
                     LOG_WARN_CAT(LogCategory::Serialization,
-                                 "Serialization: failed to seed {} config '{}' into saved path '{}': {}",
+                                 "Serialization: failed to seed {} config '{}' into saved path '{}'",
                                  sourceLabel,
                                  relativePath,
-                                 savedPath->string(),
-                                 ec.message());
-                    return sourcePath;
+                                 savedVirtualPath);
                 }
 
-                return savedPath;
+                return sourceText;
             };
 
-            if (const auto seededProjectPath = seedToSaved(projectVirtualPath, "project"); seededProjectPath.has_value())
-                return seededProjectPath;
+            if (const auto seededProjectText = seedToSaved(projectVirtualPath, "project"); seededProjectText.has_value())
+                return seededProjectText;
 
-            if (const auto seededEnginePath = seedToSaved(engineVirtualPath, "engine"); seededEnginePath.has_value())
-                return seededEnginePath;
+            if (const auto seededEngineText = seedToSaved(engineVirtualPath, "engine"); seededEngineText.has_value())
+                return seededEngineText;
 
             return std::nullopt;
         }
@@ -175,23 +188,7 @@ namespace Serialization
         ss << file.rdbuf();
         std::string data = ss.str();
 
-        PropertyTree tree;
-        if (!backend.ReadFromString(data, tree))
-        {
-            LOG_ERROR_CAT(LogCategory::Serialization, "Serialization: failed to parse '{}'", path.string());
-            return false;
-        }
-
-        // Deserialize into a temporary - only commit on success
-        T temp{};
-        if (!Deserialize(tree, temp))
-        {
-            LOG_ERROR_CAT(LogCategory::Serialization, "Serialization: failed to deserialize '{}'", path.string());
-            return false;
-        }
-
-        value = std::move(temp);
-        return true;
+        return detail::LoadValueFromString(value, data, backend, path.string());
     }
 
     /// Load with auto-detected backend (based on file extension).
@@ -207,8 +204,8 @@ namespace Serialization
     bool LoadFromVirtualPath(T &value, std::string_view virtualPath,
                              const IFormatBackend &backend)
     {
-        const auto path = FileSystem::ResolveReadPath(virtualPath);
-        if (!path.has_value())
+        const auto data = FileSystem::ReadText(virtualPath);
+        if (!data.has_value())
         {
             LOG_ERROR_CAT(LogCategory::Serialization,
                           "Serialization: failed to resolve readable virtual path '{}'",
@@ -216,15 +213,15 @@ namespace Serialization
             return false;
         }
 
-        return LoadFromFile(value, *path, backend);
+        return detail::LoadValueFromString(value, *data, backend, virtualPath);
     }
 
     /// Load with auto-detected backend through a logical resource path.
     template <Serializable T>
     bool LoadFromVirtualPath(T &value, std::string_view virtualPath)
     {
-        const auto path = FileSystem::ResolveReadPath(virtualPath);
-        if (!path.has_value())
+        const auto data = FileSystem::ReadText(virtualPath);
+        if (!data.has_value())
         {
             LOG_ERROR_CAT(LogCategory::Serialization,
                           "Serialization: failed to resolve readable virtual path '{}'",
@@ -232,7 +229,8 @@ namespace Serialization
             return false;
         }
 
-        return LoadFromFile(value, *path);
+        const auto ext = std::filesystem::path(virtualPath).extension().string();
+        return detail::LoadValueFromString(value, *data, GetBackendForExtension(ext), virtualPath);
     }
 
     /// Save through the logical config namespace. Writes always target /Saved/Config.
@@ -261,8 +259,8 @@ namespace Serialization
     bool LoadFromConfigPath(T &value, std::string_view relativePath,
                             const IFormatBackend &backend)
     {
-        const auto path = detail::ResolveConfigReadPath(relativePath);
-        if (!path.has_value())
+        const auto data = detail::ResolveConfigReadText(relativePath);
+        if (!data.has_value())
         {
             LOG_ERROR_CAT(LogCategory::Serialization,
                           "Serialization: failed to resolve config path '{}'",
@@ -270,15 +268,16 @@ namespace Serialization
             return false;
         }
 
-        return LoadFromFile(value, *path, backend);
+        const std::string sourceLabel = detail::MakeConfigVirtualPath("/Config", relativePath);
+        return detail::LoadValueFromString(value, *data, backend, sourceLabel);
     }
 
     /// Load through the config namespace with auto-detected backend.
     template <Serializable T>
     bool LoadFromConfigPath(T &value, std::string_view relativePath)
     {
-        const auto path = detail::ResolveConfigReadPath(relativePath);
-        if (!path.has_value())
+        const auto data = detail::ResolveConfigReadText(relativePath);
+        if (!data.has_value())
         {
             LOG_ERROR_CAT(LogCategory::Serialization,
                           "Serialization: failed to resolve config path '{}'",
@@ -286,7 +285,9 @@ namespace Serialization
             return false;
         }
 
-        return LoadFromFile(value, *path);
+        const std::string sourceLabel = detail::MakeConfigVirtualPath("/Config", relativePath);
+        const auto ext = std::filesystem::path(relativePath).extension().string();
+        return detail::LoadValueFromString(value, *data, GetBackendForExtension(ext), sourceLabel);
     }
 
 } // namespace Serialization

--- a/Tests/Integration/TestMountBackend.cpp
+++ b/Tests/Integration/TestMountBackend.cpp
@@ -82,10 +82,53 @@ TEST_F(MountBackendTests, ResolveReadableMountArtifactMaterializesPakArchiveEntr
 
     const auto resolved = Resource::ResolveReadableMountArtifact(mount, artifact, &errorMessage);
     ASSERT_TRUE(resolved.has_value()) << errorMessage;
-    EXPECT_EQ(*resolved, materializedRoot / "Materials" / "Checker.json");
+    EXPECT_EQ(resolved->backend, Resource::MountBackendKind::PakArchive);
+    EXPECT_EQ(resolved->mountRoot, pakPath);
+    EXPECT_EQ(resolved->relativePath, std::filesystem::path("Materials/Checker.json"));
+    EXPECT_EQ(resolved->materializedRoot, materializedRoot);
+    EXPECT_FALSE(std::filesystem::exists(materializedRoot / "Materials" / "Checker.json"));
 
-    std::ifstream in(*resolved, std::ios::binary);
-    ASSERT_TRUE(in.is_open());
-    const std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    const auto bytes = Resource::ReadReadableArtifactBinary(*resolved, &errorMessage);
+    ASSERT_TRUE(bytes.has_value()) << errorMessage;
+    const std::string contents(bytes->begin(), bytes->end());
     EXPECT_NE(contents.find("\"pak\""), std::string::npos);
+
+    const auto materializedPath = Resource::MaterializeReadableArtifact(*resolved, &errorMessage);
+    ASSERT_TRUE(materializedPath.has_value()) << errorMessage;
+    EXPECT_EQ(*materializedPath, materializedRoot / "Materials" / "Checker.json");
+}
+
+TEST_F(MountBackendTests, ResolveReadableMountArtifactReturnsDirectoryBackedDescriptor)
+{
+    const auto mountRoot = TestRoot() / "directory-mount";
+    test_support::WriteMountFileOrFail(mountRoot, "Docs/Readme.txt", "hello");
+
+    const Resource::ReadableMount mount{
+        .cacheKey = "Project",
+        .sourceKey = "Project",
+        .mountPath = Resource::VirtualPath{Resource::PathDomain::Project, std::nullopt, {}},
+        .priority = Resource::MountPriority::Source,
+        .backend = Resource::MountBackendKind::Directory,
+        .mountRoot = mountRoot,
+        .materializedRoot = {},
+    };
+    const Resource::ArtifactRecord artifact{
+        .relativePath = "Docs/Readme.txt",
+        .format = "document",
+    };
+
+    std::string errorMessage;
+    const auto resolved = Resource::ResolveReadableMountArtifact(mount, artifact, &errorMessage);
+    ASSERT_TRUE(resolved.has_value()) << errorMessage;
+    EXPECT_EQ(resolved->backend, Resource::MountBackendKind::Directory);
+    EXPECT_EQ(resolved->mountRoot, mountRoot);
+    EXPECT_EQ(resolved->relativePath, std::filesystem::path("Docs/Readme.txt"));
+
+    const auto text = Resource::ReadReadableArtifactText(*resolved, &errorMessage);
+    ASSERT_TRUE(text.has_value()) << errorMessage;
+    EXPECT_EQ(*text, "hello");
+
+    const auto physicalPath = Resource::MaterializeReadableArtifact(*resolved, &errorMessage);
+    ASSERT_TRUE(physicalPath.has_value()) << errorMessage;
+    EXPECT_EQ(*physicalPath, mountRoot / "Docs" / "Readme.txt");
 }

--- a/Tests/Integration/TestMountBackend.cpp
+++ b/Tests/Integration/TestMountBackend.cpp
@@ -52,13 +52,11 @@ TEST_F(MountBackendTests, ResolveWritableMountReturnsSavedAndCacheRoots)
     EXPECT_FALSE(Resource::ResolveWritableMount(Resource::PathDomain::Project, savedDir, cacheDir).has_value());
 }
 
-TEST_F(MountBackendTests, ResolveReadableMountArtifactMaterializesPakArchiveEntries)
+TEST_F(MountBackendTests, ResolveReadableMountArtifactReturnsPakBackedDescriptor)
 {
     const auto sourceRoot = TestRoot() / "pak-source";
     const auto packagedRoot = TestRoot() / "out";
     const auto pakPath = test_support::ProjectPackagedArchivePath(packagedRoot);
-    const auto extractedRoot = TestRoot() / "materialized";
-    const auto materializedRoot = test_support::ProjectMaterializedRoot(extractedRoot);
 
     test_support::WriteTextFileOrFail(test_support::MountCatalogPath(sourceRoot), "{\n  \"version\": 2,\n  \"kind\": \"cooked\",\n  \"entries\": []\n}\n");
     test_support::WriteMountFileOrFail(sourceRoot, "Materials/Checker.json", "{\n  \"name\": \"pak\"\n}\n");
@@ -73,7 +71,6 @@ TEST_F(MountBackendTests, ResolveReadableMountArtifactMaterializesPakArchiveEntr
         .priority = Resource::MountPriority::Packaged,
         .backend = Resource::MountBackendKind::PakArchive,
         .mountRoot = pakPath,
-        .materializedRoot = materializedRoot,
     };
     const Resource::ArtifactRecord artifact{
         .relativePath = "Materials/Checker.json",
@@ -85,8 +82,6 @@ TEST_F(MountBackendTests, ResolveReadableMountArtifactMaterializesPakArchiveEntr
     EXPECT_EQ(resolved->backend, Resource::MountBackendKind::PakArchive);
     EXPECT_EQ(resolved->mountRoot, pakPath);
     EXPECT_EQ(resolved->relativePath, std::filesystem::path("Materials/Checker.json"));
-    EXPECT_EQ(resolved->materializedRoot, materializedRoot);
-    EXPECT_FALSE(std::filesystem::exists(materializedRoot / "Materials" / "Checker.json"));
 
     const auto bytes = Resource::ReadReadableArtifactBinary(*resolved, &errorMessage);
     ASSERT_TRUE(bytes.has_value()) << errorMessage;
@@ -97,10 +92,6 @@ TEST_F(MountBackendTests, ResolveReadableMountArtifactMaterializesPakArchiveEntr
     ASSERT_NE(stream, nullptr) << errorMessage;
     const std::string streamedContents((std::istreambuf_iterator<char>(*stream)), std::istreambuf_iterator<char>());
     EXPECT_EQ(streamedContents, contents);
-
-    const auto materializedPath = Resource::MaterializeReadableArtifact(*resolved, &errorMessage);
-    ASSERT_TRUE(materializedPath.has_value()) << errorMessage;
-    EXPECT_EQ(*materializedPath, materializedRoot / "Materials" / "Checker.json");
 }
 
 TEST_F(MountBackendTests, ResolveReadableMountArtifactReturnsDirectoryBackedDescriptor)
@@ -115,7 +106,6 @@ TEST_F(MountBackendTests, ResolveReadableMountArtifactReturnsDirectoryBackedDesc
         .priority = Resource::MountPriority::Source,
         .backend = Resource::MountBackendKind::Directory,
         .mountRoot = mountRoot,
-        .materializedRoot = {},
     };
     const Resource::ArtifactRecord artifact{
         .relativePath = "Docs/Readme.txt",
@@ -137,8 +127,4 @@ TEST_F(MountBackendTests, ResolveReadableMountArtifactReturnsDirectoryBackedDesc
     ASSERT_NE(stream, nullptr) << errorMessage;
     const std::string streamedContents((std::istreambuf_iterator<char>(*stream)), std::istreambuf_iterator<char>());
     EXPECT_EQ(streamedContents, "hello");
-
-    const auto physicalPath = Resource::MaterializeReadableArtifact(*resolved, &errorMessage);
-    ASSERT_TRUE(physicalPath.has_value()) << errorMessage;
-    EXPECT_EQ(*physicalPath, mountRoot / "Docs" / "Readme.txt");
 }

--- a/Tests/Integration/TestMountBackend.cpp
+++ b/Tests/Integration/TestMountBackend.cpp
@@ -93,6 +93,11 @@ TEST_F(MountBackendTests, ResolveReadableMountArtifactMaterializesPakArchiveEntr
     const std::string contents(bytes->begin(), bytes->end());
     EXPECT_NE(contents.find("\"pak\""), std::string::npos);
 
+    const auto stream = Resource::OpenReadableArtifactStream(*resolved, &errorMessage);
+    ASSERT_NE(stream, nullptr) << errorMessage;
+    const std::string streamedContents((std::istreambuf_iterator<char>(*stream)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(streamedContents, contents);
+
     const auto materializedPath = Resource::MaterializeReadableArtifact(*resolved, &errorMessage);
     ASSERT_TRUE(materializedPath.has_value()) << errorMessage;
     EXPECT_EQ(*materializedPath, materializedRoot / "Materials" / "Checker.json");
@@ -127,6 +132,11 @@ TEST_F(MountBackendTests, ResolveReadableMountArtifactReturnsDirectoryBackedDesc
     const auto text = Resource::ReadReadableArtifactText(*resolved, &errorMessage);
     ASSERT_TRUE(text.has_value()) << errorMessage;
     EXPECT_EQ(*text, "hello");
+
+    const auto stream = Resource::OpenReadableArtifactStream(*resolved, &errorMessage);
+    ASSERT_NE(stream, nullptr) << errorMessage;
+    const std::string streamedContents((std::istreambuf_iterator<char>(*stream)), std::istreambuf_iterator<char>());
+    EXPECT_EQ(streamedContents, "hello");
 
     const auto physicalPath = Resource::MaterializeReadableArtifact(*resolved, &errorMessage);
     ASSERT_TRUE(physicalPath.has_value()) << errorMessage;

--- a/Tests/Integration/TestSourceCatalogDev.cpp
+++ b/Tests/Integration/TestSourceCatalogDev.cpp
@@ -38,7 +38,7 @@ TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsProjectSourceCatalogInMemoryD
 
     Resource::CatalogRegistry registry;
     const auto virtualPath = Resource::VirtualPath{Resource::PathDomain::Project, std::nullopt, "Textures/Grassy_Square"};
-    const auto resolved = registry.ResolvePath(
+    const auto resolved = registry.ResolveArtifact(
         repoRoot,
         test_support::EngineRoot(repoRoot),
         repoRoot / "Saved" / "Cache",
@@ -47,7 +47,9 @@ TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsProjectSourceCatalogInMemoryD
         "Project");
 
     ASSERT_TRUE(resolved.has_value());
-    EXPECT_EQ(*resolved, test_support::ProjectContentRoot(repoRoot) / "Textures" / "Grassy_Square.jpg");
+    EXPECT_EQ(resolved->backend, Resource::MountBackendKind::Directory);
+    EXPECT_EQ(resolved->mountRoot, test_support::ProjectContentRoot(repoRoot));
+    EXPECT_EQ(resolved->relativePath, std::filesystem::path("Textures/Grassy_Square.jpg"));
 }
 
 TEST_F(SourceCatalogDevTests, CatalogRegistryCanReturnReadableArtifactDescriptorWithoutMaterializedPath)
@@ -78,7 +80,7 @@ TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsProjectConfigDocumentEntriesI
 
     Resource::CatalogRegistry registry;
     const auto virtualPath = Resource::VirtualPath{Resource::PathDomain::Project, std::nullopt, "Config/Graphics.json"};
-    const auto resolved = registry.ResolvePath(
+    const auto resolved = registry.ResolveArtifact(
         repoRoot,
         test_support::EngineRoot(repoRoot),
         repoRoot / "Saved" / "Cache",
@@ -87,7 +89,9 @@ TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsProjectConfigDocumentEntriesI
         "Project");
 
     ASSERT_TRUE(resolved.has_value());
-    EXPECT_EQ(*resolved, test_support::ProjectContentRoot(repoRoot) / "Config" / "Graphics.json");
+    EXPECT_EQ(resolved->backend, Resource::MountBackendKind::Directory);
+    EXPECT_EQ(resolved->mountRoot, test_support::ProjectContentRoot(repoRoot));
+    EXPECT_EQ(resolved->relativePath, std::filesystem::path("Config/Graphics.json"));
 }
 
 TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsEngineSourceCatalogInMemoryDuringDevResolution)
@@ -97,7 +101,7 @@ TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsEngineSourceCatalogInMemoryDu
 
     Resource::CatalogRegistry registry;
     const auto virtualPath = Resource::VirtualPath{Resource::PathDomain::Engine, std::nullopt, "Defaults/Materials/ErrorMaterial"};
-    const auto resolved = registry.ResolvePath(
+    const auto resolved = registry.ResolveArtifact(
         repoRoot,
         test_support::EngineRoot(repoRoot),
         repoRoot / "Saved" / "Cache",
@@ -106,5 +110,7 @@ TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsEngineSourceCatalogInMemoryDu
         "Project");
 
     ASSERT_TRUE(resolved.has_value());
-    EXPECT_EQ(*resolved, test_support::EngineRoot(repoRoot) / "Defaults" / "Materials" / "ErrorMaterial.json");
+    EXPECT_EQ(resolved->backend, Resource::MountBackendKind::Directory);
+    EXPECT_EQ(resolved->mountRoot, test_support::EngineRoot(repoRoot));
+    EXPECT_EQ(resolved->relativePath, std::filesystem::path("Defaults/Materials/ErrorMaterial.json"));
 }

--- a/Tests/Integration/TestSourceCatalogDev.cpp
+++ b/Tests/Integration/TestSourceCatalogDev.cpp
@@ -50,6 +50,27 @@ TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsProjectSourceCatalogInMemoryD
     EXPECT_EQ(*resolved, test_support::ProjectContentRoot(repoRoot) / "Textures" / "Grassy_Square.jpg");
 }
 
+TEST_F(SourceCatalogDevTests, CatalogRegistryCanReturnReadableArtifactDescriptorWithoutMaterializedPath)
+{
+    const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
+    test_support::WriteProjectFileOrFail(repoRoot, "Textures/Grassy_Square.jpg", "jpg");
+
+    Resource::CatalogRegistry registry;
+    const auto virtualPath = Resource::VirtualPath{Resource::PathDomain::Project, std::nullopt, "Textures/Grassy_Square"};
+    const auto resolved = registry.ResolveArtifact(
+        repoRoot,
+        test_support::EngineRoot(repoRoot),
+        repoRoot / "Saved" / "Cache",
+        virtualPath,
+        "/Project/Textures/Grassy_Square",
+        "Project");
+
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_EQ(resolved->backend, Resource::MountBackendKind::Directory);
+    EXPECT_EQ(resolved->mountRoot, test_support::ProjectContentRoot(repoRoot));
+    EXPECT_EQ(resolved->relativePath, std::filesystem::path("Textures/Grassy_Square.jpg"));
+}
+
 TEST_F(SourceCatalogDevTests, CatalogRegistryBuildsProjectConfigDocumentEntriesInMemoryDuringDevResolution)
 {
     const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());

--- a/Tests/Unit/TestPakArchive.cpp
+++ b/Tests/Unit/TestPakArchive.cpp
@@ -33,12 +33,11 @@ namespace
     };
 } // namespace
 
-TEST_F(PakArchiveTests, BuildPakArchiveCanReadAndMaterializeEntries)
+TEST_F(PakArchiveTests, BuildPakArchiveCanReadEntries)
 {
     const auto sourceRoot = TestRoot() / "Mount";
     const auto packagedRoot = TestRoot() / "out";
     const auto pakPath = test_support::ProjectPackagedArchivePath(packagedRoot);
-    const auto extractedRoot = TestRoot() / "extracted";
     test_support::WriteTextFileOrFail(test_support::MountCatalogPath(sourceRoot), "{\n  \"version\": 2\n}\n");
     test_support::WriteMountFileOrFail(sourceRoot, "Textures/Checker.txt", "checker");
 
@@ -51,15 +50,6 @@ TEST_F(PakArchiveTests, BuildPakArchiveCanReadAndMaterializeEntries)
     ASSERT_TRUE(bytes.has_value()) << errorMessage;
     const std::string text(bytes->begin(), bytes->end());
     EXPECT_EQ(text, "checker");
-
-    const auto materialized = Resource::MaterializePakEntry(
-        pakPath, "Textures/Checker.txt", test_support::ProjectMaterializedRoot(extractedRoot), &errorMessage);
-    ASSERT_TRUE(materialized.has_value()) << errorMessage;
-
-    std::ifstream in(*materialized);
-    ASSERT_TRUE(in.is_open());
-    const std::string materializedText((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    EXPECT_EQ(materializedText, "checker");
 }
 
 TEST_F(PakArchiveTests, PackageCookedRepositoryCatalogsWritesProjectAndEngineArchives)


### PR DESCRIPTION
## Summary
- Shifted the resource read path from physical-path resolution to data-returning APIs.
- Added readable artifact descriptors so catalog resolution no longer depends on materialized filesystem paths.
- Updated `FileSystem` reads to operate on resolved artifacts directly through `ReadText`, `ReadBinary`, and `OpenReadStream`.
- Migrated serialization reads to consume logical-path text reads instead of `ResolveReadPath`.
- Removed pak materialization compatibility, including `MaterializePakEntry`, `PackagedExtracted`, and `materializedRoot`.

## Why
- Make packaged and loose content use the same logical read contract.
- Eliminate temp-file extraction as part of normal pak reads.
- Reduce leakage of physical filesystem details into higher-level systems.

## Affected areas
- `Src/Core/Resource/FileSystem.*`
- `Src/Core/Resource/Catalog/ResourceCatalog.*`
- `Src/Core/Resource/Mount/MountBackend.*`
- `Src/Core/Resource/Package/PakArchive.*`
- `Src/Core/Serialization/Serialization.h`
- `Tests/Integration/TestMountBackend.cpp`
- `Tests/Integration/TestSourceCatalogDev.cpp`
- `Tests/Unit/TestPakArchive.cpp`
- `Docs/Modules/ResourceSystem/Design.md`
- `Docs/Modules/ResourceSystem/Internals.md`
- `Docs/Modules/SerializationSystem/Internals.md`

## Documentation
- [ ] No documentation needed
- [x] Documentation updated

## Testing
- Rebuilt `rtrlab_unit_tests`, `rtrlab_integration_tests`, and `rtrlab_dev_profile_tests` after the code changes.
- Adjusted existing tests only where removed APIs would otherwise break compilation.

## Notes
- `ResolveReadPath()` has been removed from the public read flow; `ResolveWritePath()` remains for writable domains.
- `GetRootPath()` still exists and is currently only useful for initialization/logging-level scenarios.