### PR TITLE
Add DLC, Patch, and Mod mount support to the shipping resource system

### DIFF
--- a/Docs/Modules/ResourceSystem/Design.md
+++ b/Docs/Modules/ResourceSystem/Design.md
@@ -133,17 +133,21 @@ At a high level, the system has four cooperating pieces:
 
 ### 3.1 Public Mount Roots
 
-The resource system defines four public logical roots:
+The resource system defines six public logical roots:
 
 | Mount | Purpose | Writable | Typical Examples |
 |------|---------|----------|------------------|
 | `/Project/` | Project-authored runtime content | No | textures, materials, shaders, scenes, config defaults |
 | `/Engine/` | Engine-shipped built-in content | No | fallback materials, shared defaults, editor/support assets |
+| `/DLC/<Name>/` | First-party DLC content namespace | No | expansion-specific weapons, maps, config defaults |
+| `/Mod/<Name>/` | User-installed mod content namespace | No | mod-local assets and documents |
 | `/Saved/` | User and runtime-generated data | Yes | config overrides, logs, save data |
-| `/Cache/` | Disposable derived data | Yes | shader cache, cooked intermediates, extracted packaged artifacts |
+| `/Cache/` | Disposable derived data | Yes | shader cache, cooked intermediates |
 
-`/Project/` and `/Engine/` are read domains. `/Saved/` and `/Cache/` are write
-domains.
+`/Project/`, `/Engine/`, `/DLC/<Name>/`, and `/Mod/<Name>/` are read domains.
+`/Saved/` and `/Cache/` are write domains. `Patch` is intentionally not a public
+path root: patch paks override existing `/Project/...` and `/Engine/...` logical paths
+transparently.
 
 ### 3.2 Path Categories
 
@@ -155,6 +159,8 @@ physical source extensions:
 ```text
 /Project/Textures/Grassy_Square
 /Engine/Defaults/Materials/ErrorMaterial
+/DLC/Expansion1/Weapons/LaserRifle
+/Mod/CoolMod/Weapons/Hammer
 ```
 
 These resolve through a resource catalog rather than by probing the filesystem.
@@ -170,8 +176,9 @@ filenames and extensions:
 ```
 
 These retain explicit filenames and extensions. In the Project / Engine domains, they
-are represented as document entries in the source/cooked catalog. In the Saved / Cache
-domains, they resolve through writable mounts directly.
+are represented as document entries in the source/cooked catalog. DLC and Mod mounts
+use the same catalog-backed model, but with a required mount-name segment. In the
+Saved / Cache domains, they resolve through writable mounts directly.
 
 ### 3.3 Path Syntax Contract
 
@@ -181,6 +188,7 @@ Logical paths are part of RTRLab's serialized contract and follow strict rules:
 - path segments use forward slashes only
 - repeated `/` segments are normalized
 - `.` and `..` segments are rejected
+- `/DLC/` and `/Mod/` require a non-empty mount name segment immediately after the root
 - public logical paths are case-sensitive on all platforms
 
 The parser accepts no raw OS path syntax. Strings like
@@ -203,20 +211,26 @@ That means:
 
 This rule is enforced centrally by the resource system rather than by each caller.
 
-### 4.2 Unified Project / Engine Read Resolution
+### 4.2 Unified Catalog-Backed Read Resolution
 
-`/Project/...` and `/Engine/...` reads are resolved uniformly through the catalog
-system, regardless of whether the logical path is an extensionless asset path or an
-extension-preserving document path.
+`/Project/...`, `/Engine/...`, `/DLC/<Name>/...`, and `/Mod/<Name>/...` reads are
+resolved uniformly through the catalog system, regardless of whether the logical path
+is an extensionless asset path or an extension-preserving document path.
 
 That means:
 
 - `/Project/Textures/Grassy_Square` resolves through a catalog entry whose selected
-  artifact may be a source file, cooked file, packaged archive entry, or overlay
+  artifact may be a source file, cooked file, packaged archive entry, or higher-priority
+  DLC / Patch / Mod pak
 - `/Project/Config/Graphics.json` also resolves through a catalog entry, but keeps its
   explicit filename and extension
+- `/DLC/Expansion1/Weapons/LaserRifle` resolves through the named DLC pak namespace
+- `/Mod/CoolMod/Weapons/Hammer` resolves through the named mod pak namespace
 - the runtime no longer branches on "has extension" versus "no extension" when deciding
   whether to use the catalog
+
+Patch mounts remain invisible to callers: they override `/Project/...` or `/Engine/...`
+paths directly and do not introduce a `/Patch/...` namespace.
 
 The catalog entry type is decided at **source catalog build time**:
 
@@ -258,7 +272,7 @@ defaults are never modified in place.
 
 ### 4.4 Mount Precedence
 
-Catalog-backed Project / Engine logical paths resolve in two stages:
+Catalog-backed logical paths resolve in two stages:
 
 1. **Catalog lookup**
    Find a `ResourceCatalogEntry` for the requested logical path in the merged global
@@ -273,21 +287,25 @@ The caller never sees whether the chosen artifact came from:
 - a loose source directory
 - a loose cooked directory
 - a packaged `.rtrpak` archive
-- a higher-priority overlay directory
+- a higher-priority DLC / Patch / Mod pak
 
 The public path stays the same.
 
 Readable mounts are merged with explicit precedence. For the current implementation,
 the order is:
 
-1. overlay mounts
-2. packaged mounts
-3. loose cooked mounts
-4. loose source mounts
+1. mod mounts
+2. patch mounts
+3. DLC mounts
+4. packaged mounts
+5. loose cooked mounts
+6. loose source mounts
 
-If an overlay supplies `/Project/Textures/Grassy_Square`, it overrides lower-priority
-project mounts for that logical path. Unrelated project entries still fall back to the
-next available lower layer.
+If a mod pak supplies `/Project/Textures/Grassy_Square`, it overrides lower-priority
+patch, DLC, packaged, cooked, and source mounts for that logical path. Unrelated
+entries still fall back to the next available lower layer. DLC and Mod paks may also
+publish additive content under their own `/DLC/<Name>/...` and `/Mod/<Name>/...`
+namespaces.
 
 ---
 
@@ -548,6 +566,17 @@ At runtime, packaged Project and Engine reads are still resolved as separate log
 domains, but in packaged/shipping profiles they both mount the same shared
 `Game.rtrpak` and filter its merged catalog by domain.
 
+Shipping installs may also provide optional overlay pak directories next to the base
+archive:
+
+- `DLC/*.rtrpak`
+- `Patches/*.rtrpak`
+- `Mods/*.rtrpak`
+
+Patch paks override existing `/Project/...` and `/Engine/...` entries transparently.
+DLC and Mod paks can do that as well, and may additionally expose additive content
+through `/DLC/<Name>/...` and `/Mod/<Name>/...`.
+
 ### 10.4 Current Cooked Texture Format
 
 Cooked textures currently use an engine-private `.rtrtex` format.
@@ -573,14 +602,15 @@ is not yet a fully evolved long-term texture container.
 
 ## 11. Current Implementation Status
 
-As of 2026-04-10, the resource system is no longer a speculative design. It is an
+As of 2026-04-11, the resource system is no longer a speculative design. It is an
 active engine subsystem with the following implemented behavior:
 
 - `src/Core/Resource/` is the home of the module
 - `FileSystem` is the public facade
 - logical path parsing and domain dispatch are implemented
 - read/write domain enforcement is implemented
-- `/Project/`, `/Engine/`, `/Saved/`, and `/Cache/` are active
+- `/Project/`, `/Engine/`, `/DLC/<Name>/`, `/Mod/<Name>/`, `/Saved/`, and `/Cache/`
+  are active
 - config fallback resolution is implemented through serialization-facing helpers
 - logical-path-based file I/O is implemented
 - source catalogs can be generated for inspection or tooling, while dev runtime and cook
@@ -589,13 +619,16 @@ active engine subsystem with the following implemented behavior:
   document entries
 - loose cooked catalogs are generated and consumed
 - packaged `.rtrpak` archives are generated and consumed
-- overlay precedence over packaged/cooked/source mounts is implemented
+- shipping overlay precedence over packaged/cooked/source mounts is implemented through
+  `DLC`, `Patch`, and `Mod` pak priorities
 - mount handling now goes through a backend layer rather than being inlined inside the
   catalog resolver
 - development root discovery uses a repo-root `.rtrproject` marker instead of
   searching for `Project/`
 - shipping builds use the executable directory as the install root via
   `RTRL_SHIPPING`
+- shipping installs scan optional `DLC/`, `Patches/`, and `Mods/` directories for
+  additional pak mounts
 
 The core path and mount architecture is in place, but the system is not "fully done" in
 the sense of having every long-term artifact format, mount policy, and runtime consumer
@@ -650,19 +683,21 @@ Near-term plan:
 - prefer connecting future loaders to `/Project/...` and `/Engine/...` directly rather
   than introducing new physical-path shortcuts
 
-### 12.4 Overlay and packaging policy depth
+### 12.4 Shipping Overlay Policy Depth
 
-The current packaged/overlay model is intentionally small and explicit:
+The current packaged overlay model is intentionally small and explicit:
 
 - packaged content is mounted through `.rtrpak`
-- one loose override layer can sit above packaged/cooked/source mounts
-- precedence is defined, but multi-layer patching and chunk policy are still minimal
+- the base game ships as one `Game.rtrpak`
+- shipping can add `DLC/`, `Patches/`, and `Mods/` pak directories above the base game
+- precedence is defined, but chunk policy and runtime hot-mount behavior are still
+  minimal
 
 Near-term plan:
 
-- keep the current override model as the baseline behavior
+- keep the current shipping mount stack as the baseline behavior
 - defer more complex mod/DLC/chunk policies until there is a concrete consumer need
-- avoid inventing a broader overlay stack before the runtime actually needs one
+- avoid inventing a broader runtime mount manager before the engine actually needs one
 
 ### 12.5 Streaming versus materialized archive entries
 
@@ -721,8 +756,11 @@ Saved/Cache/Cooked/
 Saved/Cache/Packaged/
     ...                         - Packaged `.rtrpak` output
 
-Saved/Overrides/
-    ...                         - Development-time loose overlay root
+<install>/
+    Game.rtrpak                 - Base packaged content
+    DLC/                        - Optional DLC pak directory
+    Patches/                    - Optional patch pak directory
+    Mods/                       - Optional user mod pak directory
 ```
 
 ---

--- a/Docs/Modules/ResourceSystem/Internals.md
+++ b/Docs/Modules/ResourceSystem/Internals.md
@@ -8,7 +8,7 @@ It is intended as a companion to the main
 contract and design rationale. This document focuses on implementation mechanics and
 industry context.
 
-> **Snapshot date**: 2026-04-10
+> **Snapshot date**: 2026-04-11
 
 ---
 
@@ -241,12 +241,14 @@ When `ReadBinary("/Project/Textures/Grassy_Square")` is called:
 - Validate: must start with `/`, must not contain `\`, must not contain `.` or `..`
   segments.
 - Split into segments, collapse consecutive `/`.
-- Determine domain from the first segment: `Project` / `Engine` / `Saved` / `Cache`.
+- Determine domain from the first segment: `Project` / `Engine` / `DLC` / `Mod` /
+  `Saved` / `Cache`.
 
 Result: `VirtualPath { domain=Project, mountName=nullopt, relativePath="Textures/Grassy_Square" }`
 
 **Step 2: Dispatch by domain**
-- `Project` / `Engine`: always resolve through `CatalogRegistry::ResolveArtifact()`
+- `Project` / `Engine` / `DLC` / `Mod`: always resolve through
+  `CatalogRegistry::ResolveArtifact()`
 - `Saved` / `Cache`: resolve through writable mounts directly
 
 The runtime no longer branches on "has extension" versus "no extension". Document vs
@@ -254,7 +256,8 @@ asset classification now exists only inside the source catalog builder.
 
 #### 3.3 Unified Project / Engine Read Resolution
 
-`FileSystem.cpp` routes every Project / Engine read through `CatalogRegistry::ResolveArtifact()`.
+`FileSystem.cpp` routes every Project / Engine / DLC / Mod read through
+`CatalogRegistry::ResolveArtifact()`.
 
 This includes both kinds of logical path:
 
@@ -262,6 +265,8 @@ This includes both kinds of logical path:
 /Project/Textures/Grassy_Square  -> catalog entry -> selected artifact
 /Project/Config/Graphics.json    -> document catalog entry -> selected artifact
 /Engine/Defaults/Materials/ErrorMaterial -> asset catalog entry -> selected artifact
+/DLC/Expansion1/Weapons/LaserRifle -> namespaced DLC entry -> selected artifact
+/Mod/CoolMod/Weapons/Hammer -> namespaced mod entry -> selected artifact
 ```
 
 The resolution path is the same for both asset and document entries. The difference is
@@ -285,15 +290,20 @@ builder-time rule produced it.
    - `"cooked"` profile: prefer cooked, then source.
    - `"packaged"` / `"shipping"` profile: prefer packaged, then cooked, then source.
 
-   For each domain (Project / Engine), register mounts according to the profile
-   strategy, assigning priorities:
+   For each catalog-backed domain, register mounts according to the profile strategy,
+   assigning priorities:
 
    ```
-   Overlay  (300)  >  Packaged (200)  >  Cooked (100)  >  Source (0)
+   Mod      (500)  >  Patch    (400)  >  DLC      (300)
+   > Packaged (200) > Cooked   (100)  >  Source   (0)
    ```
 
-   Overlay mounts are discovered from `Saved/Overrides/` or the `RTRLAB_OVERLAY_ROOT`
-   environment variable.
+   In shipping/profiled packaged installs, the runtime scans:
+
+   - `<install>/Game.rtrpak` for the base packaged Project / Engine content
+   - `<install>/DLC/*.rtrpak` for DLC overlays and `/DLC/<Name>/...` namespace mounts
+   - `<install>/Patches/*.rtrpak` for transparent patch overlays
+   - `<install>/Mods/*.rtrpak` for mod overlays and `/Mod/<Name>/...` namespace mounts
 
 2. For each discovered mount, acquire its catalog:
    - Dev source directory backend (`Project/` or `Engine/`, source priority): build the
@@ -304,12 +314,14 @@ builder-time rule produced it.
 3. Parse the catalog JSON, validate version (v1 = source, v2 = cooked), and filter the
    merged entry set by mount domain. In packaged mode, both the Project and Engine
    mounts may read from the same shared `Game.rtrpak` catalog, but each mount only
-   keeps entries for its own logical domain. Both extensionless asset paths and
-   extension-preserving document paths are valid for Project / Engine mounts.
+   keeps entries for its own logical domain. DLC and Mod namespace mounts perform the
+   same filtering, but also require the catalog path's `mountName` to match the
+   discovered pak stem. Both extensionless asset paths and extension-preserving
+   document paths are valid for Project / Engine / DLC / Mod mounts.
 
 4. **Merge into global table** (`ResourceCatalog.cpp:334-388`):
    - A higher-priority mount's entry replaces a lower-priority one
-     (overlay > packaged > cooked > source).
+     (mod > patch > DLC > packaged > cooked > source).
    - Two equal-priority mounts providing the same `logicalPath` are treated as a
      **conflict**: the path is removed from the global table and recorded in
      `m_ConflictedLogicalPaths`. Future lookups for that path return `nullopt`.
@@ -388,7 +400,11 @@ User calls: FileSystem::ReadBinary("/Project/Textures/Grassy_Square")
        |    +- Cooked/Project/ has cat   -> register Cooked:Project   (priority=100)
        |    +- Game.rtrpak               -> register Packaged:Project (priority=200)
        |    +- Game.rtrpak               -> register Packaged:Engine  (priority=200)
-       |    +- Overrides/Project/ has cat-> register Overlay:Project  (priority=300)
+       |    +- DLC/Expansion1.rtrpak     -> register DLC:Expansion1:Project (priority=300)
+       |    +- DLC/Expansion1.rtrpak     -> register DLC:Expansion1         (priority=300)
+       |    +- Patches/Patch_001.rtrpak  -> register Patch:Patch_001:Project(priority=400)
+       |    +- Mods/CoolMod.rtrpak       -> register Mod:CoolMod:Project    (priority=500)
+       |    +- Mods/CoolMod.rtrpak       -> register Mod:CoolMod            (priority=500)
        |
        +- [first call] Load catalog for each mount -> parse JSON -> merge into global table
        |
@@ -414,9 +430,9 @@ User calls: FileSystem::ReadBinary("/Project/Textures/Grassy_Square")
 
 | Mechanism | Implementation Location | Key Point |
 |-----------|------------------------|-----------|
-| Project / Engine reads are always catalog-backed | `FileSystem::ReadText` / `ReadBinary` / `OpenReadStream` | Runtime dispatch is by domain, not by filename extension |
+| Project / Engine / DLC / Mod reads are always catalog-backed | `FileSystem::ReadText` / `ReadBinary` / `OpenReadStream` | Runtime dispatch is by domain, not by filename extension |
 | Document vs asset classification is builder-time | `SourceCatalog.cpp` | Source catalog synthesis decides whether a logical path keeps its extension |
-| Overlay overrides everything | `MountPriority::Overlay = 300` | Development-time `Saved/Overrides/` can replace any resource |
+| Shipping overlay precedence is explicit | `MountPriority::{DLC,Patch,Mod}` | Mods override patches, patches override DLC, DLC overrides packaged base content |
 | Equal-priority conflict = removal | `MergeMountEntriesIntoGlobalTable` | No implicit choice; the path becomes unavailable |
 | Catalog is lazily built | `m_GlobalTableBuilt` flag | All mounts are scanned on the first Project / Engine read |
 | Pak entries are read directly | `ReadPakEntry` / `OpenReadableArtifactStream` | No extraction cache or temp-file materialization remains in the normal read path |
@@ -528,7 +544,7 @@ more flexible conflict policy as overlay/mod scenarios grow more complex.
 | Dimension | RTRLab | Unreal Engine | Unity | id Tech / Source |
 |-----------|--------|---------------|-------|------------------|
 | Mount hierarchy | Project > Engine > Saved > Cache | /Game, /Engine, /Plugin, /Temp | No hierarchy concept | Search-path-based pak stack |
-| Override mechanism | 4-level priority (Overlay > Packaged > Cooked > Source) | Pak priority + patch pak | AssetBundle variants | Later-mounted pak overrides earlier |
+| Override mechanism | 6-level priority (Mod > Patch > DLC > Packaged > Cooked > Source) | Pak priority + patch pak | AssetBundle variants | Later-mounted pak overrides earlier |
 | Runtime dynamic mount | **Not supported** | Supported (`MountPak` / `UnmountPak`) | Supported (`LoadAssetBundle`) | Supported |
 | Write domain isolation | Hard-coded: only Saved/Cache writable | Similar (Saved/ writable) | `Application.persistentDataPath` | Dedicated write path |
 

--- a/Docs/Modules/ResourceSystem/Plan.md
+++ b/Docs/Modules/ResourceSystem/Plan.md
@@ -247,8 +247,8 @@ can be added at that time as isolated code — there is no reason to design for 
 ### 2.8 Env Vars and CLI Overrides
 
 - **Dev mode**: env vars (`RTRL_ROOT`, `RTRLAB_COOKED_ROOT`, `RTRLAB_PACKAGE_ROOT`,
-  `RTRLAB_OVERLAY_ROOT`, `RTRLAB_RESOURCE_PROFILE`) and CLI args remain supported.
-- **Shipping mode**: path-related overrides (`RTRL_ROOT`, cooked/package/overlay roots)
+  `RTRLAB_RESOURCE_PROFILE`) and CLI args remain supported.
+- **Shipping mode**: path-related overrides (`RTRL_ROOT`, cooked/package roots)
   are **compiled out** or return `nullptr` unconditionally. This prevents an attacker
   from redirecting resource loads via a malicious shortcut.
 - **Shipping whitelist**: only a small set of player-facing overrides survives
@@ -519,6 +519,13 @@ exe in shipping.
 
 **Scope**: add mount discovery for DLC, Patch, and Mod overlay directories.
 
+**Status (2026-04-11)**: completed in the current codebase. Shipping/profiled packaged
+mount discovery now scans `Game.rtrpak` plus optional `DLC/`, `Patches/`, and `Mods/`
+pak directories, `MountPriority` includes `DLC` / `Patch` / `Mod`, `/DLC/<Name>/` and
+`/Mod/<Name>/` virtual paths are parsed and resolved through the catalog system, and
+shipping-profile tests now cover base reads, additive DLC/mod namespaces, and
+`Mod > Patch > DLC > Packaged > Cooked > Source` precedence.
+
 - Extend `MountPriority` enum with `DLC = 300`, `Patch = 400`, `Mod = 500`.
 - Extend `DiscoverReadableMountBackends` to scan `<install>/DLC/`,
   `<install>/Patches/`, `<install>/Mods/` for `.rtrpak` files in shipping mode.
@@ -576,7 +583,7 @@ a small shared parser.
 **8c. Override hardening**:
 
 - Gate `RTRL_ROOT`, `RTRLAB_COOKED_ROOT`, `RTRLAB_PACKAGE_ROOT`,
-  `RTRLAB_OVERLAY_ROOT`, and `RTRLAB_RESOURCE_PROFILE` behind `#ifndef RTRL_SHIPPING`.
+  and `RTRLAB_RESOURCE_PROFILE` behind `#ifndef RTRL_SHIPPING`.
   In shipping builds, these environment variables are ignored entirely.
 - Define a shipping-mode CLI whitelist inside the new parser: only
   player-facing options (`--language`, `--windowed`, `--fullscreen`, etc.) are

--- a/Src/Core/Resource/Catalog/AssetPath.h
+++ b/Src/Core/Resource/Catalog/AssetPath.h
@@ -16,13 +16,20 @@ namespace Resource
         static bool IsValid(std::string_view path)
         {
             const auto parsed = ParseVirtualPath(path);
-            if (!parsed.has_value() || parsed->relativePath.empty() || parsed->mountName.has_value())
+            if (!parsed.has_value() || parsed->relativePath.empty())
                 return false;
 
             switch (parsed->domain)
             {
             case PathDomain::Project:
             case PathDomain::Engine:
+                if (parsed->mountName.has_value())
+                    return false;
+                break;
+            case PathDomain::DLC:
+            case PathDomain::Mod:
+                if (!parsed->mountName.has_value())
+                    return false;
                 break;
             case PathDomain::Saved:
             case PathDomain::Cache:

--- a/Src/Core/Resource/Catalog/ResourceCatalog.cpp
+++ b/Src/Core/Resource/Catalog/ResourceCatalog.cpp
@@ -33,6 +33,9 @@ namespace
             return rootPath / projectContentDirName;
         case Resource::PathDomain::Engine:
             return engineDir;
+        case Resource::PathDomain::DLC:
+        case Resource::PathDomain::Mod:
+            return rootPath;
         case Resource::PathDomain::Saved:
         case Resource::PathDomain::Cache:
             return {};
@@ -43,7 +46,8 @@ namespace
 
     bool DomainMatchesMount(const Resource::VirtualPath &catalogPath, const Resource::VirtualPath &requestedPath)
     {
-        return catalogPath.domain == requestedPath.domain;
+        return catalogPath.domain == requestedPath.domain &&
+               catalogPath.mountName == requestedPath.mountName;
     }
 
     bool IsCatalogLogicalPathForMount(const Resource::VirtualPath &catalogPath, const Resource::VirtualPath &mountPath)
@@ -51,14 +55,17 @@ namespace
         if (!DomainMatchesMount(catalogPath, mountPath))
             return false;
 
-        if (catalogPath.mountName.has_value() || catalogPath.relativePath.empty())
+        if (catalogPath.relativePath.empty())
             return false;
 
         switch (catalogPath.domain)
         {
         case Resource::PathDomain::Project:
         case Resource::PathDomain::Engine:
-            return true;
+            return !catalogPath.mountName.has_value();
+        case Resource::PathDomain::DLC:
+        case Resource::PathDomain::Mod:
+            return catalogPath.mountName.has_value();
         case Resource::PathDomain::Saved:
         case Resource::PathDomain::Cache:
             return false;

--- a/Src/Core/Resource/Catalog/ResourceCatalog.h
+++ b/Src/Core/Resource/Catalog/ResourceCatalog.h
@@ -30,7 +30,9 @@ namespace Resource
         Source = 0,
         Cooked = 100,
         Packaged = 200,
-        Overlay = 300,
+        DLC = 300,
+        Patch = 400,
+        Mod = 500,
     };
 
     struct ArtifactRecord

--- a/Src/Core/Resource/Catalog/SourceCatalog.cpp
+++ b/Src/Core/Resource/Catalog/SourceCatalog.cpp
@@ -66,6 +66,14 @@ namespace
             return relative.empty() ? "/Project" : "/Project/" + relative;
         case Resource::PathDomain::Engine:
             return relative.empty() ? "/Engine" : "/Engine/" + relative;
+        case Resource::PathDomain::DLC:
+            if (!mountPath.mountName.has_value())
+                return {};
+            return relative.empty() ? "/DLC/" + *mountPath.mountName : "/DLC/" + *mountPath.mountName + "/" + relative;
+        case Resource::PathDomain::Mod:
+            if (!mountPath.mountName.has_value())
+                return {};
+            return relative.empty() ? "/Mod/" + *mountPath.mountName : "/Mod/" + *mountPath.mountName + "/" + relative;
         case Resource::PathDomain::Saved:
             return relative.empty() ? "/Saved" : "/Saved/" + relative;
         case Resource::PathDomain::Cache:

--- a/Src/Core/Resource/FileSystem.cpp
+++ b/Src/Core/Resource/FileSystem.cpp
@@ -58,6 +58,8 @@ std::optional<Resource::ResolvedReadableArtifact> FileSystem::ResolveCatalogArti
     {
     case Resource::PathDomain::Project:
     case Resource::PathDomain::Engine:
+    case Resource::PathDomain::DLC:
+    case Resource::PathDomain::Mod:
         return s_CatalogRegistry.ResolveArtifact(
             s_RootPath, s_EngineDir, GetCacheDir(), *virtualPath, virtualPathString, kProjectContentDirName);
     case Resource::PathDomain::Saved:
@@ -88,6 +90,8 @@ std::optional<std::filesystem::path> FileSystem::ResolveWritableReadPath(std::st
     }
     case Resource::PathDomain::Project:
     case Resource::PathDomain::Engine:
+    case Resource::PathDomain::DLC:
+    case Resource::PathDomain::Mod:
         return std::nullopt;
     }
 

--- a/Src/Core/Resource/Mount/MountBackend.cpp
+++ b/Src/Core/Resource/Mount/MountBackend.cpp
@@ -149,6 +149,21 @@ namespace Resource
                 archivePath);
         };
 
+        const auto appendNamespacedArchiveMount = [&](std::string_view layerName,
+                                                      const std::string &archiveName,
+                                                      const PathDomain domain,
+                                                      const MountPriority priority,
+                                                      const std::filesystem::path &archivePath)
+        {
+            appendReadableMount(
+                std::string(layerName) + ":" + archiveName,
+                std::string(layerName) + ":" + archiveName,
+                VirtualPath{domain, archiveName, {}},
+                priority,
+                MountBackendKind::PakArchive,
+                archivePath);
+        };
+
         const auto addReadableMount = [&](const std::string &sourceKey,
                                           const VirtualPath &mountPath,
                                           const std::filesystem::path &sourceRoot,
@@ -265,15 +280,23 @@ namespace Resource
         {
             const auto appendOverlayArchives = [&](const std::filesystem::path &directory,
                                                    std::string_view layerName,
-                                                   const MountPriority priority)
+                                                   const MountPriority priority,
+                                                   const std::optional<PathDomain> namespacedDomain)
             {
                 for (const auto &archivePath : CollectPakArchives(directory))
+                {
                     appendArchiveDomainMounts(layerName, archivePath.stem().string(), priority, archivePath);
+                    if (namespacedDomain.has_value())
+                    {
+                        appendNamespacedArchiveMount(
+                            layerName, archivePath.stem().string(), *namespacedDomain, priority, archivePath);
+                    }
+                }
             };
 
-            appendOverlayArchives(rootPath / "DLC", "DLC", MountPriority::DLC);
-            appendOverlayArchives(rootPath / "Patches", "Patch", MountPriority::Patch);
-            appendOverlayArchives(rootPath / "Mods", "Mod", MountPriority::Mod);
+            appendOverlayArchives(rootPath / "DLC", "DLC", MountPriority::DLC, PathDomain::DLC);
+            appendOverlayArchives(rootPath / "Patches", "Patch", MountPriority::Patch, std::nullopt);
+            appendOverlayArchives(rootPath / "Mods", "Mod", MountPriority::Mod, PathDomain::Mod);
         }
 
         return mounts;
@@ -443,6 +466,8 @@ namespace Resource
             return WritableMount{domain, cacheDir};
         case PathDomain::Project:
         case PathDomain::Engine:
+        case PathDomain::DLC:
+        case PathDomain::Mod:
             return std::nullopt;
         }
 

--- a/Src/Core/Resource/Mount/MountBackend.cpp
+++ b/Src/Core/Resource/Mount/MountBackend.cpp
@@ -15,15 +15,39 @@ namespace Resource
 {
     namespace
     {
-        std::filesystem::path GetPackagedArchiveSearchPathForMount(const std::filesystem::path &packagedRoot,
-                                                                   std::string_view currentProfile,
-                                                                   const VirtualPath & /*mountPath*/,
-                                                                   const std::filesystem::path &legacyArchiveRelativePath)
+        std::filesystem::path GetPackagedArchiveSearchPath(const std::filesystem::path &packagedRoot,
+                                                           std::string_view currentProfile,
+                                                           const std::filesystem::path &legacyArchiveRelativePath)
         {
             if (currentProfile == "shipping" || currentProfile == "packaged")
                 return GetGamePackagedArchivePath(packagedRoot);
 
             return packagedRoot / legacyArchiveRelativePath;
+        }
+
+        std::vector<std::filesystem::path> CollectPakArchives(const std::filesystem::path &directory)
+        {
+            std::vector<std::filesystem::path> archives;
+            std::error_code ec;
+            if (!std::filesystem::exists(directory, ec) || ec || !std::filesystem::is_directory(directory, ec))
+                return archives;
+
+            for (const auto &entry : std::filesystem::directory_iterator(directory, ec))
+            {
+                if (ec)
+                    break;
+
+                if (!entry.is_regular_file())
+                    continue;
+
+                if (entry.path().extension() == kPakArchiveExtension)
+                    archives.push_back(entry.path());
+            }
+
+            std::sort(archives.begin(), archives.end(), [](const auto &lhs, const auto &rhs) {
+                return lhs.generic_string() < rhs.generic_string();
+            });
+            return archives;
         }
     } // namespace
 
@@ -38,7 +62,6 @@ namespace Resource
         const bool preferPackagedArtifacts = currentProfile == "packaged" || currentProfile == "shipping";
         std::vector<std::filesystem::path> cookedRootSearchOrder;
         std::vector<std::filesystem::path> packagedRootSearchOrder;
-        std::vector<std::filesystem::path> overlayRootSearchOrder;
 
         if (const char *overrideValue = std::getenv("RTRLAB_COOKED_ROOT"))
         {
@@ -52,18 +75,13 @@ namespace Resource
             if (!overrideRoot.empty())
                 packagedRootSearchOrder.push_back(overrideRoot);
         }
-        if (const char *overrideValue = std::getenv("RTRLAB_OVERLAY_ROOT"))
-        {
-            const std::filesystem::path overrideRoot = overrideValue;
-            if (!overrideRoot.empty())
-                overlayRootSearchOrder.push_back(overrideRoot);
-        }
 
+        if (currentProfile == "shipping")
+            packagedRootSearchOrder.push_back(rootPath);
         cookedRootSearchOrder.push_back(cacheDir / "Cooked");
         cookedRootSearchOrder.push_back(rootPath / "build" / "Cooked");
         packagedRootSearchOrder.push_back(cacheDir / "Packaged");
         packagedRootSearchOrder.push_back(rootPath / "build" / "Packaged");
-        overlayRootSearchOrder.push_back(rootPath / "Saved" / "Overrides");
 
         auto findCookedMountRoot = [&](const std::filesystem::path &mountRelativePath) -> std::filesystem::path
         {
@@ -77,27 +95,13 @@ namespace Resource
             return {};
         };
 
-        auto findPackagedMountArchive = [&](const VirtualPath &mountPath,
-                                            const std::filesystem::path &archiveRelativePath) -> std::filesystem::path
+        auto findPackagedMountArchive = [&](const std::filesystem::path &archiveRelativePath) -> std::filesystem::path
         {
             for (const auto &packagedRoot : packagedRootSearchOrder)
             {
-                const auto candidate = GetPackagedArchiveSearchPathForMount(
-                    packagedRoot, currentProfile, mountPath, archiveRelativePath);
+                const auto candidate = GetPackagedArchiveSearchPath(packagedRoot, currentProfile, archiveRelativePath);
                 std::string errorMessage;
                 if (std::filesystem::exists(candidate) && PakEntryExists(candidate, ".rtr/catalog.json", &errorMessage))
-                    return candidate;
-            }
-
-            return {};
-        };
-
-        auto findOverlayMountRoot = [&](const std::filesystem::path &mountRelativePath) -> std::filesystem::path
-        {
-            for (const auto &overlayRoot : overlayRootSearchOrder)
-            {
-                const auto candidate = overlayRoot / mountRelativePath;
-                if (std::filesystem::exists(candidate / ".rtr" / "catalog.json"))
                     return candidate;
             }
 
@@ -124,29 +128,38 @@ namespace Resource
             });
         };
 
+        const auto appendArchiveDomainMounts = [&](std::string_view layerName,
+                                                   const std::string &archiveName,
+                                                   const MountPriority priority,
+                                                   const std::filesystem::path &archivePath)
+        {
+            appendReadableMount(
+                std::string(layerName) + ":" + archiveName + ":Project",
+                std::string(layerName) + ":" + archiveName + ":Project",
+                VirtualPath{PathDomain::Project, std::nullopt, {}},
+                priority,
+                MountBackendKind::PakArchive,
+                archivePath);
+            appendReadableMount(
+                std::string(layerName) + ":" + archiveName + ":Engine",
+                std::string(layerName) + ":" + archiveName + ":Engine",
+                VirtualPath{PathDomain::Engine, std::nullopt, {}},
+                priority,
+                MountBackendKind::PakArchive,
+                archivePath);
+        };
+
         const auto addReadableMount = [&](const std::string &sourceKey,
                                           const VirtualPath &mountPath,
                                           const std::filesystem::path &sourceRoot,
                                           const std::filesystem::path &cookedMountRelativePath,
                                           const std::filesystem::path &packagedArchiveRelativePath)
         {
-            const auto overlayRoot = findOverlayMountRoot(cookedMountRelativePath);
             const auto cookedRoot = findCookedMountRoot(cookedMountRelativePath);
-            const auto packagedArchive = findPackagedMountArchive(mountPath, packagedArchiveRelativePath);
-            const bool hasOverlayCatalog = !overlayRoot.empty();
+            const auto packagedArchive = findPackagedMountArchive(packagedArchiveRelativePath);
             const bool hasCookedCatalog = !cookedRoot.empty();
             const bool hasPackagedCatalog = !packagedArchive.empty();
             const bool hasSourceRoot = std::filesystem::exists(sourceRoot);
-
-            if (hasOverlayCatalog)
-            {
-                appendReadableMount("Overlay:" + sourceKey,
-                                    sourceKey,
-                                    mountPath,
-                                    MountPriority::Overlay,
-                                    MountBackendKind::Directory,
-                                    overlayRoot);
-            }
 
             if (preferPackagedArtifacts)
             {
@@ -247,6 +260,21 @@ namespace Resource
             engineDir,
             "Engine",
             std::filesystem::path(std::string("Engine") + std::string(kPakArchiveExtension)));
+
+        if (preferPackagedArtifacts)
+        {
+            const auto appendOverlayArchives = [&](const std::filesystem::path &directory,
+                                                   std::string_view layerName,
+                                                   const MountPriority priority)
+            {
+                for (const auto &archivePath : CollectPakArchives(directory))
+                    appendArchiveDomainMounts(layerName, archivePath.stem().string(), priority, archivePath);
+            };
+
+            appendOverlayArchives(rootPath / "DLC", "DLC", MountPriority::DLC);
+            appendOverlayArchives(rootPath / "Patches", "Patch", MountPriority::Patch);
+            appendOverlayArchives(rootPath / "Mods", "Mod", MountPriority::Mod);
+        }
 
         return mounts;
     }

--- a/Src/Core/Resource/Path/PathParser.cpp
+++ b/Src/Core/Resource/Path/PathParser.cpp
@@ -88,6 +88,28 @@ namespace Resource
             return virtualPath;
         }
 
+        if (segments[0] == "DLC")
+        {
+            if (segments.size() < 2)
+                return std::nullopt;
+
+            virtualPath.domain = PathDomain::DLC;
+            virtualPath.mountName = segments[1];
+            virtualPath.relativePath = JoinSegments(segments, 2);
+            return virtualPath;
+        }
+
+        if (segments[0] == "Mod")
+        {
+            if (segments.size() < 2)
+                return std::nullopt;
+
+            virtualPath.domain = PathDomain::Mod;
+            virtualPath.mountName = segments[1];
+            virtualPath.relativePath = JoinSegments(segments, 2);
+            return virtualPath;
+        }
+
         return std::nullopt;
     }
 } // namespace Resource

--- a/Src/Core/Resource/Path/PathTypes.h
+++ b/Src/Core/Resource/Path/PathTypes.h
@@ -9,6 +9,8 @@ namespace Resource
     {
         Project,
         Engine,
+        DLC,
+        Mod,
         Saved,
         Cache,
     };

--- a/Tests/Integration/TestMountDiscoveryShipping.cpp
+++ b/Tests/Integration/TestMountDiscoveryShipping.cpp
@@ -1,6 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
 
 #include "Core/Resource/Catalog/ResourceCatalog.h"
 #include "Core/Resource/Mount/MountBackend.h"
@@ -12,10 +16,16 @@ namespace
 {
     using MountDiscoveryShippingTests = test_support::RootDiscoveryTestsBase;
 
+    struct ArchiveEntry
+    {
+        std::string logicalPath;
+        std::string relativePath;
+        std::string contents;
+    };
+
     void BuildSharedGameArchiveFixture(const std::filesystem::path &repoRoot)
     {
         const auto cookedRoot = test_support::CookedRoot(repoRoot);
-        const auto packagedRoot = repoRoot / "Saved" / "Cache" / "Packaged";
 
         test_support::WriteTextFileOrFail(
             test_support::ProjectCookedCatalogPath(cookedRoot),
@@ -28,42 +38,164 @@ namespace
         test_support::WriteEngineCookedFileOrFail(cookedRoot, "Defaults/Materials/ErrorMaterial.json", "engine");
 
         std::string errorMessage;
-        ASSERT_TRUE(Resource::PackageCookedRepositoryCatalogs(cookedRoot, packagedRoot, &errorMessage)) << errorMessage;
+        ASSERT_TRUE(Resource::PackageCookedRepositoryCatalogs(cookedRoot, repoRoot, &errorMessage)) << errorMessage;
+    }
+
+    void BuildArchiveFixture(const std::filesystem::path &archiveRoot,
+                             const std::filesystem::path &archivePath,
+                             const std::vector<ArchiveEntry> &entries)
+    {
+        std::string catalog = "{\n  \"version\": 2,\n  \"kind\": \"cooked\",\n  \"entries\": [\n";
+        for (size_t i = 0; i < entries.size(); ++i)
+        {
+            const auto &entry = entries[i];
+            if (i != 0)
+                catalog += ",\n";
+
+            catalog +=
+                "    {\n"
+                "      \"logicalPath\": \"" + entry.logicalPath + "\",\n"
+                "      \"artifacts\": [\n"
+                "        {\n"
+                "          \"relativePath\": \"" + entry.relativePath + "\",\n"
+                "          \"format\": \"bin\",\n"
+                "          \"profileTag\": \"cooked\",\n"
+                "          \"backendTag\": \"any\",\n"
+                "          \"platformTag\": \"any\"\n"
+                "        }\n"
+                "      ]\n"
+                "    }";
+        }
+        catalog += "\n  ]\n}\n";
+
+        test_support::WriteTextFileOrFail(test_support::MountCatalogPath(archiveRoot), catalog);
+        for (const auto &entry : entries)
+            test_support::WriteMountFileOrFail(archiveRoot, entry.relativePath, entry.contents);
+
+        std::string errorMessage;
+        ASSERT_TRUE(Resource::BuildPakArchive(archiveRoot, archivePath, &errorMessage)) << errorMessage;
+    }
+
+    bool ContainsMount(const std::vector<Resource::ReadableMount> &mounts,
+                       std::string_view sourceKey,
+                       Resource::MountPriority priority,
+                       const std::filesystem::path &mountRoot)
+    {
+        return std::any_of(mounts.begin(), mounts.end(), [&](const auto &mount) {
+            return mount.sourceKey == sourceKey &&
+                   mount.priority == priority &&
+                   mount.backend == Resource::MountBackendKind::PakArchive &&
+                   mount.mountRoot == mountRoot;
+        });
     }
 } // namespace
 
-TEST_F(MountDiscoveryShippingTests, DiscoverReadableMountBackendsUsesGameArchiveForPackagedProfile)
+TEST_F(MountDiscoveryShippingTests, DiscoverReadableMountBackendsUsesGameArchiveForShippingProfile)
 {
     const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
-    const auto packagedRoot = repoRoot / "Saved" / "Cache" / "Packaged";
     BuildSharedGameArchiveFixture(repoRoot);
 
     const auto mounts = Resource::DiscoverReadableMountBackends(
-        repoRoot, test_support::EngineRoot(repoRoot), repoRoot / "Saved" / "Cache", "Project", "packaged");
+        repoRoot, test_support::EngineRoot(repoRoot), repoRoot / "Saved" / "Cache", "Project", "shipping");
 
     ASSERT_EQ(mounts.size(), 4u);
     EXPECT_EQ(mounts[0].sourceKey, "Project");
     EXPECT_EQ(mounts[0].priority, Resource::MountPriority::Packaged);
     EXPECT_EQ(mounts[0].backend, Resource::MountBackendKind::PakArchive);
-    EXPECT_EQ(mounts[0].mountRoot, test_support::GamePackagedArchivePath(packagedRoot));
+    EXPECT_EQ(mounts[0].mountRoot, test_support::GamePackagedArchivePath(repoRoot));
     EXPECT_EQ(mounts[1].sourceKey, "Project");
     EXPECT_EQ(mounts[1].priority, Resource::MountPriority::Cooked);
     EXPECT_EQ(mounts[1].backend, Resource::MountBackendKind::Directory);
     EXPECT_EQ(mounts[2].sourceKey, "Engine");
     EXPECT_EQ(mounts[2].priority, Resource::MountPriority::Packaged);
     EXPECT_EQ(mounts[2].backend, Resource::MountBackendKind::PakArchive);
-    EXPECT_EQ(mounts[2].mountRoot, test_support::GamePackagedArchivePath(packagedRoot));
+    EXPECT_EQ(mounts[2].mountRoot, test_support::GamePackagedArchivePath(repoRoot));
     EXPECT_EQ(mounts[3].sourceKey, "Engine");
     EXPECT_EQ(mounts[3].priority, Resource::MountPriority::Cooked);
     EXPECT_EQ(mounts[3].backend, Resource::MountBackendKind::Directory);
 }
 
-TEST_F(MountDiscoveryShippingTests, CatalogRegistryResolvesProjectAndEngineEntriesFromSharedGameArchive)
+TEST_F(MountDiscoveryShippingTests, DiscoverReadableMountBackendsFindsDlcPatchAndModArchives)
 {
     const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
-    const auto packagedRoot = repoRoot / "Saved" / "Cache" / "Packaged";
     BuildSharedGameArchiveFixture(repoRoot);
-    test_support::ScopedEnvVar packagedProfile("RTRLAB_RESOURCE_PROFILE", "packaged");
+
+    BuildArchiveFixture(
+        repoRoot / "DLC" / "Expansion1_Source",
+        repoRoot / "DLC" / "Expansion1.rtrpak",
+        {ArchiveEntry{
+            .logicalPath = "/Project/Textures/Grassy_Square",
+            .relativePath = "Project/Textures/Grassy_Square.rtrtex",
+            .contents = "dlc",
+        }});
+    BuildArchiveFixture(
+        repoRoot / "Patches" / "Patch_001_Source",
+        repoRoot / "Patches" / "Patch_001.rtrpak",
+        {ArchiveEntry{
+            .logicalPath = "/Project/Textures/Grassy_Square",
+            .relativePath = "Project/Textures/Grassy_Square.rtrtex",
+            .contents = "patch",
+        }});
+    BuildArchiveFixture(
+        repoRoot / "Mods" / "CoolMod_Source",
+        repoRoot / "Mods" / "CoolMod.rtrpak",
+        {ArchiveEntry{
+            .logicalPath = "/Project/Textures/Grassy_Square",
+            .relativePath = "Project/Textures/Grassy_Square.rtrtex",
+            .contents = "mod",
+        }});
+
+    const auto mounts = Resource::DiscoverReadableMountBackends(
+        repoRoot, test_support::EngineRoot(repoRoot), repoRoot / "Saved" / "Cache", "Project", "shipping");
+
+    ASSERT_EQ(mounts.size(), 10u);
+    EXPECT_TRUE(ContainsMount(
+        mounts,
+        "DLC:Expansion1:Project",
+        Resource::MountPriority::DLC,
+        repoRoot / "DLC" / "Expansion1.rtrpak"));
+    EXPECT_TRUE(ContainsMount(
+        mounts,
+        "Patch:Patch_001:Project",
+        Resource::MountPriority::Patch,
+        repoRoot / "Patches" / "Patch_001.rtrpak"));
+    EXPECT_TRUE(ContainsMount(
+        mounts,
+        "Mod:CoolMod:Project",
+        Resource::MountPriority::Mod,
+        repoRoot / "Mods" / "CoolMod.rtrpak"));
+}
+
+TEST_F(MountDiscoveryShippingTests, CatalogRegistryPrefersModOverPatchDlcAndBaseInShippingProfile)
+{
+    const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
+    BuildSharedGameArchiveFixture(repoRoot);
+    test_support::ScopedEnvVar shippingProfile("RTRLAB_RESOURCE_PROFILE", "shipping");
+
+    BuildArchiveFixture(
+        repoRoot / "DLC" / "Expansion1_Source",
+        repoRoot / "DLC" / "Expansion1.rtrpak",
+        {ArchiveEntry{
+            .logicalPath = "/Project/Textures/Grassy_Square",
+            .relativePath = "Project/Textures/Grassy_Square.rtrtex",
+            .contents = "dlc",
+        }});
+    BuildArchiveFixture(
+        repoRoot / "Patches" / "Patch_001_Source",
+        repoRoot / "Patches" / "Patch_001.rtrpak",
+        {ArchiveEntry{
+            .logicalPath = "/Project/Textures/Grassy_Square",
+            .relativePath = "Project/Textures/Grassy_Square.rtrtex",
+            .contents = "patch",
+        }});
+    BuildArchiveFixture(
+        repoRoot / "Mods" / "CoolMod_Source",
+        repoRoot / "Mods" / "CoolMod.rtrpak",
+        {ArchiveEntry{
+            .logicalPath = "/Project/Textures/Grassy_Square",
+            .relativePath = "Project/Textures/Grassy_Square.rtrtex",
+            .contents = "mod",
+        }});
 
     Resource::CatalogRegistry registry;
 
@@ -77,7 +209,34 @@ TEST_F(MountDiscoveryShippingTests, CatalogRegistryResolvesProjectAndEngineEntri
         "Project");
     ASSERT_TRUE(projectResolved.has_value());
     EXPECT_EQ(projectResolved->backend, Resource::MountBackendKind::PakArchive);
-    EXPECT_EQ(projectResolved->mountRoot, test_support::GamePackagedArchivePath(packagedRoot));
+    EXPECT_EQ(projectResolved->mountRoot, repoRoot / "Mods" / "CoolMod.rtrpak");
+    EXPECT_EQ(projectResolved->relativePath, std::filesystem::path("Project/Textures/Grassy_Square.rtrtex"));
+
+    std::string errorMessage;
+    const auto projectBytes = Resource::ReadReadableArtifactBinary(*projectResolved, &errorMessage);
+    ASSERT_TRUE(projectBytes.has_value()) << errorMessage;
+    EXPECT_EQ(std::string(projectBytes->begin(), projectBytes->end()), "mod");
+}
+
+TEST_F(MountDiscoveryShippingTests, CatalogRegistryResolvesProjectAndEngineEntriesFromSharedGameArchive)
+{
+    const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
+    BuildSharedGameArchiveFixture(repoRoot);
+    test_support::ScopedEnvVar shippingProfile("RTRLAB_RESOURCE_PROFILE", "shipping");
+
+    Resource::CatalogRegistry registry;
+
+    const auto projectVirtualPath = Resource::VirtualPath{Resource::PathDomain::Project, std::nullopt, "Textures/Grassy_Square"};
+    const auto projectResolved = registry.ResolveArtifact(
+        repoRoot,
+        test_support::EngineRoot(repoRoot),
+        repoRoot / "Saved" / "Cache",
+        projectVirtualPath,
+        "/Project/Textures/Grassy_Square",
+        "Project");
+    ASSERT_TRUE(projectResolved.has_value());
+    EXPECT_EQ(projectResolved->backend, Resource::MountBackendKind::PakArchive);
+    EXPECT_EQ(projectResolved->mountRoot, test_support::GamePackagedArchivePath(repoRoot));
     EXPECT_EQ(projectResolved->relativePath, std::filesystem::path("Project/Textures/Grassy_Square.rtrtex"));
     std::string errorMessage;
     const auto projectBytes = Resource::ReadReadableArtifactBinary(*projectResolved, &errorMessage);
@@ -94,7 +253,7 @@ TEST_F(MountDiscoveryShippingTests, CatalogRegistryResolvesProjectAndEngineEntri
         "Project");
     ASSERT_TRUE(engineResolved.has_value());
     EXPECT_EQ(engineResolved->backend, Resource::MountBackendKind::PakArchive);
-    EXPECT_EQ(engineResolved->mountRoot, test_support::GamePackagedArchivePath(packagedRoot));
+    EXPECT_EQ(engineResolved->mountRoot, test_support::GamePackagedArchivePath(repoRoot));
     EXPECT_EQ(engineResolved->relativePath, std::filesystem::path("Engine/Defaults/Materials/ErrorMaterial.json"));
     const auto engineText = Resource::ReadReadableArtifactText(*engineResolved, &errorMessage);
     ASSERT_TRUE(engineText.has_value()) << errorMessage;

--- a/Tests/Integration/TestMountDiscoveryShipping.cpp
+++ b/Tests/Integration/TestMountDiscoveryShipping.cpp
@@ -123,11 +123,18 @@ TEST_F(MountDiscoveryShippingTests, DiscoverReadableMountBackendsFindsDlcPatchAn
     BuildArchiveFixture(
         repoRoot / "DLC" / "Expansion1_Source",
         repoRoot / "DLC" / "Expansion1.rtrpak",
-        {ArchiveEntry{
-            .logicalPath = "/Project/Textures/Grassy_Square",
-            .relativePath = "Project/Textures/Grassy_Square.rtrtex",
-            .contents = "dlc",
-        }});
+        {
+            ArchiveEntry{
+                .logicalPath = "/Project/Textures/Grassy_Square",
+                .relativePath = "Project/Textures/Grassy_Square.rtrtex",
+                .contents = "dlc",
+            },
+            ArchiveEntry{
+                .logicalPath = "/DLC/Expansion1/Weapons/LaserRifle",
+                .relativePath = "DLC/Expansion1/Weapons/LaserRifle.bin",
+                .contents = "laser",
+            },
+        });
     BuildArchiveFixture(
         repoRoot / "Patches" / "Patch_001_Source",
         repoRoot / "Patches" / "Patch_001.rtrpak",
@@ -148,10 +155,15 @@ TEST_F(MountDiscoveryShippingTests, DiscoverReadableMountBackendsFindsDlcPatchAn
     const auto mounts = Resource::DiscoverReadableMountBackends(
         repoRoot, test_support::EngineRoot(repoRoot), repoRoot / "Saved" / "Cache", "Project", "shipping");
 
-    ASSERT_EQ(mounts.size(), 10u);
+    ASSERT_EQ(mounts.size(), 12u);
     EXPECT_TRUE(ContainsMount(
         mounts,
         "DLC:Expansion1:Project",
+        Resource::MountPriority::DLC,
+        repoRoot / "DLC" / "Expansion1.rtrpak"));
+    EXPECT_TRUE(ContainsMount(
+        mounts,
+        "DLC:Expansion1",
         Resource::MountPriority::DLC,
         repoRoot / "DLC" / "Expansion1.rtrpak"));
     EXPECT_TRUE(ContainsMount(
@@ -162,6 +174,11 @@ TEST_F(MountDiscoveryShippingTests, DiscoverReadableMountBackendsFindsDlcPatchAn
     EXPECT_TRUE(ContainsMount(
         mounts,
         "Mod:CoolMod:Project",
+        Resource::MountPriority::Mod,
+        repoRoot / "Mods" / "CoolMod.rtrpak"));
+    EXPECT_TRUE(ContainsMount(
+        mounts,
+        "Mod:CoolMod",
         Resource::MountPriority::Mod,
         repoRoot / "Mods" / "CoolMod.rtrpak"));
 }
@@ -216,6 +233,63 @@ TEST_F(MountDiscoveryShippingTests, CatalogRegistryPrefersModOverPatchDlcAndBase
     const auto projectBytes = Resource::ReadReadableArtifactBinary(*projectResolved, &errorMessage);
     ASSERT_TRUE(projectBytes.has_value()) << errorMessage;
     EXPECT_EQ(std::string(projectBytes->begin(), projectBytes->end()), "mod");
+}
+
+TEST_F(MountDiscoveryShippingTests, CatalogRegistryResolvesDlcAndModNamespaceEntriesFromOverlayArchives)
+{
+    const auto repoRoot = test_support::CreateRepoRootOrFail(TestRoot());
+    BuildSharedGameArchiveFixture(repoRoot);
+    test_support::ScopedEnvVar shippingProfile("RTRLAB_RESOURCE_PROFILE", "shipping");
+
+    BuildArchiveFixture(
+        repoRoot / "DLC" / "Expansion1_Source",
+        repoRoot / "DLC" / "Expansion1.rtrpak",
+        {ArchiveEntry{
+            .logicalPath = "/DLC/Expansion1/Weapons/LaserRifle",
+            .relativePath = "DLC/Expansion1/Weapons/LaserRifle.bin",
+            .contents = "laser",
+        }});
+    BuildArchiveFixture(
+        repoRoot / "Mods" / "CoolMod_Source",
+        repoRoot / "Mods" / "CoolMod.rtrpak",
+        {ArchiveEntry{
+            .logicalPath = "/Mod/CoolMod/Weapons/Hammer",
+            .relativePath = "Mod/CoolMod/Weapons/Hammer.bin",
+            .contents = "hammer",
+        }});
+
+    Resource::CatalogRegistry registry;
+    std::string errorMessage;
+
+    const auto dlcVirtualPath = Resource::VirtualPath{Resource::PathDomain::DLC, std::string("Expansion1"), "Weapons/LaserRifle"};
+    const auto dlcResolved = registry.ResolveArtifact(
+        repoRoot,
+        test_support::EngineRoot(repoRoot),
+        repoRoot / "Saved" / "Cache",
+        dlcVirtualPath,
+        "/DLC/Expansion1/Weapons/LaserRifle",
+        "Project");
+    ASSERT_TRUE(dlcResolved.has_value());
+    EXPECT_EQ(dlcResolved->mountRoot, repoRoot / "DLC" / "Expansion1.rtrpak");
+    EXPECT_EQ(dlcResolved->relativePath, std::filesystem::path("DLC/Expansion1/Weapons/LaserRifle.bin"));
+    const auto dlcBytes = Resource::ReadReadableArtifactBinary(*dlcResolved, &errorMessage);
+    ASSERT_TRUE(dlcBytes.has_value()) << errorMessage;
+    EXPECT_EQ(std::string(dlcBytes->begin(), dlcBytes->end()), "laser");
+
+    const auto modVirtualPath = Resource::VirtualPath{Resource::PathDomain::Mod, std::string("CoolMod"), "Weapons/Hammer"};
+    const auto modResolved = registry.ResolveArtifact(
+        repoRoot,
+        test_support::EngineRoot(repoRoot),
+        repoRoot / "Saved" / "Cache",
+        modVirtualPath,
+        "/Mod/CoolMod/Weapons/Hammer",
+        "Project");
+    ASSERT_TRUE(modResolved.has_value());
+    EXPECT_EQ(modResolved->mountRoot, repoRoot / "Mods" / "CoolMod.rtrpak");
+    EXPECT_EQ(modResolved->relativePath, std::filesystem::path("Mod/CoolMod/Weapons/Hammer.bin"));
+    const auto modBytes = Resource::ReadReadableArtifactBinary(*modResolved, &errorMessage);
+    ASSERT_TRUE(modBytes.has_value()) << errorMessage;
+    EXPECT_EQ(std::string(modBytes->begin(), modBytes->end()), "hammer");
 }
 
 TEST_F(MountDiscoveryShippingTests, CatalogRegistryResolvesProjectAndEngineEntriesFromSharedGameArchive)

--- a/Tests/Unit/TestAssetPath.cpp
+++ b/Tests/Unit/TestAssetPath.cpp
@@ -9,12 +9,16 @@ TEST(AssetPathTests, TryCreateAcceptsContentPathsWithoutExtensions)
 {
     EXPECT_TRUE(Resource::AssetPath::TryCreate("/Project/Textures/Grassy_Square").has_value());
     EXPECT_TRUE(Resource::AssetPath::TryCreate("/Engine/Defaults/Materials/ErrorMaterial").has_value());
+    EXPECT_TRUE(Resource::AssetPath::TryCreate("/DLC/Expansion1/Weapons/LaserRifle").has_value());
+    EXPECT_TRUE(Resource::AssetPath::TryCreate("/Mod/CoolMod/Weapons/Hammer").has_value());
 }
 
 TEST(AssetPathTests, TryCreateRejectsConfigDocumentPaths)
 {
     EXPECT_FALSE(Resource::AssetPath::TryCreate("/Project/Config/Graphics.json").has_value());
     EXPECT_FALSE(Resource::AssetPath::TryCreate("/Engine/Config/Graphics.json").has_value());
+    EXPECT_FALSE(Resource::AssetPath::TryCreate("/DLC/Expansion1/Config/Graphics.json").has_value());
+    EXPECT_FALSE(Resource::AssetPath::TryCreate("/Mod/CoolMod/Config/Graphics.json").has_value());
 }
 
 TEST(AssetPathTests, DeserializeRejectsAbsoluteFilesystemPathAndLeavesOutputUnchanged)

--- a/Tests/Unit/TestFileSystemVirtualPaths.cpp
+++ b/Tests/Unit/TestFileSystemVirtualPaths.cpp
@@ -32,6 +32,8 @@ TEST(FileSystemVirtualPathTests, IsVirtualPathAcceptsReadableAndWritableDomains)
 {
     EXPECT_TRUE(FileSystem::IsVirtualPath("/Project/Config/input/DebugCameraControl.json"));
     EXPECT_TRUE(FileSystem::IsVirtualPath("/Engine/Defaults/Materials/ErrorMaterial"));
+    EXPECT_TRUE(FileSystem::IsVirtualPath("/DLC/Expansion1/Weapons/LaserRifle"));
+    EXPECT_TRUE(FileSystem::IsVirtualPath("/Mod/CoolMod/Weapons/Hammer"));
     EXPECT_TRUE(FileSystem::IsVirtualPath("/Saved/Config/imgui.ini"));
     EXPECT_TRUE(FileSystem::IsVirtualPath("/Cache/Shaders/bootstrap.bin"));
 }
@@ -48,4 +50,28 @@ TEST(FileSystemVirtualPathTests, ParseRecognizesSavedAndCacheDomains)
     ASSERT_TRUE(cache.has_value());
     EXPECT_EQ(cache->domain, FileSystem::PathDomain::Cache);
     EXPECT_EQ(cache->relativePath, "Shaders/bootstrap.bin");
+}
+
+TEST(FileSystemVirtualPathTests, ParseRecognizesDlcAndModDomainsWithMountNames)
+{
+    const auto dlc = FileSystem::ParseVirtualPath("/DLC/Expansion1/Weapons/LaserRifle");
+    const auto mod = FileSystem::ParseVirtualPath("/Mod/CoolMod/Weapons/Hammer");
+
+    ASSERT_TRUE(dlc.has_value());
+    EXPECT_EQ(dlc->domain, FileSystem::PathDomain::DLC);
+    ASSERT_TRUE(dlc->mountName.has_value());
+    EXPECT_EQ(*dlc->mountName, "Expansion1");
+    EXPECT_EQ(dlc->relativePath, "Weapons/LaserRifle");
+
+    ASSERT_TRUE(mod.has_value());
+    EXPECT_EQ(mod->domain, FileSystem::PathDomain::Mod);
+    ASSERT_TRUE(mod->mountName.has_value());
+    EXPECT_EQ(*mod->mountName, "CoolMod");
+    EXPECT_EQ(mod->relativePath, "Weapons/Hammer");
+}
+
+TEST(FileSystemVirtualPathTests, ParseRejectsDlcAndModPathsWithoutMountNames)
+{
+    EXPECT_FALSE(FileSystem::ParseVirtualPath("/DLC").has_value());
+    EXPECT_FALSE(FileSystem::ParseVirtualPath("/Mod").has_value());
 }


### PR DESCRIPTION
## Summary
- Added shipping/profiled packaged mount discovery for `Game.rtrpak` plus optional `DLC/`, `Patches/`, and `Mods/` overlay pak directories.
- Extended mount precedence with `DLC`, `Patch`, and `Mod` priorities so shipping overlays resolve as `Mod > Patch > DLC > Packaged > Cooked > Source`.
- Added `/DLC/<Name>/...` and `/Mod/<Name>/...` virtual path support so additive DLC/mod content can be addressed directly while overlay paks can still transparently override `/Project/...` and `/Engine/...`.

## Why
- Make shipping installs support additive DLC/mod namespaces and deterministic override behavior without changing the base logical-path contract.
- Keep runtime resolution representative of the intended packaged deployment model.

## Affected areas
- `Src/Core/Resource/Mount/MountBackend.cpp`
- `Src/Core/Resource/Path/PathTypes.h`
- `Src/Core/Resource/Path/PathParser.cpp`
- `Src/Core/Resource/FileSystem.cpp`
- `Src/Core/Resource/Catalog/ResourceCatalog.*`
- `Src/Core/Resource/Catalog/AssetPath.h`
- `Src/Core/Resource/Catalog/SourceCatalog.cpp`
- `Tests/Unit/TestFileSystemVirtualPaths.cpp`
- `Tests/Unit/TestAssetPath.cpp`
- `Tests/Integration/TestMountDiscoveryShipping.cpp`
- `Docs/Modules/ResourceSystem/Plan.md`
- `Docs/Modules/ResourceSystem/Design.md`
- `Docs/Modules/ResourceSystem/Internals.md`

## Documentation
- [ ] No documentation needed
- [x] Documentation updated

## Testing
- Rebuilt `rtrlab_unit_tests` after adding `/DLC/<Name>/` and `/Mod/<Name>/` virtual-path parsing and asset-path validation.
- Rebuilt `rtrlab_shipping_profile_tests` after adding shipping DLC/Patch/Mod mount discovery and namespace mounts.
- Ran `rtrlab_unit_tests.exe` and verified all tests passed.
- Ran `rtrlab_shipping_profile_tests.exe` and verified coverage for:
  - base `Game.rtrpak` shipping resolution
  - shipping discovery of `DLC/`, `Patches/`, and `Mods/` pak overlays
  - `Mod > Patch > DLC > Packaged > Cooked > Source` precedence
  - direct `/DLC/<Name>/...` and `/Mod/<Name>/...` namespace reads

## Notes
- Patch overlays remain transparent and do not introduce a `/Patch/...` virtual namespace.
- DLC and Mod paks can both override base logical paths and expose additive content through their own namespaced logical roots.
- The old loose `Saved/Overrides/` documentation has been retired in favor of the shipping pak overlay model.
