### PR TITLE
Drop legacy runtime content copy and gate staging targets to Release

### DIFF
--- a/CMake/Src/App.cmake
+++ b/CMake/Src/App.cmake
@@ -13,7 +13,6 @@ if(GLAB_ENABLE_PCH)
     target_precompile_headers(RTRLab REUSE_FROM RTRLabCore)
 endif()
 
-glab_copy_runtime_content(RTRLab)
 glab_configure_local_target(RTRLab)
 
 set_target_properties(RTRLab PROPERTIES

--- a/CMake/Src/Helpers.cmake
+++ b/CMake/Src/Helpers.cmake
@@ -9,24 +9,6 @@ function(glab_enable_local_pch target_name)
     endif()
 endfunction()
 
-function(glab_copy_runtime_content target_name)
-    add_custom_command(TARGET ${target_name} POST_BUILD
-        # Copy source content (textures, config defaults, etc.)
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-                ${CMAKE_SOURCE_DIR}/Project
-                $<TARGET_FILE_DIR:${target_name}>/Project
-    )
-
-    if(EXISTS ${CMAKE_SOURCE_DIR}/Engine)
-        add_custom_command(TARGET ${target_name} POST_BUILD
-            # Copy engine-shipped defaults and shared resources.
-            COMMAND ${CMAKE_COMMAND} -E copy_directory
-                    ${CMAKE_SOURCE_DIR}/Engine
-                    $<TARGET_FILE_DIR:${target_name}>/Engine
-        )
-    endif()
-endfunction()
-
 function(glab_add_tool_target target_name source_file)
     add_executable(${target_name}
         ${source_file}

--- a/CMake/Src/Packaging.cmake
+++ b/CMake/Src/Packaging.cmake
@@ -1,29 +1,31 @@
-set(GLAB_PACKAGE_CONTENT_COOKED_DIR "${CMAKE_BINARY_DIR}/Packaging/$<CONFIG>/Cooked")
-set(GLAB_STAGE_RUNTIME_DIR "${CMAKE_BINARY_DIR}/Stage/$<CONFIG>")
-set(GLAB_STAGE_RUNTIME_NAME "$<TARGET_FILE_NAME:RTRLab>")
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(GLAB_PACKAGE_CONTENT_COOKED_DIR "${CMAKE_BINARY_DIR}/Packaging/$<CONFIG>/Cooked")
+    set(GLAB_STAGE_RUNTIME_DIR "${CMAKE_BINARY_DIR}/Stage/$<CONFIG>")
+    set(GLAB_STAGE_RUNTIME_NAME "$<TARGET_FILE_NAME:RTRLab>")
 
-add_custom_target(rtrlab_package_content
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${GLAB_PACKAGE_CONTENT_COOKED_DIR}"
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${GLAB_STAGE_RUNTIME_DIR}"
-    COMMAND $<TARGET_FILE:rtr_asset_cook>
-            --root "${CMAKE_SOURCE_DIR}"
-            --out "${GLAB_PACKAGE_CONTENT_COOKED_DIR}"
-    COMMAND $<TARGET_FILE:rtr_asset_pack>
-            --source "${GLAB_PACKAGE_CONTENT_COOKED_DIR}"
-            --out "${GLAB_STAGE_RUNTIME_DIR}"
-    DEPENDS
-        rtr_asset_cook
-        rtr_asset_pack
-    COMMENT "Packaging runtime content into ${GLAB_STAGE_RUNTIME_DIR}"
-)
+    add_custom_target(rtrlab_package_content
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${GLAB_PACKAGE_CONTENT_COOKED_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${GLAB_STAGE_RUNTIME_DIR}"
+        COMMAND $<TARGET_FILE:rtr_asset_cook>
+                --root "${CMAKE_SOURCE_DIR}"
+                --out "${GLAB_PACKAGE_CONTENT_COOKED_DIR}"
+        COMMAND $<TARGET_FILE:rtr_asset_pack>
+                --source "${GLAB_PACKAGE_CONTENT_COOKED_DIR}"
+                --out "${GLAB_STAGE_RUNTIME_DIR}"
+        DEPENDS
+            rtr_asset_cook
+            rtr_asset_pack
+        COMMENT "Packaging runtime content into ${GLAB_STAGE_RUNTIME_DIR}"
+    )
 
-add_custom_target(rtrlab_stage_runtime
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${GLAB_STAGE_RUNTIME_DIR}"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:RTRLab>
-            "${GLAB_STAGE_RUNTIME_DIR}/$<TARGET_FILE_NAME:RTRLab>"
-    DEPENDS
-        RTRLab
-        rtrlab_package_content
-    COMMENT "Staging runtime into ${GLAB_STAGE_RUNTIME_DIR}"
-)
+    add_custom_target(rtrlab_stage_runtime
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${GLAB_STAGE_RUNTIME_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                $<TARGET_FILE:RTRLab>
+                "${GLAB_STAGE_RUNTIME_DIR}/$<TARGET_FILE_NAME:RTRLab>"
+        DEPENDS
+            RTRLab
+            rtrlab_package_content
+        COMMENT "Staging runtime into ${GLAB_STAGE_RUNTIME_DIR}"
+    )
+endif()


### PR DESCRIPTION
## Summary
- Remove `glab_copy_runtime_content` helper and its `RTRLab` POST_BUILD hook so `Project/` and `Engine/` are no longer mirrored next to the built executable in `bin/`.
- Wrap `rtrlab_package_content` and `rtrlab_stage_runtime` in `if(CMAKE_BUILD_TYPE STREQUAL "Release")` so the staging/packaging targets only exist in Release configure presets.

## Why
- Runtime content now ships via the `rtr_asset_cook` → `rtr_asset_pack` → `Stage/<cfg>/Game.rtrpak` pipeline introduced in recent commits (`Move packaged runtime content to a single Game.rtrpak layout`, `Simplify resource runtime profiles and ship from staged pak artifacts`). The POST_BUILD copy of raw `Project/` + `Engine/` directories into `bin/` is a leftover from the old flow and duplicates content.
- `rtrlab_package_content` / `rtrlab_stage_runtime` were declared unconditionally, so they surfaced in Debug / RelWithDebInfo build directories even though no build preset drives them outside Release. Gating them keeps dev configurations focused on the app + tests.

## Affected areas
- [CMake/Src/Helpers.cmake](CMake/Src/Helpers.cmake) — deleted `glab_copy_runtime_content`.
- [CMake/Src/App.cmake](CMake/Src/App.cmake) — removed the `glab_copy_runtime_content(RTRLab)` call.
- [CMake/Src/Packaging.cmake](CMake/Src/Packaging.cmake) — wrapped both custom targets in a Release-only guard.

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- reconfigure + build `windows-debug` and confirm `bin/` no longer contains `Project/` or `Engine/` and that `rtrlab_package_content` / `rtrlab_stage_runtime` are absent from the Ninja target list.
- reconfigure + build `windows-release` via `build-windows-release-stage-runtime` and confirm `Stage/Release/` still contains the packaged pak + `RTRLab` executable.

## Notes
- Safe because every preset uses Ninja (single-config), so `CMAKE_BUILD_TYPE` is known at configure time, and [CMake/Project.cmake](CMake/Project.cmake) already restricts it to `Debug` / `RelWithDebInfo` / `Release`.
- All build presets that reference the packaging/staging targets are based on `*-release` configure presets, so the new guard doesn't break any existing preset entry point.
