### PR TITLE
Require implicit cook and pack paths in resource tools

### DIFF
--- a/Src/Core/Resource/Cook/CookedCatalog.cpp
+++ b/Src/Core/Resource/Cook/CookedCatalog.cpp
@@ -427,19 +427,6 @@ namespace
 
 namespace Resource
 {
-    std::filesystem::path GetCookOutputRoot(const std::filesystem::path &rootPath, CookOutputLayout layout)
-    {
-        switch (layout)
-        {
-        case CookOutputLayout::Cache:
-            return rootPath / "Saved" / "Cache" / "Cooked";
-        case CookOutputLayout::Build:
-            return rootPath / "build" / "Cooked";
-        }
-
-        return rootPath / "Saved" / "Cache" / "Cooked";
-    }
-
     std::optional<CookedTextureMetadata> ReadCookedTextureMetadata(const std::filesystem::path &artifactPath,
                                                                    std::string *errorMessage)
     {

--- a/Src/Core/Resource/Cook/CookedCatalog.h
+++ b/Src/Core/Resource/Cook/CookedCatalog.h
@@ -9,12 +9,6 @@
 
 namespace Resource
 {
-    enum class CookOutputLayout
-    {
-        Cache,
-        Build,
-    };
-
     inline constexpr std::string_view kCookedTextureArtifactExtension = ".rtrtex";
     inline constexpr std::string_view kCookedTextureArtifactFormat = "rtrtex";
 
@@ -51,8 +45,6 @@ namespace Resource
 
     std::optional<CookedTextureData> LoadCookedTexture(const std::filesystem::path &artifactPath,
                                                        std::string *errorMessage = nullptr);
-
-    std::filesystem::path GetCookOutputRoot(const std::filesystem::path &rootPath, CookOutputLayout layout);
 
     bool CookRepositoryCatalogs(const std::filesystem::path &rootPath,
                                 const std::filesystem::path &cookedRootPath,

--- a/Src/Core/Resource/Package/PakArchive.cpp
+++ b/Src/Core/Resource/Package/PakArchive.cpp
@@ -406,19 +406,6 @@ namespace
 
 namespace Resource
 {
-    std::filesystem::path GetPackagedOutputRoot(const std::filesystem::path &rootPath, CookOutputLayout layout)
-    {
-        switch (layout)
-        {
-        case CookOutputLayout::Cache:
-            return rootPath / "Saved" / "Cache" / "Packaged";
-        case CookOutputLayout::Build:
-            return rootPath / "build" / "Packaged";
-        }
-
-        return rootPath / "Saved" / "Cache" / "Packaged";
-    }
-
     std::filesystem::path GetGamePackagedArchivePath(const std::filesystem::path &packagedRootPath)
     {
         return packagedRootPath / "Game.rtrpak";

--- a/Src/Core/Resource/Package/PakArchive.h
+++ b/Src/Core/Resource/Package/PakArchive.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "Core/Resource/Cook/CookedCatalog.h"
-
 #include <filesystem>
 #include <optional>
 #include <string>
@@ -12,7 +10,6 @@ namespace Resource
 {
     inline constexpr std::string_view kPakArchiveExtension = ".rtrpak";
 
-    std::filesystem::path GetPackagedOutputRoot(const std::filesystem::path &rootPath, CookOutputLayout layout);
     std::filesystem::path GetGamePackagedArchivePath(const std::filesystem::path &packagedRootPath);
 
     bool BuildPakArchive(const std::filesystem::path &sourceRoot,

--- a/Src/Tools/AssetCookMain.cpp
+++ b/Src/Tools/AssetCookMain.cpp
@@ -13,8 +13,7 @@ namespace
         Util::CommandLineSpec spec;
         spec.AddFlag("help", 'h', "Show command-line help and exit.")
             .AddValueOption("root", std::nullopt, "path", "Repository root to cook.")
-            .AddValueOption("out", std::nullopt, "path", "Explicit cooked output root.")
-            .AddValueOption("layout", std::nullopt, "name", "Cook output layout: cache or build.");
+            .AddValueOption("out", std::nullopt, "path", "Cooked output root.");
         return spec;
     }
 }
@@ -36,38 +35,24 @@ int main(int argc, char **argv)
         return 0;
     }
 
-    std::filesystem::path rootPath = std::filesystem::current_path();
-    std::filesystem::path cookedRootPath;
-    Resource::CookOutputLayout layout = Resource::CookOutputLayout::Cache;
-    bool layoutExplicitlySet = false;
-    if (const auto rootOverride = commandLine.GetOptionValue("root"))
-        rootPath = std::string(*rootOverride);
-    if (const auto outputOverride = commandLine.GetOptionValue("out"))
-        cookedRootPath = std::string(*outputOverride);
-    if (const auto layoutValue = commandLine.GetOptionValue("layout"))
+    const auto rootOverride = commandLine.GetOptionValue("root");
+    if (!rootOverride.has_value() || rootOverride->empty())
     {
-        if (*layoutValue == "cache")
-            layout = Resource::CookOutputLayout::Cache;
-        else if (*layoutValue == "build")
-            layout = Resource::CookOutputLayout::Build;
-        else
-        {
-            std::cerr << "Unknown cook layout: " << *layoutValue << "\n\n"
-                      << commandLineSpec.BuildUsage("rtr_asset_cook");
-            return 1;
-        }
-
-        layoutExplicitlySet = true;
-    }
-
-    if (cookedRootPath.empty())
-        cookedRootPath = Resource::GetCookOutputRoot(rootPath, layout);
-    else if (layoutExplicitlySet)
-    {
-        std::cerr << "Use either --out or --layout, not both\n\n"
+        std::cerr << "Missing required argument: --root\n\n"
                   << commandLineSpec.BuildUsage("rtr_asset_cook");
         return 1;
     }
+
+    const auto outputOverride = commandLine.GetOptionValue("out");
+    if (!outputOverride.has_value() || outputOverride->empty())
+    {
+        std::cerr << "Missing required argument: --out\n\n"
+                  << commandLineSpec.BuildUsage("rtr_asset_cook");
+        return 1;
+    }
+
+    const std::filesystem::path rootPath = std::string(*rootOverride);
+    const std::filesystem::path cookedRootPath = std::string(*outputOverride);
 
     if (!Resource::CookRepositoryCatalogs(rootPath, cookedRootPath, kProjectContentDirName, &errorMessage))
     {

--- a/Src/Tools/AssetPackMain.cpp
+++ b/Src/Tools/AssetPackMain.cpp
@@ -11,10 +11,8 @@ namespace
     {
         Util::CommandLineSpec spec;
         spec.AddFlag("help", 'h', "Show command-line help and exit.")
-            .AddValueOption("root", std::nullopt, "path", "Repository root used for default output layout.")
             .AddValueOption("source", std::nullopt, "path", "Cooked source directory to package.")
-            .AddValueOption("out", std::nullopt, "path", "Explicit packaged output root.")
-            .AddValueOption("layout", std::nullopt, "name", "Packaged output layout: cache or build.");
+            .AddValueOption("out", std::nullopt, "path", "Packaged output root.");
         return spec;
     }
 }
@@ -36,44 +34,24 @@ int main(int argc, char **argv)
         return 0;
     }
 
-    std::filesystem::path rootPath = std::filesystem::current_path();
-    std::filesystem::path cookedRootPath;
-    std::filesystem::path packagedRootPath;
-    Resource::CookOutputLayout layout = Resource::CookOutputLayout::Cache;
-    bool layoutExplicitlySet = false;
-    if (const auto rootOverride = commandLine.GetOptionValue("root"))
-        rootPath = std::string(*rootOverride);
-    if (const auto sourceOverride = commandLine.GetOptionValue("source"))
-        cookedRootPath = std::string(*sourceOverride);
-    if (const auto outputOverride = commandLine.GetOptionValue("out"))
-        packagedRootPath = std::string(*outputOverride);
-    if (const auto layoutValue = commandLine.GetOptionValue("layout"))
+    const auto sourceOverride = commandLine.GetOptionValue("source");
+    if (!sourceOverride.has_value() || sourceOverride->empty())
     {
-        if (*layoutValue == "cache")
-            layout = Resource::CookOutputLayout::Cache;
-        else if (*layoutValue == "build")
-            layout = Resource::CookOutputLayout::Build;
-        else
-        {
-            std::cerr << "Unknown package layout: " << *layoutValue << "\n\n"
-                      << commandLineSpec.BuildUsage("rtr_asset_pack");
-            return 1;
-        }
-
-        layoutExplicitlySet = true;
-    }
-
-    if (cookedRootPath.empty())
-        cookedRootPath = Resource::GetCookOutputRoot(rootPath, layout);
-
-    if (packagedRootPath.empty())
-        packagedRootPath = Resource::GetPackagedOutputRoot(rootPath, layout);
-    else if (layoutExplicitlySet)
-    {
-        std::cerr << "Use either --out or --layout, not both\n\n"
+        std::cerr << "Missing required argument: --source\n\n"
                   << commandLineSpec.BuildUsage("rtr_asset_pack");
         return 1;
     }
+
+    const auto outputOverride = commandLine.GetOptionValue("out");
+    if (!outputOverride.has_value() || outputOverride->empty())
+    {
+        std::cerr << "Missing required argument: --out\n\n"
+                  << commandLineSpec.BuildUsage("rtr_asset_pack");
+        return 1;
+    }
+
+    const std::filesystem::path cookedRootPath = std::string(*sourceOverride);
+    const std::filesystem::path packagedRootPath = std::string(*outputOverride);
 
     if (!Resource::PackageCookedRepositoryCatalogs(cookedRootPath, packagedRootPath, &errorMessage))
     {

--- a/Tests/Support/ResourceTestSupport.h
+++ b/Tests/Support/ResourceTestSupport.h
@@ -83,11 +83,6 @@ namespace test_support
         return repoRoot / "Saved" / "Cache" / "Cooked";
     }
 
-    inline std::filesystem::path BuildCookedRoot(const std::filesystem::path &repoRoot)
-    {
-        return repoRoot / "build" / "Cooked";
-    }
-
     inline std::filesystem::path ProjectCookedRoot(const std::filesystem::path &cookedRoot)
     {
         return cookedRoot / "Project";

--- a/Tests/Unit/TestCommandLine.cpp
+++ b/Tests/Unit/TestCommandLine.cpp
@@ -10,7 +10,7 @@ namespace
         spec.AddFlag("help", 'h', "Show help.")
             .AddValueOption("root", std::nullopt, "path", "Override root path.",
                             Util::CommandLineOptionVisibility::DevelopmentOnly)
-            .AddValueOption("layout", std::nullopt, "name", "Select output layout.")
+            .AddValueOption("out", std::nullopt, "path", "Select output path.")
             .AddFlag("dev-mode", std::nullopt, "Enable development-only behavior.");
         return spec;
     }
@@ -27,7 +27,7 @@ TEST(CommandLineTests, ParseSupportsFlagsValueOptionsAndShortAliases)
         const_cast<char *>("-h"),
         const_cast<char *>("--root"),
         const_cast<char *>("D:/Repo"),
-        const_cast<char *>("--layout=build"),
+        const_cast<char *>("--out=D:/Cooked"),
     };
 
     ASSERT_TRUE(Util::ParseCommandLine(
@@ -36,8 +36,8 @@ TEST(CommandLineTests, ParseSupportsFlagsValueOptionsAndShortAliases)
     EXPECT_TRUE(parsed.HasOption("help"));
     ASSERT_TRUE(parsed.GetOptionValue("root").has_value());
     EXPECT_EQ(*parsed.GetOptionValue("root"), "D:/Repo");
-    ASSERT_TRUE(parsed.GetOptionValue("layout").has_value());
-    EXPECT_EQ(*parsed.GetOptionValue("layout"), "build");
+    ASSERT_TRUE(parsed.GetOptionValue("out").has_value());
+    EXPECT_EQ(*parsed.GetOptionValue("out"), "D:/Cooked");
 }
 
 TEST(CommandLineTests, ParseRejectsUnknownArguments)

--- a/Tests/Unit/TestCookedCatalog.cpp
+++ b/Tests/Unit/TestCookedCatalog.cpp
@@ -67,16 +67,6 @@ TEST_F(CookedCatalogTests, LoadCookedTextureRejectsInvalidMagic)
     EXPECT_NE(errorMessage.find("invalid magic"), std::string::npos);
 }
 
-TEST_F(CookedCatalogTests, GetCookOutputRootSupportsCacheAndBuildLayouts)
-{
-    const auto repoRoot = TestRoot() / "Repo";
-
-    EXPECT_EQ(Resource::GetCookOutputRoot(repoRoot, Resource::CookOutputLayout::Cache),
-              test_support::CookedRoot(repoRoot));
-    EXPECT_EQ(Resource::GetCookOutputRoot(repoRoot, Resource::CookOutputLayout::Build),
-              test_support::BuildCookedRoot(repoRoot));
-}
-
 TEST_F(CookedCatalogTests, LoadCookedTextureSupportsLegacyVersion1Artifacts)
 {
     const auto cookedArtifactPath = TestRoot() / "legacy.rtrtex";


### PR DESCRIPTION
## Summary
- Require explicit `--root` and `--out` for `rtr_asset_cook`
- Require explicit `--source` and `--out` for `rtr_asset_pack`
- Remove legacy default output layout helpers and the old `--layout` path-selection flow
- Update tests to stop treating `build/Cooked` / `build/Packaged` as supported default behavior

## Why
- Eliminate the old default path contract that conflicted with the newer CMake staging/install layout
- Make output-location policy an orchestration concern instead of embedding it inside the resource tools
- Prevent the resource pipeline from silently preserving two different “official” directory layouts

## Affected areas
- Src/Tools/AssetCookMain.cpp`
- `Src/Tools/AssetPackMain.cpp`
- `Src/Core/Resource/Cook/CookedCatalog.{h,cpp}`
- `Src/Core/Resource/Package/PakArchive.{h,cpp}`
- `Tests/Unit/TestCookedCatalog.cpp`
- `Tests/Unit/TestCommandLine.cpp`
- `Tests/Support/ResourceTestSupport.h`

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Updated unit tests to remove the old default-layout expectation

## Notes
- CMake packaging/install flow already passes explicit paths, so the intended staged runtime pipeline remains aligned with this change