### PR TITLE
Clarify RHI window handle boundary and lockstep backend bring-up

### DIFF
--- a/Docs/Modules/RenderSystem/Design/RHI.md
+++ b/Docs/Modules/RenderSystem/Design/RHI.md
@@ -460,6 +460,41 @@ struct SwapchainDesc
     bool     vsync      = true;
 };
 
+enum class NativeWindowSystem
+{
+    Win32,
+    Cocoa,
+    Xlib,
+    Xcb,
+    Wayland,
+};
+
+struct NativeWindowHandle
+{
+    NativeWindowSystem system;
+
+    // Platform-native top-level window or surface handle:
+    // - Win32:   HWND
+    // - Cocoa:   NSWindow*
+    // - Xlib:    X11 Window value cast to uintptr_t
+    // - Xcb:     xcb_window_t value cast to uintptr_t
+    // - Wayland: wl_surface*
+    uintptr_t window = 0;
+
+    // Optional companion native object:
+    // - Xlib:    Display*
+    // - Xcb:     xcb_connection_t*
+    // - Wayland: wl_display*
+    // - Win32 / Cocoa: null
+    void* display = nullptr;
+
+    // Optional presentation layer object when required by a backend:
+    // - Metal:   CAMetalLayer*
+    // - Vulkan on Apple platforms: CAMetalLayer*
+    // - others:  null
+    void* layer = nullptr;
+};
+
 class Swapchain
 {
 public:
@@ -490,7 +525,15 @@ public:
 
 **Image ownership rule**: `getImage()` / `getImageView()` return non-owning pointers. The swapchain owns all its images and views; callers must not delete them or wrap them in `Scope<T>`.
 
-**Native window handle**: `Device::createSwapchain()` takes a `void* nativeWindowHandle` whose interpretation is backend-specific — see the relevant backend document for details.
+**Native window handle**: `Device::createSwapchain()` takes a strongly typed `NativeWindowHandle`, not a `GLFWwindow*` and not a raw `void*`.
+
+This is an intentional abstraction boundary:
+
+- the **windowing layer** may use GLFW internally
+- the **RHI public API** should remain independent from any particular window library
+- the windowing layer is responsible for extracting platform-native handles from `GLFWwindow*` and packaging them into `NativeWindowHandle`
+
+This keeps GLFW from leaking into the public renderer API and makes future platform-layer changes low-friction.
 
 ---
 
@@ -1216,7 +1259,7 @@ All factory methods return `Scope<T>` (see §12.1). `CommandList` and `FrameCont
 class Device
 {
 public:
-    virtual Scope<Swapchain>          createSwapchain         (const SwapchainDesc&, void* nativeWindowHandle) = 0;
+    virtual Scope<Swapchain>          createSwapchain         (const SwapchainDesc&, const NativeWindowHandle&) = 0;
 
     virtual Scope<Buffer>             createBuffer            (const BufferDesc&) = 0;
     virtual Scope<Texture>            createTexture           (const TextureDesc&) = 0;

--- a/Docs/Modules/RenderSystem/Design/RHI.md
+++ b/Docs/Modules/RenderSystem/Design/RHI.md
@@ -1369,49 +1369,86 @@ This renderer code is backend-agnostic — no backend-specific types or calls ap
 
 ## 16. Recommended Implementation Order
 
-To reduce complexity and validate the architecture early, implementation should proceed in a vertical slice.
+To reduce complexity and validate the architecture early, implementation should proceed in **shared milestones**, not as three completely separate backend projects.
 
-### Phase 1: Core architecture
+### 16.1 Shared implementation policy
+
+- define and freeze the public RHI interface first
+- advance **Vulkan, Metal, and OpenGL together at the milestone level**
+- use **Vulkan as the reference backend** for semantics and edge-case resolution
+- allow Vulkan to land slightly ahead of the others inside a milestone, but do not let Metal/OpenGL drift across multiple milestones
+
+This is a lockstep strategy, not a Vulkan-only strategy. The goal is to keep one coherent public abstraction while ensuring every milestone is exercised by all three backends.
+
+### 16.2 Milestone 1: Public API and backend shells
 Implement:
 
-- Device
+- header-level RHI API draft
+- backend selection / factory plumbing
+- backend-private `Device`, `Swapchain`, and `CommandList` shells for Vulkan / Metal / OpenGL
+- `NativeWindowHandle` extraction boundary between the platform window layer and the RHI
+
+Exit criteria:
+
+- all three backends compile against the same public headers
+- all three backends can create a device and a swapchain-compatible presentation path
+
+### 16.3 Milestone 2: Clear and present on all backends
+Implement:
+
+- frame lifecycle (`acquireNextImage()` / `beginFrame()` / `beginCommandList()` / `submit()` / `present()`)
+- minimal render pass / dynamic rendering path sufficient to clear the backbuffer
+- resize handling
+
+Exit criteria:
+
+- the same "clear backbuffer and present" demo runs on Vulkan, Metal, and OpenGL
+
+### 16.4 Milestone 3: Core resources and graphics pipeline
+Implement:
+
 - Buffer
 - Texture
+- TextureView
 - Sampler
-- ShaderProgram
-- PipelineLayout
-- ResourceSet
 - VertexInputLayout
 - GraphicsPipeline
-- CommandList
 
-### Phase 2: Shader pipeline
+Exit criteria:
+
+- the same simple mesh draw path works on all three backends
+
+### 16.5 Milestone 4: Shader pipeline and binding model
 Implement:
 
 - Slang compilation
 - reflection extraction
 - neutral reflection conversion
+- `ShaderProgram`
+- `PipelineLayout`
+- `ResourceSet`
 - parameter writer
-- backend code generation
+- backend code generation / module creation
 
-### Phase 3: Vulkan first
-Implement the full Vulkan path first because it is the cleanest mapping to the public model.
+Exit criteria:
 
-### Phase 4: Metal
-Implement Metal direct-slot mode first.
+- one shader program with `Frame` / `Material` / `Object` parameter groups works on all three backends
 
-### Phase 5: OpenGL
-Implement OpenGL compatibility layer for the first supported shader subset.
-
-### Phase 6: Renderer demo
+### 16.6 Milestone 5: Minimal renderer demo
 Create a minimal renderer test:
+
 - textured mesh
 - camera
 - one material
 - multiple objects
 
-### Phase 7: Optional improvements
+Exit criteria:
+
+- identical renderer-side code path above the RHI boundary for all backends
+
+### 16.7 Optional improvements
 After first end-to-end success:
+
 - Metal argument buffers for material sets
 - shader hot reload
 - compute pipeline path
@@ -1482,5 +1519,7 @@ The next implementation artifacts after this document should be:
    - `MaterialParams`
    - `ObjectParams`
    - one unlit or PBR-lite shader
+4. a **platform window-handle extraction layer** that converts `GLFWwindow*` into `NativeWindowHandle`
+5. a **backend lockstep bring-up checklist** for the first clear/present milestone across Vulkan / Metal / OpenGL
 
-These three together will turn this design from architecture into a buildable skeleton.
+These artifacts together will turn this design from architecture into a buildable skeleton.

--- a/Docs/Modules/RenderSystem/Design/RHI_Backend_Vulkan.md
+++ b/Docs/Modules/RenderSystem/Design/RHI_Backend_Vulkan.md
@@ -205,12 +205,14 @@ The Vulkan backend implements the `CommandList::textureBarrier()` / `bufferBarri
 
 ## 7. Swapchain
 
-`Device::createSwapchain()` uses the `void* nativeWindowHandle` to create a `VkSurfaceKHR` via the appropriate platform extension:
+`Device::createSwapchain()` consumes `NativeWindowHandle` (see RHI.md §6.6) and uses it to create a `VkSurfaceKHR` via the appropriate platform extension:
 
-- **Windows**: `VK_KHR_win32_surface` — handle is a `HWND`
-- **macOS/iOS**: `VK_EXT_metal_surface` — handle is a `CAMetalLayer*`
-- **Linux (Xlib)**: `VK_KHR_xlib_surface` — handle encodes a `Display*` and an Xlib `Window`
-- **Linux (XCB)**: `VK_KHR_xcb_surface` — handle encodes an `xcb_connection_t*` and an `xcb_window_t`
+- **Windows**: `system = NativeWindowSystem::Win32`, `window = HWND`
+- **macOS/iOS**: `system = NativeWindowSystem::Cocoa`, `layer = CAMetalLayer*`, then create the surface with `VK_EXT_metal_surface`
+- **Linux (Xlib)**: `system = NativeWindowSystem::Xlib`, `display = Display*`, `window = X11 Window`
+- **Linux (XCB)**: `system = NativeWindowSystem::Xcb`, `display = xcb_connection_t*`, `window = xcb_window_t`
+
+The Vulkan backend should validate that the required fields are present for the selected `NativeWindowSystem` before attempting surface creation and fail loudly if the handle is incomplete.
 
 These are separate Vulkan extensions with separate `VkSurfaceKHR` creation paths (`vkCreateXlibSurfaceKHR` vs. `vkCreateXcbSurfaceKHR`). Choose one per platform layer; do not mix them.
 


### PR DESCRIPTION
## Summary
- Define a strongly typed `NativeWindowHandle` in the RHI design doc
- Replace the raw swapchain window-handle API with `Device::createSwapchain(const SwapchainDesc&, const NativeWindowHandle&)`
- Clarify that GLFW stays in the platform/window layer and should not leak into the public RHI API
- Update the implementation plan to milestone-based lockstep bring-up across Vulkan, Metal, and OpenGL
- Document the Vulkan-side mapping from `NativeWindowHandle` to surface creation inputs

## Why
- Settle the RHI/platform boundary before implementation starts
- Avoid coupling the public renderer API to `GLFWwindow*`
- Replace the ambiguous raw `void*` swapchain handle with a stronger, more explicit contract
- Make the multi-backend execution plan explicit: shared milestones, Vulkan as reference backend, no long-term drift between backends

## Affected areas
- `Docs/Modules/RenderSystem/Design/RHI.md`
- `Docs/Modules/RenderSystem/Design/RHI_Backend_Vulkan.md`

## Documentation
- [ ] No documentation needed
- [x] Documentation updated

## Testing
- Documentation-only change
- No code compiled
- No runtime testing performed

## Notes
- This PR records two architecture decisions:
- Use a strong `NativeWindowHandle` boundary instead of exposing `GLFWwindow*` in public RHI APIs
- Advance Vulkan, Metal, and OpenGL in lockstep by milestone, with Vulkan used as the semantic reference backend
