### PR TITLE
Add initial public RHI skeleton

### DIFF
--- a/CMake/Src/Sources.cmake
+++ b/CMake/Src/Sources.cmake
@@ -139,7 +139,9 @@ set(GLAB_SCENE_HEADERS
     Scene/Transform.h
 )
 
-set(GLAB_RENDER_SOURCES)
+set(GLAB_RENDER_SOURCES
+    Render/RHI/ResourceStateTracker.cpp
+)
 
 set(GLAB_RENDER_HEADERS
     Render/RHI/RHI.h

--- a/CMake/Src/Sources.cmake
+++ b/CMake/Src/Sources.cmake
@@ -139,6 +139,17 @@ set(GLAB_SCENE_HEADERS
     Scene/Transform.h
 )
 
+set(GLAB_RENDER_SOURCES)
+
+set(GLAB_RENDER_HEADERS
+    Render/RHI/RHI.h
+    Render/RHI/RHIResources.h
+    Render/RHI/RHIPipeline.h
+    Render/RHI/RHICommandList.h
+    Render/RHI/RHIDevice.h
+    Render/Shader/ShaderTypes.h
+)
+
 set(GLAB_DEMO_SOURCES
     Demos/DemoRegistry.cpp
     Demos/LabLayer.cpp
@@ -190,6 +201,7 @@ set(GLAB_CORE_SOURCES
     ${GLAB_DIAGNOSTICS_SOURCES}
     ${GLAB_SERIALIZATION_SOURCES}
     ${GLAB_SCENE_SOURCES}
+    ${GLAB_RENDER_SOURCES}
     ${GLAB_DEMO_SOURCES}
     ${GLAB_GUI_SOURCES}
     ${GLAB_PLATFORM_SOURCES}
@@ -202,6 +214,7 @@ set(GLAB_CORE_HEADERS
     ${GLAB_DIAGNOSTICS_HEADERS}
     ${GLAB_SERIALIZATION_HEADERS}
     ${GLAB_SCENE_HEADERS}
+    ${GLAB_RENDER_HEADERS}
     ${GLAB_DEMO_HEADERS}
     ${GLAB_GUI_HEADERS}
 )

--- a/Src/Render/RHI/RHI.h
+++ b/Src/Render/RHI/RHI.h
@@ -1,0 +1,9 @@
+#pragma once
+
+/// @file RHI.h
+/// @brief Umbrella include for the public RHI interface skeleton.
+
+#include "Render/RHI/RHIResources.h"
+#include "Render/RHI/RHIPipeline.h"
+#include "Render/RHI/RHICommandList.h"
+#include "Render/RHI/RHIDevice.h"

--- a/Src/Render/RHI/RHICommandList.h
+++ b/Src/Render/RHI/RHICommandList.h
@@ -1,0 +1,130 @@
+#pragma once
+
+/// @file RHICommandList.h
+/// @brief Public RHI command-recording and render-pass description types.
+
+#include <cstdint>
+#include <vector>
+
+#include "Render/RHI/RHIPipeline.h"
+
+enum class LoadOp
+{
+    Load,
+    Clear,
+    DontCare,
+};
+
+enum class StoreOp
+{
+    Store,
+    DontCare,
+};
+
+struct ClearColor
+{
+    float r = 0.0f;
+    float g = 0.0f;
+    float b = 0.0f;
+    float a = 1.0f;
+};
+
+struct ClearDepthStencil
+{
+    float depth = 1.0f;
+    uint8_t stencil = 0;
+};
+
+struct ColorAttachmentInfo
+{
+    TextureView *view = nullptr;
+    LoadOp loadOp = LoadOp::Load;
+    StoreOp storeOp = StoreOp::Store;
+    ClearColor clearValue;
+};
+
+struct DepthAttachmentInfo
+{
+    TextureView *view = nullptr;
+    LoadOp loadOp = LoadOp::Load;
+    StoreOp storeOp = StoreOp::Store;
+    ClearDepthStencil clearValue;
+};
+
+struct Rect2D
+{
+    int32_t x = 0;
+    int32_t y = 0;
+    uint32_t width = 0;
+    uint32_t height = 0;
+};
+
+struct RenderingInfo
+{
+    std::vector<ColorAttachmentInfo> colorAttachments;
+    DepthAttachmentInfo depthAttachment;
+    Rect2D renderArea;
+};
+
+enum class TextureState
+{
+    Undefined,
+    RenderTarget,
+    DepthStencil,
+    ShaderRead,
+    ShaderReadWrite,
+    CopySource,
+    CopyDest,
+    Present,
+};
+
+enum class BufferState
+{
+    Undefined,
+    VertexIndex,
+    UniformRead,
+    StorageRead,
+    StorageReadWrite,
+    CopySource,
+    CopyDest,
+    IndirectArgument,
+};
+
+class CommandList
+{
+public:
+    virtual ~CommandList() = default;
+
+    virtual void beginRendering(const RenderingInfo &renderingInfo) = 0;
+    virtual void endRendering() = 0;
+
+    virtual void bindGraphicsPipeline(GraphicsPipeline *pipeline) = 0;
+    virtual void bindComputePipeline(ComputePipeline *pipeline) = 0;
+
+    virtual void bindResourceSet(uint32_t setIndex, ResourceSet *resourceSet) = 0;
+    virtual void pushConstants(ShaderStage stageMask, uint32_t offset, uint32_t size, const void *data) = 0;
+
+    virtual void bindMesh(const MeshBinding &meshBinding, const uint64_t *vertexOffsets = nullptr) = 0;
+    virtual void bindVertexBuffers(uint32_t firstSlot, Buffer *const *buffers, uint32_t count, const uint64_t *offsets) = 0;
+    virtual void bindIndexBuffer(Buffer *buffer, uint64_t offset, IndexType indexType) = 0;
+
+    virtual void setViewport(float x, float y, float w, float h, float zmin, float zmax) = 0;
+    virtual void setScissor(int32_t x, int32_t y, uint32_t w, uint32_t h) = 0;
+
+    virtual void draw(uint32_t vertexCount, uint32_t firstVertex) = 0;
+    virtual void drawIndexed(uint32_t indexCount, uint32_t firstIndex, int32_t vertexOffset) = 0;
+
+    virtual void dispatch(uint32_t groupX, uint32_t groupY, uint32_t groupZ) = 0;
+
+    virtual void textureBarrier(Texture *texture, TextureState oldState, TextureState newState, ShaderStage srcStage, ShaderStage dstStage) = 0;
+    virtual void bufferBarrier(Buffer *buffer, BufferState oldState, BufferState newState, ShaderStage srcStage, ShaderStage dstStage) = 0;
+};
+
+class ResourceStateTracker
+{
+public:
+    void transition(Texture *texture, TextureState newState);
+    void transition(Buffer *buffer, BufferState newState);
+    void flushBarriers(CommandList *commandList);
+    void reset();
+};

--- a/Src/Render/RHI/RHICommandList.h
+++ b/Src/Render/RHI/RHICommandList.h
@@ -4,6 +4,7 @@
 /// @brief Public RHI command-recording and render-pass description types.
 
 #include <cstdint>
+#include <unordered_map>
 #include <vector>
 
 #include "Render/RHI/RHIPipeline.h"
@@ -127,4 +128,24 @@ public:
     void transition(Buffer *buffer, BufferState newState);
     void flushBarriers(CommandList *commandList);
     void reset();
+
+private:
+    struct PendingTextureTransition
+    {
+        Texture *texture = nullptr;
+        TextureState oldState = TextureState::Undefined;
+        TextureState newState = TextureState::Undefined;
+    };
+
+    struct PendingBufferTransition
+    {
+        Buffer *buffer = nullptr;
+        BufferState oldState = BufferState::Undefined;
+        BufferState newState = BufferState::Undefined;
+    };
+
+    std::unordered_map<Texture *, TextureState> m_TextureStates;
+    std::unordered_map<Buffer *, BufferState> m_BufferStates;
+    std::vector<PendingTextureTransition> m_PendingTextureTransitions;
+    std::vector<PendingBufferTransition> m_PendingBufferTransitions;
 };

--- a/Src/Render/RHI/RHIDevice.h
+++ b/Src/Render/RHI/RHIDevice.h
@@ -1,0 +1,40 @@
+#pragma once
+
+/// @file RHIDevice.h
+/// @brief Public RHI device and frame-lifetime interfaces.
+
+#include "Render/RHI/RHICommandList.h"
+
+class FrameContext
+{
+public:
+    virtual ~FrameContext() = default;
+};
+
+class Device
+{
+public:
+    virtual ~Device() = default;
+
+    virtual Scope<Swapchain> createSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle) = 0;
+
+    virtual Scope<Buffer> createBuffer(const BufferDesc &desc) = 0;
+    virtual Scope<Texture> createTexture(const TextureDesc &desc) = 0;
+    virtual Scope<TextureView> createTextureView(Texture *texture, const TextureViewDesc &desc) = 0;
+    virtual Scope<Sampler> createSampler(const SamplerDesc &desc) = 0;
+
+    virtual Scope<ShaderProgram> createShaderProgram(const CompiledShaderProgramDesc &desc) = 0;
+    virtual Scope<PipelineLayout> createPipelineLayout(const PipelineLayoutDesc &desc) = 0;
+    virtual Scope<ResourceSet> createResourceSet(PipelineLayout *layout, uint32_t setIndex) = 0;
+
+    virtual Scope<VertexInputLayout> createVertexInputLayout(const VertexInputLayoutDesc &desc) = 0;
+
+    virtual Scope<GraphicsPipeline> createGraphicsPipeline(const GraphicsPipelineDesc &desc) = 0;
+    virtual Scope<ComputePipeline> createComputePipeline(const ComputePipelineDesc &desc) = 0;
+
+    virtual CommandList *beginCommandList() = 0;
+    virtual void submit(CommandList *commandList) = 0;
+
+    virtual FrameContext *beginFrame() = 0;
+    virtual void endFrame(FrameContext *frameContext) = 0;
+};

--- a/Src/Render/RHI/RHIPipeline.h
+++ b/Src/Render/RHI/RHIPipeline.h
@@ -206,8 +206,6 @@ public:
 
     virtual const ShaderReflectionData &getReflection() const = 0;
     virtual PipelineLayoutDesc derivePipelineLayoutDesc() const = 0;
-    virtual const void *getBackendCode(BackendType backend, ShaderStage stage) const = 0;
-    virtual size_t getBackendCodeSize(BackendType backend, ShaderStage stage) const = 0;
 };
 
 class GraphicsPipeline

--- a/Src/Render/RHI/RHIPipeline.h
+++ b/Src/Render/RHI/RHIPipeline.h
@@ -1,0 +1,227 @@
+#pragma once
+
+/// @file RHIPipeline.h
+/// @brief Public RHI pipeline-layout, vertex-input, and pipeline object types.
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "Render/RHI/RHIResources.h"
+#include "Render/Shader/ShaderTypes.h"
+
+enum class ResourceKind
+{
+    UniformBuffer,
+    StorageBuffer,
+    SampledTexture,
+    StorageTexture,
+    Sampler,
+};
+
+struct BindingInfo
+{
+    std::string name;
+    uint32_t setIndex = 0;
+    uint32_t binding = 0;
+    ResourceKind kind = ResourceKind::UniformBuffer;
+    uint32_t arrayCount = 1;
+    ShaderStage stageMask = ShaderStage::None;
+};
+
+struct PipelineLayoutDesc
+{
+    std::vector<BindingInfo> bindings;
+    std::vector<PushConstantRangeDesc> pushConstants;
+};
+
+class PipelineLayout
+{
+public:
+    virtual ~PipelineLayout() = default;
+
+    virtual const PipelineLayoutDesc &getDesc() const = 0;
+};
+
+struct VertexAttributeDesc
+{
+    uint32_t location = 0;
+    Format format = Format::Unknown;
+    uint32_t offset = 0;
+    uint32_t bufferSlot = 0;
+};
+
+struct VertexBufferLayoutDesc
+{
+    uint32_t stride = 0;
+    bool perInstance = false;
+};
+
+struct VertexInputLayoutDesc
+{
+    std::vector<VertexAttributeDesc> attributes;
+    std::vector<VertexBufferLayoutDesc> buffers;
+};
+
+class VertexInputLayout
+{
+public:
+    virtual ~VertexInputLayout() = default;
+
+    virtual const VertexInputLayoutDesc &getDesc() const = 0;
+};
+
+enum class IndexType
+{
+    UInt16,
+    UInt32,
+};
+
+struct MeshBinding
+{
+    std::vector<Buffer *> vertexBuffers;
+    Buffer *indexBuffer = nullptr;
+    IndexType indexType = IndexType::UInt32;
+};
+
+enum class PrimitiveTopology
+{
+    TriangleList,
+    TriangleStrip,
+    LineList,
+    LineStrip,
+    PointList,
+};
+
+enum class CullMode
+{
+    None,
+    Front,
+    Back,
+};
+
+enum class FrontFace
+{
+    CW,
+    CCW,
+};
+
+enum class FillMode
+{
+    Solid,
+    Wireframe,
+};
+
+struct RasterState
+{
+    CullMode cullMode = CullMode::Back;
+    FrontFace frontFace = FrontFace::CCW;
+    FillMode fillMode = FillMode::Solid;
+    bool depthClampEnable = false;
+    bool depthBiasEnable = false;
+    float depthBiasConstant = 0.0f;
+    float depthBiasSlopeFactor = 0.0f;
+};
+
+enum class CompareOp
+{
+    Never,
+    Less,
+    Equal,
+    LessEqual,
+    Greater,
+    NotEqual,
+    GreaterEqual,
+    Always,
+};
+
+struct DepthStencilState
+{
+    bool depthTestEnable = false;
+    bool depthWriteEnable = false;
+    CompareOp depthCompareOp = CompareOp::Less;
+};
+
+enum class BlendFactor
+{
+    Zero,
+    One,
+    SrcColor,
+    OneMinusSrcColor,
+    DstColor,
+    OneMinusDstColor,
+    SrcAlpha,
+    OneMinusSrcAlpha,
+    DstAlpha,
+    OneMinusDstAlpha,
+};
+
+enum class BlendOp
+{
+    Add,
+    Subtract,
+    ReverseSubtract,
+    Min,
+    Max,
+};
+
+struct BlendState
+{
+    bool blendEnable = false;
+    BlendFactor srcColorFactor = BlendFactor::One;
+    BlendFactor dstColorFactor = BlendFactor::Zero;
+    BlendOp colorBlendOp = BlendOp::Add;
+    BlendFactor srcAlphaFactor = BlendFactor::One;
+    BlendFactor dstAlphaFactor = BlendFactor::Zero;
+    BlendOp alphaBlendOp = BlendOp::Add;
+    uint8_t colorWriteMask = 0xF;
+};
+
+struct GraphicsPipelineDesc
+{
+    PipelineLayout *pipelineLayout = nullptr;
+    class ShaderProgram *shaderProgram = nullptr;
+    VertexInputLayout *vertexInput = nullptr;
+
+    BlendState blendState;
+    DepthStencilState depthStencilState;
+    RasterState rasterState;
+    PrimitiveTopology topology = PrimitiveTopology::TriangleList;
+
+    std::vector<Format> colorFormats;
+    Format depthFormat = Format::Unknown;
+};
+
+struct ComputePipelineDesc
+{
+    PipelineLayout *pipelineLayout = nullptr;
+    class ShaderProgram *shaderProgram = nullptr;
+};
+
+class ShaderProgram
+{
+public:
+    virtual ~ShaderProgram() = default;
+
+    virtual const ShaderReflectionData &getReflection() const = 0;
+    virtual PipelineLayoutDesc derivePipelineLayoutDesc() const = 0;
+    virtual const void *getBackendCode(BackendType backend, ShaderStage stage) const = 0;
+    virtual size_t getBackendCodeSize(BackendType backend, ShaderStage stage) const = 0;
+};
+
+class GraphicsPipeline
+{
+public:
+    virtual ~GraphicsPipeline() = default;
+
+    virtual const GraphicsPipelineDesc &getDesc() const = 0;
+};
+
+class ComputePipeline
+{
+public:
+    virtual ~ComputePipeline() = default;
+
+    virtual const ComputePipelineDesc &getDesc() const = 0;
+};

--- a/Src/Render/RHI/RHIResources.h
+++ b/Src/Render/RHI/RHIResources.h
@@ -1,0 +1,348 @@
+#pragma once
+
+/// @file RHIResources.h
+/// @brief Public RHI resource types, swapchain types, and resource-set value types.
+
+#include <cfloat>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "Core/Util/Base.h"
+
+class PipelineLayout;
+
+enum class Format
+{
+    Unknown,
+
+    R8_UNORM,
+    RG8_UNORM,
+    RGBA8_UNORM,
+    RGBA8_SRGB,
+    BGRA8_UNORM,
+    BGRA8_SRGB,
+
+    R16F,
+    RG16F,
+    RGBA16F,
+
+    R32F,
+    RG32F,
+    RGBA32F,
+
+    R32_UINT,
+
+    D16_UNORM,
+    D32_SFLOAT,
+    D24_UNORM_S8_UINT,
+    D32_SFLOAT_S8_UINT,
+};
+
+enum class BufferUsage : uint32_t
+{
+    None     = 0,
+    Vertex   = BIT(0),
+    Index    = BIT(1),
+    Uniform  = BIT(2),
+    Storage  = BIT(3),
+    CopySrc  = BIT(4),
+    CopyDst  = BIT(5),
+    Indirect = BIT(6),
+};
+
+constexpr BufferUsage operator|(BufferUsage lhs, BufferUsage rhs)
+{
+    return static_cast<BufferUsage>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+}
+
+constexpr BufferUsage operator&(BufferUsage lhs, BufferUsage rhs)
+{
+    return static_cast<BufferUsage>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
+}
+
+constexpr BufferUsage &operator|=(BufferUsage &lhs, BufferUsage rhs)
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+enum class MemoryUsage
+{
+    GpuOnly,
+    CpuToGpu,
+    GpuToCpu,
+};
+
+struct BufferDesc
+{
+    uint64_t size = 0;
+    BufferUsage usageMask = BufferUsage::None;
+    MemoryUsage memoryUsage = MemoryUsage::GpuOnly;
+    const char *debugName = nullptr;
+};
+
+class Buffer
+{
+public:
+    virtual ~Buffer() = default;
+
+    virtual const BufferDesc &getDesc() const = 0;
+};
+
+enum class TextureType
+{
+    Tex2D,
+    Tex2DArray,
+    Tex3D,
+    Cube,
+};
+
+enum class TextureUsage : uint32_t
+{
+    None         = 0,
+    Sampled      = BIT(0),
+    Storage      = BIT(1),
+    RenderTarget = BIT(2),
+    DepthStencil = BIT(3),
+    CopySrc      = BIT(4),
+    CopyDst      = BIT(5),
+};
+
+constexpr TextureUsage operator|(TextureUsage lhs, TextureUsage rhs)
+{
+    return static_cast<TextureUsage>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+}
+
+constexpr TextureUsage operator&(TextureUsage lhs, TextureUsage rhs)
+{
+    return static_cast<TextureUsage>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
+}
+
+constexpr TextureUsage &operator|=(TextureUsage &lhs, TextureUsage rhs)
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+struct Extent3D
+{
+    uint32_t width = 1;
+    uint32_t height = 1;
+    uint32_t depth = 1;
+};
+
+struct TextureDesc
+{
+    TextureType type = TextureType::Tex2D;
+    Format format = Format::Unknown;
+    Extent3D extent;
+    uint32_t mipLevels = 1;
+    uint32_t arrayLayers = 1;
+    TextureUsage usageMask = TextureUsage::None;
+    const char *debugName = nullptr;
+};
+
+class Texture
+{
+public:
+    virtual ~Texture() = default;
+
+    virtual const TextureDesc &getDesc() const = 0;
+};
+
+enum class FilterMode
+{
+    Nearest,
+    Linear,
+};
+
+enum class MipFilterMode
+{
+    None,
+    Nearest,
+    Linear,
+};
+
+enum class AddressMode
+{
+    Repeat,
+    MirroredRepeat,
+    ClampToEdge,
+    ClampToBorder,
+};
+
+struct SamplerDesc
+{
+    FilterMode minFilter = FilterMode::Linear;
+    FilterMode magFilter = FilterMode::Linear;
+    MipFilterMode mipFilter = MipFilterMode::Linear;
+    AddressMode addressU = AddressMode::Repeat;
+    AddressMode addressV = AddressMode::Repeat;
+    AddressMode addressW = AddressMode::Repeat;
+    float minLod = 0.0f;
+    float maxLod = FLT_MAX;
+    float mipLodBias = 0.0f;
+    bool anisotropyEnable = false;
+    float maxAnisotropy = 1.0f;
+};
+
+class Sampler
+{
+public:
+    virtual ~Sampler() = default;
+
+    virtual const SamplerDesc &getDesc() const = 0;
+};
+
+enum class TextureAspect : uint32_t
+{
+    None    = 0,
+    Color   = BIT(0),
+    Depth   = BIT(1),
+    Stencil = BIT(2),
+};
+
+constexpr TextureAspect operator|(TextureAspect lhs, TextureAspect rhs)
+{
+    return static_cast<TextureAspect>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+}
+
+constexpr TextureAspect operator&(TextureAspect lhs, TextureAspect rhs)
+{
+    return static_cast<TextureAspect>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
+}
+
+constexpr TextureAspect &operator|=(TextureAspect &lhs, TextureAspect rhs)
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+struct TextureViewDesc
+{
+    TextureType type = TextureType::Tex2D;
+    Format format = Format::Unknown;
+    TextureAspect aspect = TextureAspect::Color;
+    uint32_t baseMipLevel = 0;
+    uint32_t mipLevelCount = 1;
+    uint32_t baseArrayLayer = 0;
+    uint32_t arrayLayerCount = 1;
+};
+
+class TextureView
+{
+public:
+    virtual ~TextureView() = default;
+
+    virtual Texture *getTexture() const = 0;
+    virtual const TextureViewDesc &getDesc() const = 0;
+};
+
+enum class NativeWindowSystem
+{
+    Win32,
+    Cocoa,
+    Xlib,
+    Xcb,
+    Wayland,
+};
+
+struct NativeWindowHandle
+{
+    NativeWindowSystem system = NativeWindowSystem::Win32;
+    uintptr_t window = 0;
+    void *display = nullptr;
+    void *layer = nullptr;
+};
+
+struct SwapchainDesc
+{
+    uint32_t width = 0;
+    uint32_t height = 0;
+    Format format = Format::BGRA8_UNORM;
+    uint32_t imageCount = 2;
+    bool vsync = true;
+};
+
+class Swapchain
+{
+public:
+    virtual ~Swapchain() = default;
+
+    virtual uint32_t acquireNextImage() = 0;
+    virtual Texture *getImage(uint32_t imageIndex) const = 0;
+    virtual TextureView *getImageView(uint32_t imageIndex) const = 0;
+    virtual void present(uint32_t imageIndex) = 0;
+    virtual void resize(uint32_t newWidth, uint32_t newHeight) = 0;
+    virtual uint32_t width() const = 0;
+    virtual uint32_t height() const = 0;
+    virtual Format format() const = 0;
+    virtual uint32_t imageCount() const = 0;
+};
+
+class ParameterBlockData
+{
+public:
+    void setRaw(uint32_t offset, const void *data, size_t size)
+    {
+        if (size == 0)
+            return;
+
+        if (offset + size > m_Data.size())
+            m_Data.resize(offset + size);
+
+        std::memcpy(m_Data.data() + offset, data, size);
+    }
+
+    template <typename T>
+    void set(uint32_t offset, const T &value)
+    {
+        setRaw(offset, &value, sizeof(T));
+    }
+
+    const void *data() const { return m_Data.empty() ? nullptr : m_Data.data(); }
+    size_t size() const { return m_Data.size(); }
+    void resize(size_t bytes) { m_Data.resize(bytes); }
+
+private:
+    std::vector<uint8_t> m_Data;
+};
+
+struct BufferBinding
+{
+    Buffer *buffer = nullptr;
+    uint64_t offset = 0;
+    uint64_t size = 0;
+};
+
+struct TextureBinding
+{
+    Texture *texture = nullptr;
+    TextureView *view = nullptr;
+};
+
+struct SamplerBinding
+{
+    Sampler *sampler = nullptr;
+};
+
+class ResourceSet
+{
+public:
+    virtual ~ResourceSet() = default;
+
+    virtual PipelineLayout *getLayout() const = 0;
+    virtual uint32_t getSetIndex() const = 0;
+
+    virtual ParameterBlockData &constants() = 0;
+    virtual const ParameterBlockData &constants() const = 0;
+
+    virtual void setBuffer(uint32_t binding, const BufferBinding &bufferBinding) = 0;
+    virtual void setTexture(uint32_t binding, const TextureBinding &textureBinding) = 0;
+    virtual void setSampler(uint32_t binding, const SamplerBinding &samplerBinding) = 0;
+
+    virtual uint32_t version() const = 0;
+};

--- a/Src/Render/RHI/ResourceStateTracker.cpp
+++ b/Src/Render/RHI/ResourceStateTracker.cpp
@@ -1,0 +1,103 @@
+#include "Render/RHI/RHICommandList.h"
+
+namespace
+{
+    // ResourceStateTracker is intentionally conservative at v1: without pass-level
+    // usage metadata yet, barriers are emitted with an all-stages mask.
+    constexpr ShaderStage kBarrierStageMask = ShaderStage::All;
+}
+
+void ResourceStateTracker::transition(Texture *texture, TextureState newState)
+{
+    if (texture == nullptr)
+        return;
+
+    const auto currentStateIt = m_TextureStates.find(texture);
+    const TextureState currentState = currentStateIt == m_TextureStates.end()
+        ? TextureState::Undefined
+        : currentStateIt->second;
+
+    if (currentState == newState)
+        return;
+
+    for (auto &pending : m_PendingTextureTransitions)
+    {
+        if (pending.texture == texture)
+        {
+            pending.newState = newState;
+            m_TextureStates[texture] = newState;
+            return;
+        }
+    }
+
+    m_PendingTextureTransitions.push_back({texture, currentState, newState});
+    m_TextureStates[texture] = newState;
+}
+
+void ResourceStateTracker::transition(Buffer *buffer, BufferState newState)
+{
+    if (buffer == nullptr)
+        return;
+
+    const auto currentStateIt = m_BufferStates.find(buffer);
+    const BufferState currentState = currentStateIt == m_BufferStates.end()
+        ? BufferState::Undefined
+        : currentStateIt->second;
+
+    if (currentState == newState)
+        return;
+
+    for (auto &pending : m_PendingBufferTransitions)
+    {
+        if (pending.buffer == buffer)
+        {
+            pending.newState = newState;
+            m_BufferStates[buffer] = newState;
+            return;
+        }
+    }
+
+    m_PendingBufferTransitions.push_back({buffer, currentState, newState});
+    m_BufferStates[buffer] = newState;
+}
+
+void ResourceStateTracker::flushBarriers(CommandList *commandList)
+{
+    if (commandList == nullptr)
+    {
+        m_PendingTextureTransitions.clear();
+        m_PendingBufferTransitions.clear();
+        return;
+    }
+
+    for (const auto &pending : m_PendingTextureTransitions)
+    {
+        commandList->textureBarrier(
+            pending.texture,
+            pending.oldState,
+            pending.newState,
+            kBarrierStageMask,
+            kBarrierStageMask);
+    }
+
+    for (const auto &pending : m_PendingBufferTransitions)
+    {
+        commandList->bufferBarrier(
+            pending.buffer,
+            pending.oldState,
+            pending.newState,
+            kBarrierStageMask,
+            kBarrierStageMask);
+    }
+
+    m_PendingTextureTransitions.clear();
+    m_PendingBufferTransitions.clear();
+}
+
+void ResourceStateTracker::reset()
+{
+    m_TextureStates.clear();
+    m_BufferStates.clear();
+    m_PendingTextureTransitions.clear();
+    m_PendingBufferTransitions.clear();
+}

--- a/Src/Render/Shader/ShaderTypes.h
+++ b/Src/Render/Shader/ShaderTypes.h
@@ -1,0 +1,126 @@
+#pragma once
+
+/// @file ShaderTypes.h
+/// @brief Public shader-system boundary types shared with the RHI.
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "Core/Util/Base.h"
+
+enum class BackendType
+{
+    Vulkan,
+    Metal,
+    OpenGL,
+};
+
+enum class ShaderStage : uint32_t
+{
+    None     = 0,
+    Vertex   = BIT(0),
+    Fragment = BIT(1),
+    Compute  = BIT(2),
+    All      = BIT(0) | BIT(1) | BIT(2),
+};
+
+constexpr ShaderStage operator|(ShaderStage lhs, ShaderStage rhs)
+{
+    return static_cast<ShaderStage>(static_cast<uint32_t>(lhs) | static_cast<uint32_t>(rhs));
+}
+
+constexpr ShaderStage operator&(ShaderStage lhs, ShaderStage rhs)
+{
+    return static_cast<ShaderStage>(static_cast<uint32_t>(lhs) & static_cast<uint32_t>(rhs));
+}
+
+constexpr ShaderStage &operator|=(ShaderStage &lhs, ShaderStage rhs)
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+struct ShaderEntryPointDesc
+{
+    std::string moduleName;
+    std::string entryName;
+    ShaderStage stage = ShaderStage::None;
+};
+
+struct ShaderSourceDesc
+{
+    std::vector<ShaderEntryPointDesc> entries;
+    std::vector<std::string> defines;
+};
+
+enum class MetalCodeFormat
+{
+    MslSource,
+    Metallib,
+};
+
+enum class ReflectedTypeKind
+{
+    Struct,
+    ConstantData,
+    Texture,
+    Sampler,
+    Buffer,
+    ParameterBlock,
+};
+
+enum class LayoutConvention
+{
+    Std430,
+    Std140,
+    Scalar,
+};
+
+struct ReflectedField
+{
+    std::string name;
+    ReflectedTypeKind typeKind = ReflectedTypeKind::Struct;
+
+    uint32_t offset = 0;
+    uint32_t size = 0;
+    uint32_t alignment = 0;
+    uint32_t arrayStride = 0;
+    uint32_t matrixStride = 0;
+    LayoutConvention layoutConvention = LayoutConvention::Std430;
+
+    uint32_t setIndex = 0;
+    uint32_t binding = 0;
+    uint32_t arrayCount = 1;
+    ShaderStage stageMask = ShaderStage::None;
+
+    std::vector<ReflectedField> children;
+};
+
+struct PushConstantRangeDesc
+{
+    ShaderStage stageMask = ShaderStage::None;
+    uint32_t offset = 0;
+    uint32_t size = 0;
+};
+
+struct ShaderReflectionData
+{
+    std::vector<ReflectedField> globals;
+    std::vector<PushConstantRangeDesc> pushConstants;
+};
+
+struct CompiledShaderBlob
+{
+    BackendType backend = BackendType::Vulkan;
+    ShaderStage stage = ShaderStage::None;
+    std::vector<uint8_t> code;
+    MetalCodeFormat metalCodeFormat = MetalCodeFormat::MslSource;
+};
+
+struct CompiledShaderProgramDesc
+{
+    std::vector<CompiledShaderBlob> blobs;
+    ShaderReflectionData reflection;
+};


### PR DESCRIPTION
## Summary
- Add the initial public RHI skeleton under `Src/Render`
- Introduce the first shared shader/RHI boundary types under `Src/Render/Shader`
- Add public RHI headers for resources, pipelines, command recording, and device/frame interfaces
- Add a minimal concrete `ResourceStateTracker` implementation
- Wire the new Render headers/source into `CMake/Src/Sources.cmake`

## Why
- Establish the first code-level public RHI surface before backend implementation starts
- Give Vulkan, Metal, and OpenGL a shared interface target for lockstep bring-up
- Make the RHI/shader boundary explicit instead of letting backend-specific needs leak into ad hoc interfaces

## Affected areas
- `Src/Render/RHI`
- `Src/Render/Shader`
- `CMake/Src/Sources.cmake`

## Documentation
- [ ] No documentation needed
- [x] Documentation updated

## Testing
- Headers/source skeleton added and wired into CMake
- `ResourceStateTracker` link gap was closed with a concrete implementation

## Notes
- `ResourceStateTracker` currently uses a conservative `ShaderStage::All` barrier mask as a v1 interim implementation
- Follow-up work will connect the platform window layer to the RHI via `NativeWindowHandle`
