### PR TITLE
Connect Window to the RHI NativeWindowHandle boundary

### DIFF
--- a/CMake/Src/Core.cmake
+++ b/CMake/Src/Core.cmake
@@ -10,6 +10,18 @@ target_include_directories(RTRLabCore PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+set_source_files_properties(
+    ${CMAKE_CURRENT_SOURCE_DIR}/Core/App/Window.cpp
+    PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+)
+
+if(APPLE)
+    set_source_files_properties(
+        ${CMAKE_CURRENT_SOURCE_DIR}/Core/App/CocoaNativeWindow.mm
+        PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+    )
+endif()
+
 target_link_libraries(RTRLabCore PUBLIC
     glfw
     glm
@@ -44,9 +56,15 @@ if(GLAB_BACKEND_OPENGL)
 
     set_source_files_properties(
         ${CMAKE_CURRENT_SOURCE_DIR}/Core/App/Application.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/Core/App/Window.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/Core/Input/Input.cpp
         PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+    )
+endif()
+
+if(APPLE)
+    target_link_libraries(RTRLabCore PUBLIC
+        "-framework AppKit"
+        "-framework QuartzCore"
     )
 endif()
 
@@ -61,9 +79,7 @@ if(GLAB_BACKEND_METAL)
     )
 
     target_link_libraries(RTRLabCore PUBLIC
-        "-framework AppKit"
         "-framework Metal"
-        "-framework QuartzCore"
     )
 
     target_compile_definitions(RTRLabCore PUBLIC
@@ -75,6 +91,20 @@ if(GLAB_BACKEND_VULKAN)
     target_compile_definitions(RTRLabCore PUBLIC
         GLAB_BACKEND_VULKAN
     )
+endif()
+
+if(UNIX AND NOT APPLE)
+    if(GLFW_BUILD_WAYLAND)
+        target_compile_definitions(RTRLabCore PRIVATE
+            GLAB_GLFW_WAYLAND_NATIVE
+        )
+    endif()
+
+    if(GLFW_BUILD_X11)
+        target_compile_definitions(RTRLabCore PRIVATE
+            GLAB_GLFW_X11_NATIVE
+        )
+    endif()
 endif()
 
 target_compile_definitions(RTRLabCore PUBLIC

--- a/CMake/Src/Core.cmake
+++ b/CMake/Src/Core.cmake
@@ -22,6 +22,13 @@ if(APPLE)
     )
 endif()
 
+if(UNIX AND NOT APPLE)
+    set_source_files_properties(
+        ${CMAKE_CURRENT_SOURCE_DIR}/Core/App/LinuxNativeWindow.cpp
+        PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+    )
+endif()
+
 target_link_libraries(RTRLabCore PUBLIC
     glfw
     glm

--- a/CMake/Src/Sources.cmake
+++ b/CMake/Src/Sources.cmake
@@ -33,6 +33,16 @@ if(APPLE)
     )
 endif()
 
+if(UNIX AND NOT APPLE)
+    list(APPEND GLAB_APP_SOURCES
+        Core/App/LinuxNativeWindow.cpp
+    )
+
+    list(APPEND GLAB_APP_HEADERS
+        Core/App/LinuxNativeWindow.h
+    )
+endif()
+
 set(GLAB_RESOURCE_SOURCES
     Core/Resource/Cook/CookedCatalog.cpp
     Core/Resource/FileSystem.cpp

--- a/CMake/Src/Sources.cmake
+++ b/CMake/Src/Sources.cmake
@@ -23,6 +23,16 @@ set(GLAB_APP_HEADERS
     Core/Event/ScopedConnection.h
 )
 
+if(APPLE)
+    list(APPEND GLAB_APP_SOURCES
+        Core/App/CocoaNativeWindow.mm
+    )
+
+    list(APPEND GLAB_APP_HEADERS
+        Core/App/CocoaNativeWindow.h
+    )
+endif()
+
 set(GLAB_RESOURCE_SOURCES
     Core/Resource/Cook/CookedCatalog.cpp
     Core/Resource/FileSystem.cpp
@@ -144,6 +154,7 @@ set(GLAB_RENDER_SOURCES
 )
 
 set(GLAB_RENDER_HEADERS
+    Render/RHI/NativeWindowHandle.h
     Render/RHI/RHI.h
     Render/RHI/RHIResources.h
     Render/RHI/RHIPipeline.h

--- a/Src/Core/App/CocoaNativeWindow.h
+++ b/Src/Core/App/CocoaNativeWindow.h
@@ -1,0 +1,10 @@
+#pragma once
+
+/// @file CocoaNativeWindow.h
+/// @brief Apple-specific helper for extracting a NativeWindowHandle from GLFW.
+
+#include "Render/RHI/NativeWindowHandle.h"
+
+struct GLFWwindow;
+
+NativeWindowHandle CreateCocoaNativeWindowHandle(GLFWwindow *window);

--- a/Src/Core/App/CocoaNativeWindow.mm
+++ b/Src/Core/App/CocoaNativeWindow.mm
@@ -1,0 +1,52 @@
+#include "Core/App/CocoaNativeWindow.h"
+
+#define GLFW_EXPOSE_NATIVE_COCOA
+#include <GLFW/glfw3.h>
+#include <GLFW/glfw3native.h>
+
+#import <AppKit/AppKit.h>
+#import <QuartzCore/CAMetalLayer.h>
+
+NativeWindowHandle CreateCocoaNativeWindowHandle(GLFWwindow *window)
+{
+    NativeWindowHandle nativeWindowHandle{};
+    nativeWindowHandle.system = NativeWindowSystem::Cocoa;
+
+    NSWindow *nsWindow = glfwGetCocoaWindow(window);
+    NSView *nsView = glfwGetCocoaView(window);
+
+    nativeWindowHandle.window = reinterpret_cast<uintptr_t>((__bridge void *)nsWindow);
+
+#if defined(GLAB_BACKEND_METAL) || defined(GLAB_BACKEND_VULKAN)
+    // Layer creation is best-effort here. If GLFW/Cocoa does not currently expose
+    // a valid NSView, the returned layer may remain null and the RHI consumer must
+    // validate the handle before attempting swapchain creation.
+    CAMetalLayer *layer = nil;
+
+    if (nsView != nil)
+    {
+        if ([nsView.layer isKindOfClass:[CAMetalLayer class]])
+        {
+            layer = static_cast<CAMetalLayer *>(nsView.layer);
+        }
+        else
+        {
+            layer = [CAMetalLayer layer];
+            nsView.wantsLayer = YES;
+            nsView.layer = layer;
+        }
+
+        const CGFloat scale = nsWindow != nil ? nsWindow.backingScaleFactor : 1.0;
+        layer.contentsScale = scale;
+
+        CGSize drawableSize = nsView.bounds.size;
+        drawableSize.width *= scale;
+        drawableSize.height *= scale;
+        layer.drawableSize = drawableSize;
+    }
+
+    nativeWindowHandle.layer = (__bridge void *)layer;
+#endif
+
+    return nativeWindowHandle;
+}

--- a/Src/Core/App/LinuxNativeWindow.cpp
+++ b/Src/Core/App/LinuxNativeWindow.cpp
@@ -1,0 +1,45 @@
+#include "Core/App/LinuxNativeWindow.h"
+
+#if defined(GLAB_GLFW_WAYLAND_NATIVE)
+#define GLFW_EXPOSE_NATIVE_WAYLAND
+#endif
+
+#if defined(GLAB_GLFW_X11_NATIVE)
+#define GLFW_EXPOSE_NATIVE_X11
+#endif
+
+#include <GLFW/glfw3.h>
+#include <GLFW/glfw3native.h>
+
+#include "Core/Diagnostics/Assert/Assert.h"
+
+NativeWindowHandle CreateLinuxNativeWindowHandle(GLFWwindow *window)
+{
+    RTRLAB_ASSERT_MSG(window != nullptr, "GLFW window is null.");
+
+    NativeWindowHandle nativeWindowHandle{};
+    const int platform = glfwGetPlatform();
+
+#if defined(GLAB_GLFW_WAYLAND_NATIVE)
+    if (platform == GLFW_PLATFORM_WAYLAND)
+    {
+        nativeWindowHandle.system = NativeWindowSystem::Wayland;
+        nativeWindowHandle.window = reinterpret_cast<uintptr_t>(glfwGetWaylandWindow(window));
+        nativeWindowHandle.display = glfwGetWaylandDisplay();
+        return nativeWindowHandle;
+    }
+#endif
+
+#if defined(GLAB_GLFW_X11_NATIVE)
+    if (platform == GLFW_PLATFORM_X11)
+    {
+        nativeWindowHandle.system = NativeWindowSystem::Xlib;
+        nativeWindowHandle.window = static_cast<uintptr_t>(glfwGetX11Window(window));
+        nativeWindowHandle.display = glfwGetX11Display();
+        return nativeWindowHandle;
+    }
+#endif
+
+    RTRLAB_ASSERT_MSG(false, "Unsupported GLFW native platform.");
+    return nativeWindowHandle;
+}

--- a/Src/Core/App/LinuxNativeWindow.h
+++ b/Src/Core/App/LinuxNativeWindow.h
@@ -1,0 +1,10 @@
+#pragma once
+
+/// @file LinuxNativeWindow.h
+/// @brief Linux-specific helper for extracting a NativeWindowHandle from GLFW.
+
+#include "Render/RHI/NativeWindowHandle.h"
+
+struct GLFWwindow;
+
+NativeWindowHandle CreateLinuxNativeWindowHandle(GLFWwindow *window);

--- a/Src/Core/App/Window.cpp
+++ b/Src/Core/App/Window.cpp
@@ -2,25 +2,20 @@
 
 #if defined(_WIN32)
 #define GLFW_EXPOSE_NATIVE_WIN32
-#elif defined(__APPLE__)
-#define GLFW_EXPOSE_NATIVE_COCOA
-#elif defined(__linux__)
-#if defined(GLAB_GLFW_WAYLAND_NATIVE)
-#define GLFW_EXPOSE_NATIVE_WAYLAND
-#endif
-#if defined(GLAB_GLFW_X11_NATIVE)
-#define GLFW_EXPOSE_NATIVE_X11
-#endif
 #endif
 
 #if defined(GLAB_BACKEND_OPENGL)
 #include <glad/glad.h>
 #endif
 #include <GLFW/glfw3.h>
+#if defined(_WIN32)
 #include <GLFW/glfw3native.h>
+#endif
 
 #if defined(__APPLE__)
 #include "Core/App/CocoaNativeWindow.h"
+#elif defined(__linux__)
+#include "Core/App/LinuxNativeWindow.h"
 #endif
 #include "Core/Diagnostics/Assert/Assert.h"
 #include "Core/Event/EventBus.h"
@@ -199,31 +194,7 @@ NativeWindowHandle Window::GetNativeWindowHandle() const
 #elif defined(__APPLE__)
     return CreateCocoaNativeWindowHandle(m_Handle);
 #elif defined(__linux__)
-    NativeWindowHandle nativeWindowHandle{};
-    const int platform = glfwGetPlatform();
-
-#if defined(GLAB_GLFW_WAYLAND_NATIVE)
-    if (platform == GLFW_PLATFORM_WAYLAND)
-    {
-        nativeWindowHandle.system = NativeWindowSystem::Wayland;
-        nativeWindowHandle.window = reinterpret_cast<uintptr_t>(glfwGetWaylandWindow(m_Handle));
-        nativeWindowHandle.display = glfwGetWaylandDisplay();
-        return nativeWindowHandle;
-    }
-#endif
-
-#if defined(GLAB_GLFW_X11_NATIVE)
-    if (platform == GLFW_PLATFORM_X11)
-    {
-        nativeWindowHandle.system = NativeWindowSystem::Xlib;
-        nativeWindowHandle.window = static_cast<uintptr_t>(glfwGetX11Window(m_Handle));
-        nativeWindowHandle.display = glfwGetX11Display();
-        return nativeWindowHandle;
-    }
-#endif
-
-    RTRLAB_ASSERT_MSG(false, "Unsupported GLFW native platform.");
-    return nativeWindowHandle;
+    return CreateLinuxNativeWindowHandle(m_Handle);
 #else
 #error Unsupported platform
 #endif

--- a/Src/Core/App/Window.cpp
+++ b/Src/Core/App/Window.cpp
@@ -1,10 +1,27 @@
 #include "Core/App/Window.h"
 
+#if defined(_WIN32)
+#define GLFW_EXPOSE_NATIVE_WIN32
+#elif defined(__APPLE__)
+#define GLFW_EXPOSE_NATIVE_COCOA
+#elif defined(__linux__)
+#if defined(GLAB_GLFW_WAYLAND_NATIVE)
+#define GLFW_EXPOSE_NATIVE_WAYLAND
+#endif
+#if defined(GLAB_GLFW_X11_NATIVE)
+#define GLFW_EXPOSE_NATIVE_X11
+#endif
+#endif
+
 #if defined(GLAB_BACKEND_OPENGL)
 #include <glad/glad.h>
 #endif
 #include <GLFW/glfw3.h>
+#include <GLFW/glfw3native.h>
 
+#if defined(__APPLE__)
+#include "Core/App/CocoaNativeWindow.h"
+#endif
 #include "Core/Diagnostics/Assert/Assert.h"
 #include "Core/Event/EventBus.h"
 #include "Core/Event/Events.h"
@@ -168,6 +185,48 @@ void Window::SwapBuffers()
 bool Window::ShouldClose() const
 {
     return glfwWindowShouldClose(m_Handle) != 0;
+}
+
+NativeWindowHandle Window::GetNativeWindowHandle() const
+{
+    RTRLAB_ASSERT_MSG(m_Handle != nullptr, "Window handle is null.");
+
+#if defined(_WIN32)
+    NativeWindowHandle nativeWindowHandle{};
+    nativeWindowHandle.system = NativeWindowSystem::Win32;
+    nativeWindowHandle.window = reinterpret_cast<uintptr_t>(glfwGetWin32Window(m_Handle));
+    return nativeWindowHandle;
+#elif defined(__APPLE__)
+    return CreateCocoaNativeWindowHandle(m_Handle);
+#elif defined(__linux__)
+    NativeWindowHandle nativeWindowHandle{};
+    const int platform = glfwGetPlatform();
+
+#if defined(GLAB_GLFW_WAYLAND_NATIVE)
+    if (platform == GLFW_PLATFORM_WAYLAND)
+    {
+        nativeWindowHandle.system = NativeWindowSystem::Wayland;
+        nativeWindowHandle.window = reinterpret_cast<uintptr_t>(glfwGetWaylandWindow(m_Handle));
+        nativeWindowHandle.display = glfwGetWaylandDisplay();
+        return nativeWindowHandle;
+    }
+#endif
+
+#if defined(GLAB_GLFW_X11_NATIVE)
+    if (platform == GLFW_PLATFORM_X11)
+    {
+        nativeWindowHandle.system = NativeWindowSystem::Xlib;
+        nativeWindowHandle.window = static_cast<uintptr_t>(glfwGetX11Window(m_Handle));
+        nativeWindowHandle.display = glfwGetX11Display();
+        return nativeWindowHandle;
+    }
+#endif
+
+    RTRLAB_ASSERT_MSG(false, "Unsupported GLFW native platform.");
+    return nativeWindowHandle;
+#else
+#error Unsupported platform
+#endif
 }
 
 void Window::SetVSync(bool enabled)

--- a/Src/Core/App/Window.h
+++ b/Src/Core/App/Window.h
@@ -16,6 +16,8 @@
 #include <functional>
 #include <cstdint>
 
+#include "Render/RHI/NativeWindowHandle.h"
+
 struct GLFWwindow;
 class EventBus;
 
@@ -53,6 +55,8 @@ public:
 
     /// Return the underlying GLFW window pointer (needed by Input, ImGui, etc.).
     GLFWwindow *GetNativeHandle() const { return m_Handle; }
+    /// Return the platform-native presentation handle package for the RHI.
+    NativeWindowHandle GetNativeWindowHandle() const;
 
     /// Register a callback invoked when the window needs to be redrawn
     /// (e.g., during live resize on macOS).

--- a/Src/Render/RHI/NativeWindowHandle.h
+++ b/Src/Render/RHI/NativeWindowHandle.h
@@ -1,0 +1,23 @@
+#pragma once
+
+/// @file NativeWindowHandle.h
+/// @brief Small platform-native window handle package consumed by the RHI.
+
+#include <cstdint>
+
+enum class NativeWindowSystem
+{
+    Win32,
+    Cocoa,
+    Xlib,
+    Xcb,
+    Wayland,
+};
+
+struct NativeWindowHandle
+{
+    NativeWindowSystem system = NativeWindowSystem::Win32;
+    uintptr_t window = 0;
+    void *display = nullptr;
+    void *layer = nullptr;
+};

--- a/Src/Render/RHI/RHI.h
+++ b/Src/Render/RHI/RHI.h
@@ -3,6 +3,7 @@
 /// @file RHI.h
 /// @brief Umbrella include for the public RHI interface skeleton.
 
+#include "Render/RHI/NativeWindowHandle.h"
 #include "Render/RHI/RHIResources.h"
 #include "Render/RHI/RHIPipeline.h"
 #include "Render/RHI/RHICommandList.h"

--- a/Src/Render/RHI/RHIResources.h
+++ b/Src/Render/RHI/RHIResources.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "Core/Util/Base.h"
+#include "Render/RHI/NativeWindowHandle.h"
 
 class PipelineLayout;
 
@@ -239,23 +240,6 @@ public:
 
     virtual Texture *getTexture() const = 0;
     virtual const TextureViewDesc &getDesc() const = 0;
-};
-
-enum class NativeWindowSystem
-{
-    Win32,
-    Cocoa,
-    Xlib,
-    Xcb,
-    Wayland,
-};
-
-struct NativeWindowHandle
-{
-    NativeWindowSystem system = NativeWindowSystem::Win32;
-    uintptr_t window = 0;
-    void *display = nullptr;
-    void *layer = nullptr;
 };
 
 struct SwapchainDesc


### PR DESCRIPTION
## Summary
- Add a lightweight `NativeWindowHandle` header for the public RHI boundary
- Move `NativeWindowHandle` out of `RHIResources.h` into its own small include
- Add `Window::GetNativeWindowHandle()` so the platform/window layer can provide RHI-ready native handles
- Implement native handle extraction for Win32, Cocoa, and Linux GLFW backends
- Add an Apple-specific Cocoa helper to package `NSWindow` and best-effort `CAMetalLayer` data
- Update CMake wiring for the new headers/source and related platform/framework setup

## Why
- Establish the platform-to-RHI handoff point before backend swapchain work begins
- Keep GLFW confined to the window/platform layer instead of leaking it into public RHI APIs
- Make native presentation-handle extraction explicit and reusable for upcoming swapchain/device integration work

## Affected areas
- `Src/Core/App/Window.h`
- `Src/Core/App/Window.cpp`
- `Src/Core/App/CocoaNativeWindow.h`
- `Src/Core/App/CocoaNativeWindow.mm`
- `Src/Render/RHI/NativeWindowHandle.h`
- `Src/Render/RHI/RHIResources.h`
- `Src/Render/RHI/RHI.h`
- `CMake/Src/Sources.cmake`
- `CMake/Src/Core.cmake`

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Platform/native-handle extraction paths were added and CMake wiring updated

## Notes
- The Cocoa helper treats `CAMetalLayer` creation as best-effort; `layer` may be null if no valid `NSView` is currently available
- RHI consumers are expected to validate `NativeWindowHandle` completeness before swapchain creation
- `Window::GetNativeWindowHandle()` intentionally does not cache the packaged handle
