### PR TITLE
Add RHI backend factory and backend shells

### DIFF
--- a/CMake/Src/Sources.cmake
+++ b/CMake/Src/Sources.cmake
@@ -160,18 +160,52 @@ set(GLAB_SCENE_HEADERS
 )
 
 set(GLAB_RENDER_SOURCES
+    Render/RHI/RHIFactory.cpp
     Render/RHI/ResourceStateTracker.cpp
+    Render/RHI/Backends/Common/RHIShellCommon.cpp
 )
 
 set(GLAB_RENDER_HEADERS
     Render/RHI/NativeWindowHandle.h
     Render/RHI/RHI.h
+    Render/RHI/RHIFactory.h
     Render/RHI/RHIResources.h
     Render/RHI/RHIPipeline.h
     Render/RHI/RHICommandList.h
     Render/RHI/RHIDevice.h
+    Render/RHI/Backends/Common/RHIShellCommon.h
     Render/Shader/ShaderTypes.h
 )
+
+if(GLAB_BACKEND_VULKAN)
+    list(APPEND GLAB_RENDER_SOURCES
+        Render/RHI/Backends/Vulkan/VulkanDevice.cpp
+    )
+
+    list(APPEND GLAB_RENDER_HEADERS
+        Render/RHI/Backends/Vulkan/VulkanDevice.h
+    )
+endif()
+
+if(GLAB_BACKEND_METAL)
+    list(APPEND GLAB_RENDER_SOURCES
+        Render/RHI/Backends/Metal/MetalDevice.cpp
+    )
+
+    list(APPEND GLAB_RENDER_HEADERS
+        Render/RHI/Backends/Metal/MetalDevice.h
+    )
+endif()
+
+if(GLAB_BACKEND_OPENGL)
+    list(APPEND GLAB_RENDER_SOURCES
+        Render/RHI/Backends/OpenGL/OpenGLDevice.cpp
+    )
+
+    list(APPEND GLAB_RENDER_HEADERS
+        Render/RHI/Backends/OpenGL/OpenGLDevice.h
+    )
+endif()
 
 set(GLAB_DEMO_SOURCES
     Demos/DemoRegistry.cpp

--- a/Src/Core/App/Application.cpp
+++ b/Src/Core/App/Application.cpp
@@ -31,7 +31,6 @@ Application::Application(const ApplicationSpecification &spec)
     props.Title = spec.Name;
     props.Width = spec.Width;
     props.Height = spec.Height;
-    props.VSync = spec.VSync;
 
     m_Window = CreateScope<Window>(props);
     m_Window->SetRefreshCallback([this]()
@@ -77,7 +76,7 @@ void Application::RenderFrame()
 {
     Diagnostics::IncrementFrameNumber();
 
-    // P1: Begin frame - Metal/Vulkan create command buffer here.
+    BeginFrame();
 
     // Phase 1: logic update (input, physics, animation, etc.)
     for (auto &layer : m_LayerStack)
@@ -94,9 +93,8 @@ void Application::RenderFrame()
     //     layer->OnImGuiRender();
     // m_ImGuiLayer->End();
 
-    // P1: End frame - Metal/Vulkan commit command buffer and present here.
-
-    m_Window->SwapBuffers();
+    EndFrame();
+    PresentFrame();
 }
 
 void Application::Run()
@@ -113,7 +111,7 @@ void Application::Run()
         // and some drivers return a 0x0 framebuffer which would cause GL errors.
         // Also skip if the window refresh callback already rendered a frame this tick
         // (happens on macOS during live resize).
-        if (!m_Minimized && !m_FrameRenderedThisTick)
+        if (ShouldRenderFrame())
             RenderFrame();
 
         m_FrameRenderedThisTick = false;
@@ -147,4 +145,30 @@ void Application::OnWindowResize(uint32_t width, uint32_t height)
 
     for (auto &layer : m_LayerStack)
         layer->OnResize(width, height);
+}
+
+bool Application::ShouldRenderFrame() const
+{
+    return !m_Minimized && !m_FrameRenderedThisTick;
+}
+
+void Application::BeginFrame()
+{
+    // Explicit-RHI frame begin work will live here:
+    // - swapchain image acquire
+    // - Device::beginFrame()
+    // - Device::beginCommandList()
+}
+
+void Application::EndFrame()
+{
+    // Explicit-RHI frame end work will live here:
+    // - command submission
+    // - Device::endFrame()
+}
+
+void Application::PresentFrame()
+{
+    // Explicit-RHI present work will live here:
+    // - swapchain->present()
 }

--- a/Src/Core/App/Application.h
+++ b/Src/Core/App/Application.h
@@ -9,9 +9,10 @@
 /// Main loop (Application::Run):
 ///   1. Poll OS events
 ///   2. Update frame time
-///   3. For each layer: OnUpdate(dt) -> OnRender()
-///   4. ImGuiLayer::Begin() -> For each layer: OnImGuiRender() 鈫?ImGuiLayer::End()
-///   5. Swap buffers
+///   3. Begin frame
+///   4. For each layer: OnUpdate(dt) -> OnRender()
+///   5. ImGuiLayer::Begin() -> For each layer: OnImGuiRender() 鈫?ImGuiLayer::End()
+///   6. End frame -> present
 ///
 /// Only one Application instance may exist at a time (enforced by s_Instance).
 
@@ -31,7 +32,6 @@ struct ApplicationSpecification
     std::string Name = "RTRLab";
     uint32_t Width = 1600;
     uint32_t Height = 900;
-    bool VSync = true;
 };
 
 class Application
@@ -63,9 +63,17 @@ public:
 private:
     /// Handles window resize: updates viewport and notifies all layers.
     void OnWindowResize(uint32_t width, uint32_t height);
-    /// Render one full frame (update -> render -> ImGui). Called from Run() and
+    /// Render one full frame (begin frame -> update -> render -> ImGui -> end/present). Called from Run() and
     /// the window refresh callback (macOS live resize).
     void RenderFrame();
+    /// Return whether the current loop tick should render a frame.
+    bool ShouldRenderFrame() const;
+    /// Begin the graphics frame. Future explicit-RHI acquire/beginFrame work lands here.
+    void BeginFrame();
+    /// End the graphics frame. Future explicit-RHI submit/endFrame work lands here.
+    void EndFrame();
+    /// Present the completed frame. Future explicit-RHI swapchain present lands here.
+    void PresentFrame();
 
 private:
     // Non-owning singleton-style pointer. Lifetime is managed externally by the actual Application object.

--- a/Src/Core/App/Window.cpp
+++ b/Src/Core/App/Window.cpp
@@ -48,7 +48,6 @@ void Window::Init(const WindowProps &props)
 {
     m_Width = props.Width;
     m_Height = props.Height;
-    m_VSync = props.VSync;
 
     if (!s_GLFWInitialized)
     {
@@ -147,8 +146,6 @@ void Window::Init(const WindowProps &props)
     glfwSetScrollCallback(m_Handle, [](GLFWwindow * /*window*/, double /*xoffset*/, double yoffset)
                           { Input::AccumulateScroll(static_cast<float>(yoffset)); });
 
-    SetVSync(props.VSync);
-
 #if defined(GLAB_BACKEND_OPENGL)
     LOG_INFO_CAT(LogCategory::Window, "OpenGL Vendor   : {}", reinterpret_cast<const char *>(glGetString(GL_VENDOR)));
     LOG_INFO_CAT(LogCategory::Window, "OpenGL Renderer : {}", reinterpret_cast<const char *>(glGetString(GL_RENDERER)));
@@ -170,18 +167,6 @@ void Window::PollEvents()
     glfwPollEvents();
 }
 
-void Window::SwapBuffers()
-{
-#if defined(GLAB_BACKEND_OPENGL)
-    glfwSwapBuffers(m_Handle);
-#endif
-}
-
-bool Window::ShouldClose() const
-{
-    return glfwWindowShouldClose(m_Handle) != 0;
-}
-
 NativeWindowHandle Window::GetNativeWindowHandle() const
 {
     RTRLAB_ASSERT_MSG(m_Handle != nullptr, "Window handle is null.");
@@ -200,12 +185,9 @@ NativeWindowHandle Window::GetNativeWindowHandle() const
 #endif
 }
 
-void Window::SetVSync(bool enabled)
+bool Window::ShouldClose() const
 {
-#if defined(GLAB_BACKEND_OPENGL)
-    glfwSwapInterval(enabled ? 1 : 0);
-#endif
-    m_VSync = enabled;
+    return glfwWindowShouldClose(m_Handle) != 0;
 }
 
 void Window::SetRefreshCallback(RefreshCallback callback)

--- a/Src/Core/App/Window.h
+++ b/Src/Core/App/Window.h
@@ -4,9 +4,9 @@
 /// @brief Platform window abstraction backed by GLFW.
 ///
 /// Responsibilities:
-///   - Create an OS window with an OpenGL context
-///   - Initialize GLFW (once) and load GL functions via Glad
-///   - Register an OpenGL debug callback (non-Apple platforms)
+///   - Create an OS window suitable for the active graphics backend
+///   - Initialize GLFW (once)
+///   - Configure backend-specific window integration details during creation
 ///   - Publish framebuffer-resize and other events via EventBus
 ///
 /// The Window does NOT own the Input system - Input is initialized separately
@@ -26,7 +26,6 @@ struct WindowProps
     std::string Title = "RTRLab";
     uint32_t Width = 1600;
     uint32_t Height = 900;
-    bool VSync = true;
 };
 
 class Window
@@ -42,13 +41,8 @@ public:
 
     /// Process pending OS/input events (non-blocking).
     void PollEvents();
-    /// Present the back buffer to the screen.
-    void SwapBuffers();
     /// True if the user requested the window to close (e.g., clicked the X button).
     bool ShouldClose() const;
-
-    void SetVSync(bool enabled);
-    bool IsVSync() const { return m_VSync; }
 
     uint32_t GetWidth() const { return m_Width; }
     uint32_t GetHeight() const { return m_Height; }
@@ -78,7 +72,6 @@ private:
     GLFWwindow *m_Handle = nullptr; // Non-owning; destroyed manually in Shutdown().
     uint32_t m_Width = 0;
     uint32_t m_Height = 0;
-    bool m_VSync = true;
 
     RefreshCallback m_RefreshCallback;
     EventBus *m_EventBus = nullptr; // Non-owning. Lifetime managed by Application.

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
@@ -1,0 +1,364 @@
+#include "Render/RHI/Backends/Common/RHIShellCommon.h"
+
+#include <algorithm>
+#include <cstring>
+
+#include "Core/Diagnostics/Assert/Assert.h"
+
+namespace
+{
+    ResourceKind mapReflectedResourceKind(ReflectedTypeKind typeKind)
+    {
+        switch (typeKind)
+        {
+        case ReflectedTypeKind::Buffer:
+            return ResourceKind::StorageBuffer;
+        case ReflectedTypeKind::Texture:
+            return ResourceKind::SampledTexture;
+        case ReflectedTypeKind::Sampler:
+            return ResourceKind::Sampler;
+        case ReflectedTypeKind::ConstantData:
+        case ReflectedTypeKind::ParameterBlock:
+        case ReflectedTypeKind::Struct:
+            return ResourceKind::UniformBuffer;
+        }
+
+        return ResourceKind::UniformBuffer;
+    }
+}
+
+namespace RHIInternal
+{
+    bool isNativeWindowHandleValid(const NativeWindowHandle &nativeWindowHandle)
+    {
+        switch (nativeWindowHandle.system)
+        {
+        case NativeWindowSystem::Win32:
+            return nativeWindowHandle.window != 0;
+        case NativeWindowSystem::Cocoa:
+            return nativeWindowHandle.window != 0 && nativeWindowHandle.layer != nullptr;
+        case NativeWindowSystem::Xlib:
+        case NativeWindowSystem::Xcb:
+        case NativeWindowSystem::Wayland:
+            return nativeWindowHandle.window != 0 && nativeWindowHandle.display != nullptr;
+        }
+
+        return false;
+    }
+
+    SwapchainDesc sanitizeSwapchainDesc(const SwapchainDesc &desc)
+    {
+        SwapchainDesc sanitized = desc;
+        sanitized.width = std::max(desc.width, 1u);
+        sanitized.height = std::max(desc.height, 1u);
+        sanitized.imageCount = std::max(desc.imageCount, 1u);
+        if (sanitized.format == Format::Unknown)
+            sanitized.format = Format::BGRA8_UNORM;
+        return sanitized;
+    }
+
+    PipelineLayoutDesc buildPipelineLayoutDescFromReflection(const ShaderReflectionData &reflection)
+    {
+        PipelineLayoutDesc layoutDesc;
+
+        for (const ReflectedField &field : reflection.globals)
+        {
+            const bool isBindableResource =
+                field.typeKind == ReflectedTypeKind::Texture ||
+                field.typeKind == ReflectedTypeKind::Sampler ||
+                field.typeKind == ReflectedTypeKind::Buffer ||
+                field.typeKind == ReflectedTypeKind::ParameterBlock ||
+                field.typeKind == ReflectedTypeKind::ConstantData;
+
+            if (!isBindableResource)
+                continue;
+
+            BindingInfo bindingInfo;
+            bindingInfo.name = field.name;
+            bindingInfo.setIndex = field.setIndex;
+            bindingInfo.binding = field.binding;
+            bindingInfo.kind = mapReflectedResourceKind(field.typeKind);
+            bindingInfo.arrayCount = field.arrayCount;
+            bindingInfo.stageMask = field.stageMask;
+            layoutDesc.bindings.push_back(std::move(bindingInfo));
+        }
+
+        layoutDesc.pushConstants = reflection.pushConstants;
+        return layoutDesc;
+    }
+
+    PipelineLayoutDesc ShellShaderProgram::derivePipelineLayoutDesc() const
+    {
+        return buildPipelineLayoutDescFromReflection(m_Reflection);
+    }
+
+    ShellResourceSet::ShellResourceSet(PipelineLayout *layout, uint32_t setIndex)
+        : m_Layout(layout), m_SetIndex(setIndex)
+    {
+    }
+
+    void ShellResourceSet::setBuffer(uint32_t binding, const BufferBinding &bufferBinding)
+    {
+        m_BufferBindings[binding] = bufferBinding;
+        ++m_Version;
+    }
+
+    void ShellResourceSet::setTexture(uint32_t binding, const TextureBinding &textureBinding)
+    {
+        m_TextureBindings[binding] = textureBinding;
+        ++m_Version;
+    }
+
+    void ShellResourceSet::setSampler(uint32_t binding, const SamplerBinding &samplerBinding)
+    {
+        m_SamplerBindings[binding] = samplerBinding;
+        ++m_Version;
+    }
+
+    void ShellCommandListBase::beginRendering(const RenderingInfo &renderingInfo)
+    {
+        m_RenderingInfo = renderingInfo;
+        m_IsRendering = true;
+    }
+
+    void ShellCommandListBase::endRendering()
+    {
+        m_IsRendering = false;
+    }
+
+    void ShellCommandListBase::bindGraphicsPipeline(GraphicsPipeline *pipeline)
+    {
+        m_GraphicsPipeline = pipeline;
+    }
+
+    void ShellCommandListBase::bindComputePipeline(ComputePipeline *pipeline)
+    {
+        m_ComputePipeline = pipeline;
+    }
+
+    void ShellCommandListBase::bindResourceSet(uint32_t setIndex, ResourceSet *resourceSet)
+    {
+        m_ResourceSets[setIndex] = resourceSet;
+    }
+
+    void ShellCommandListBase::pushConstants(ShaderStage, uint32_t offset, uint32_t size, const void *data)
+    {
+        if (size == 0 || data == nullptr)
+            return;
+
+        if (offset + size > m_PushConstants.size())
+            m_PushConstants.resize(offset + size);
+
+        std::memcpy(m_PushConstants.data() + offset, data, size);
+    }
+
+    void ShellCommandListBase::bindMesh(const MeshBinding &meshBinding, const uint64_t *vertexOffsets)
+    {
+        m_MeshBinding = meshBinding;
+        m_VertexOffsets.clear();
+
+        if (vertexOffsets != nullptr)
+        {
+            m_VertexOffsets.assign(vertexOffsets, vertexOffsets + meshBinding.vertexBuffers.size());
+        }
+    }
+
+    void ShellCommandListBase::bindVertexBuffers(uint32_t firstSlot, Buffer *const *buffers, uint32_t count, const uint64_t *offsets)
+    {
+        if (m_MeshBinding.vertexBuffers.size() < firstSlot + count)
+            m_MeshBinding.vertexBuffers.resize(firstSlot + count);
+        if (m_VertexOffsets.size() < firstSlot + count)
+            m_VertexOffsets.resize(firstSlot + count, 0);
+
+        for (uint32_t index = 0; index < count; ++index)
+        {
+            m_MeshBinding.vertexBuffers[firstSlot + index] = buffers[index];
+            m_VertexOffsets[firstSlot + index] = offsets != nullptr ? offsets[index] : 0;
+        }
+    }
+
+    void ShellCommandListBase::bindIndexBuffer(Buffer *buffer, uint64_t offset, IndexType indexType)
+    {
+        m_IndexBuffer = buffer;
+        m_IndexOffset = offset;
+        m_IndexType = indexType;
+    }
+
+    void ShellCommandListBase::setViewport(float x, float y, float w, float h, float zmin, float zmax)
+    {
+        m_Viewport[0] = x;
+        m_Viewport[1] = y;
+        m_Viewport[2] = w;
+        m_Viewport[3] = h;
+        m_Viewport[4] = zmin;
+        m_Viewport[5] = zmax;
+    }
+
+    void ShellCommandListBase::setScissor(int32_t x, int32_t y, uint32_t w, uint32_t h)
+    {
+        m_Scissor = Rect2D{x, y, w, h};
+    }
+
+    void ShellCommandListBase::draw(uint32_t vertexCount, uint32_t firstVertex)
+    {
+        m_LastDrawVertexCount = vertexCount;
+        m_LastDrawFirstVertex = firstVertex;
+    }
+
+    void ShellCommandListBase::drawIndexed(uint32_t indexCount, uint32_t firstIndex, int32_t vertexOffset)
+    {
+        m_LastDrawIndexedCount = indexCount;
+        m_LastDrawFirstIndex = firstIndex;
+        m_LastDrawVertexOffset = vertexOffset;
+    }
+
+    void ShellCommandListBase::dispatch(uint32_t groupX, uint32_t groupY, uint32_t groupZ)
+    {
+        m_LastDispatchX = groupX;
+        m_LastDispatchY = groupY;
+        m_LastDispatchZ = groupZ;
+    }
+
+    void ShellCommandListBase::textureBarrier(Texture *, TextureState, TextureState, ShaderStage, ShaderStage)
+    {
+    }
+
+    void ShellCommandListBase::bufferBarrier(Buffer *, BufferState, BufferState, ShaderStage, ShaderStage)
+    {
+    }
+
+    ShellSwapchainBase::ShellSwapchainBase(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle)
+        : m_Desc(sanitizeSwapchainDesc(desc)), m_NativeWindowHandle(nativeWindowHandle)
+    {
+        RTRLAB_ASSERT_MSG(isNativeWindowHandleValid(nativeWindowHandle), "Native window handle is incomplete.");
+        rebuildImages();
+    }
+
+    uint32_t ShellSwapchainBase::acquireNextImage()
+    {
+        const uint32_t currentImageIndex = m_NextImageIndex;
+        m_NextImageIndex = (m_NextImageIndex + 1) % imageCount();
+        return currentImageIndex;
+    }
+
+    Texture *ShellSwapchainBase::getImage(uint32_t imageIndex) const
+    {
+        RTRLAB_ASSERT_MSG(imageIndex < m_Images.size(), "Swapchain image index out of range.");
+        return m_Images[imageIndex].get();
+    }
+
+    TextureView *ShellSwapchainBase::getImageView(uint32_t imageIndex) const
+    {
+        RTRLAB_ASSERT_MSG(imageIndex < m_ImageViews.size(), "Swapchain image-view index out of range.");
+        return m_ImageViews[imageIndex].get();
+    }
+
+    void ShellSwapchainBase::present(uint32_t imageIndex)
+    {
+        RTRLAB_ASSERT_MSG(imageIndex < m_Images.size(), "Swapchain present index out of range.");
+    }
+
+    void ShellSwapchainBase::resize(uint32_t newWidth, uint32_t newHeight)
+    {
+        m_Desc.width = std::max(newWidth, 1u);
+        m_Desc.height = std::max(newHeight, 1u);
+        rebuildImages();
+    }
+
+    TextureDesc ShellSwapchainBase::buildSwapchainImageDesc() const
+    {
+        TextureDesc textureDesc;
+        textureDesc.type = TextureType::Tex2D;
+        textureDesc.format = m_Desc.format;
+        textureDesc.extent = Extent3D{m_Desc.width, m_Desc.height, 1};
+        textureDesc.mipLevels = 1;
+        textureDesc.arrayLayers = 1;
+        textureDesc.usageMask = TextureUsage::RenderTarget | TextureUsage::CopySrc;
+        textureDesc.debugName = "SwapchainImage";
+        return textureDesc;
+    }
+
+    void ShellSwapchainBase::rebuildImages()
+    {
+        m_Images.clear();
+        m_ImageViews.clear();
+        m_Images.reserve(m_Desc.imageCount);
+        m_ImageViews.reserve(m_Desc.imageCount);
+
+        const TextureDesc imageDesc = buildSwapchainImageDesc();
+
+        for (uint32_t imageIndex = 0; imageIndex < m_Desc.imageCount; ++imageIndex)
+        {
+            auto image = CreateScope<ShellTexture>(imageDesc);
+
+            TextureViewDesc viewDesc;
+            viewDesc.type = TextureType::Tex2D;
+            viewDesc.format = imageDesc.format;
+            viewDesc.aspect = TextureAspect::Color;
+
+            auto view = CreateScope<ShellTextureView>(image.get(), viewDesc);
+            m_ImageViews.push_back(std::move(view));
+            m_Images.push_back(std::move(image));
+        }
+
+        m_NextImageIndex = 0;
+    }
+
+    Scope<Buffer> ShellDeviceBase::createBuffer(const BufferDesc &desc)
+    {
+        return CreateScope<ShellBuffer>(desc);
+    }
+
+    Scope<Texture> ShellDeviceBase::createTexture(const TextureDesc &desc)
+    {
+        return CreateScope<ShellTexture>(desc);
+    }
+
+    Scope<TextureView> ShellDeviceBase::createTextureView(Texture *texture, const TextureViewDesc &desc)
+    {
+        return CreateScope<ShellTextureView>(texture, desc);
+    }
+
+    Scope<Sampler> ShellDeviceBase::createSampler(const SamplerDesc &desc)
+    {
+        return CreateScope<ShellSampler>(desc);
+    }
+
+    Scope<ShaderProgram> ShellDeviceBase::createShaderProgram(const CompiledShaderProgramDesc &desc)
+    {
+        return CreateScope<ShellShaderProgram>(desc);
+    }
+
+    Scope<PipelineLayout> ShellDeviceBase::createPipelineLayout(const PipelineLayoutDesc &desc)
+    {
+        return CreateScope<ShellPipelineLayout>(desc);
+    }
+
+    Scope<ResourceSet> ShellDeviceBase::createResourceSet(PipelineLayout *layout, uint32_t setIndex)
+    {
+        return CreateScope<ShellResourceSet>(layout, setIndex);
+    }
+
+    Scope<VertexInputLayout> ShellDeviceBase::createVertexInputLayout(const VertexInputLayoutDesc &desc)
+    {
+        return CreateScope<ShellVertexInputLayout>(desc);
+    }
+
+    Scope<GraphicsPipeline> ShellDeviceBase::createGraphicsPipeline(const GraphicsPipelineDesc &desc)
+    {
+        return CreateScope<ShellGraphicsPipeline>(desc);
+    }
+
+    Scope<ComputePipeline> ShellDeviceBase::createComputePipeline(const ComputePipelineDesc &desc)
+    {
+        return CreateScope<ShellComputePipeline>(desc);
+    }
+
+    void ShellDeviceBase::submit(CommandList *)
+    {
+    }
+
+    void ShellDeviceBase::endFrame(FrameContext *)
+    {
+    }
+} // namespace RHIInternal

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.h
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.h
@@ -1,0 +1,277 @@
+#pragma once
+
+/// @file RHIShellCommon.h
+/// @brief Shared implementation helpers for backend-private RHI skeleton objects.
+
+#include <unordered_map>
+#include <vector>
+
+#include "Render/RHI/RHIDevice.h"
+
+namespace RHIInternal
+{
+    bool isNativeWindowHandleValid(const NativeWindowHandle &nativeWindowHandle);
+    SwapchainDesc sanitizeSwapchainDesc(const SwapchainDesc &desc);
+    PipelineLayoutDesc buildPipelineLayoutDescFromReflection(const ShaderReflectionData &reflection);
+
+    class ShellFrameContext : public FrameContext
+    {
+    };
+
+    class ShellBuffer final : public Buffer
+    {
+    public:
+        explicit ShellBuffer(const BufferDesc &desc)
+            : m_Desc(desc)
+        {
+        }
+
+        const BufferDesc &getDesc() const override { return m_Desc; }
+
+    private:
+        BufferDesc m_Desc;
+    };
+
+    class ShellTexture final : public Texture
+    {
+    public:
+        explicit ShellTexture(const TextureDesc &desc)
+            : m_Desc(desc)
+        {
+        }
+
+        const TextureDesc &getDesc() const override { return m_Desc; }
+
+    private:
+        TextureDesc m_Desc;
+    };
+
+    class ShellTextureView final : public TextureView
+    {
+    public:
+        ShellTextureView(Texture *texture, const TextureViewDesc &desc)
+            : m_Texture(texture), m_Desc(desc)
+        {
+        }
+
+        Texture *getTexture() const override { return m_Texture; }
+        const TextureViewDesc &getDesc() const override { return m_Desc; }
+
+    private:
+        Texture *m_Texture = nullptr;
+        TextureViewDesc m_Desc;
+    };
+
+    class ShellSampler final : public Sampler
+    {
+    public:
+        explicit ShellSampler(const SamplerDesc &desc)
+            : m_Desc(desc)
+        {
+        }
+
+        const SamplerDesc &getDesc() const override { return m_Desc; }
+
+    private:
+        SamplerDesc m_Desc;
+    };
+
+    class ShellPipelineLayout final : public PipelineLayout
+    {
+    public:
+        explicit ShellPipelineLayout(const PipelineLayoutDesc &desc)
+            : m_Desc(desc)
+        {
+        }
+
+        const PipelineLayoutDesc &getDesc() const override { return m_Desc; }
+
+    private:
+        PipelineLayoutDesc m_Desc;
+    };
+
+    class ShellVertexInputLayout final : public VertexInputLayout
+    {
+    public:
+        explicit ShellVertexInputLayout(const VertexInputLayoutDesc &desc)
+            : m_Desc(desc)
+        {
+        }
+
+        const VertexInputLayoutDesc &getDesc() const override { return m_Desc; }
+
+    private:
+        VertexInputLayoutDesc m_Desc;
+    };
+
+    class ShellShaderProgram final : public ShaderProgram
+    {
+    public:
+        // Milestone 1 keeps shader-program shells intentionally thin. Reflection is stored
+        // so the public interface is satisfied, but backend code generation still belongs
+        // to the later shader milestone.
+        explicit ShellShaderProgram(const CompiledShaderProgramDesc &desc)
+            : m_Reflection(desc.reflection)
+        {
+        }
+
+        const ShaderReflectionData &getReflection() const override { return m_Reflection; }
+        PipelineLayoutDesc derivePipelineLayoutDesc() const override;
+
+    private:
+        ShaderReflectionData m_Reflection;
+    };
+
+    class ShellGraphicsPipeline final : public GraphicsPipeline
+    {
+    public:
+        explicit ShellGraphicsPipeline(const GraphicsPipelineDesc &desc)
+            : m_Desc(desc)
+        {
+        }
+
+        const GraphicsPipelineDesc &getDesc() const override { return m_Desc; }
+
+    private:
+        GraphicsPipelineDesc m_Desc;
+    };
+
+    class ShellComputePipeline final : public ComputePipeline
+    {
+    public:
+        explicit ShellComputePipeline(const ComputePipelineDesc &desc)
+            : m_Desc(desc)
+        {
+        }
+
+        const ComputePipelineDesc &getDesc() const override { return m_Desc; }
+
+    private:
+        ComputePipelineDesc m_Desc;
+    };
+
+    class ShellResourceSet final : public ResourceSet
+    {
+    public:
+        ShellResourceSet(PipelineLayout *layout, uint32_t setIndex);
+
+        PipelineLayout *getLayout() const override { return m_Layout; }
+        uint32_t getSetIndex() const override { return m_SetIndex; }
+
+        ParameterBlockData &constants() override { return m_Constants; }
+        const ParameterBlockData &constants() const override { return m_Constants; }
+
+        void setBuffer(uint32_t binding, const BufferBinding &bufferBinding) override;
+        void setTexture(uint32_t binding, const TextureBinding &textureBinding) override;
+        void setSampler(uint32_t binding, const SamplerBinding &samplerBinding) override;
+
+        uint32_t version() const override { return m_Version; }
+
+    private:
+        PipelineLayout *m_Layout = nullptr;
+        uint32_t m_SetIndex = 0;
+        ParameterBlockData m_Constants;
+        std::unordered_map<uint32_t, BufferBinding> m_BufferBindings;
+        std::unordered_map<uint32_t, TextureBinding> m_TextureBindings;
+        std::unordered_map<uint32_t, SamplerBinding> m_SamplerBindings;
+        uint32_t m_Version = 0;
+    };
+
+    class ShellCommandListBase : public CommandList
+    {
+    public:
+        void beginRendering(const RenderingInfo &renderingInfo) override;
+        void endRendering() override;
+
+        void bindGraphicsPipeline(GraphicsPipeline *pipeline) override;
+        void bindComputePipeline(ComputePipeline *pipeline) override;
+
+        void bindResourceSet(uint32_t setIndex, ResourceSet *resourceSet) override;
+        void pushConstants(ShaderStage stageMask, uint32_t offset, uint32_t size, const void *data) override;
+
+        void bindMesh(const MeshBinding &meshBinding, const uint64_t *vertexOffsets = nullptr) override;
+        void bindVertexBuffers(uint32_t firstSlot, Buffer *const *buffers, uint32_t count, const uint64_t *offsets) override;
+        void bindIndexBuffer(Buffer *buffer, uint64_t offset, IndexType indexType) override;
+
+        void setViewport(float x, float y, float w, float h, float zmin, float zmax) override;
+        void setScissor(int32_t x, int32_t y, uint32_t w, uint32_t h) override;
+
+        void draw(uint32_t vertexCount, uint32_t firstVertex) override;
+        void drawIndexed(uint32_t indexCount, uint32_t firstIndex, int32_t vertexOffset) override;
+
+        void dispatch(uint32_t groupX, uint32_t groupY, uint32_t groupZ) override;
+
+        void textureBarrier(Texture *texture, TextureState oldState, TextureState newState, ShaderStage srcStage, ShaderStage dstStage) override;
+        void bufferBarrier(Buffer *buffer, BufferState oldState, BufferState newState, ShaderStage srcStage, ShaderStage dstStage) override;
+
+    protected:
+        RenderingInfo m_RenderingInfo;
+        bool m_IsRendering = false;
+        GraphicsPipeline *m_GraphicsPipeline = nullptr;
+        ComputePipeline *m_ComputePipeline = nullptr;
+        std::unordered_map<uint32_t, ResourceSet *> m_ResourceSets;
+        MeshBinding m_MeshBinding;
+        std::vector<uint64_t> m_VertexOffsets;
+        Buffer *m_IndexBuffer = nullptr;
+        uint64_t m_IndexOffset = 0;
+        IndexType m_IndexType = IndexType::UInt32;
+        Rect2D m_Scissor;
+        float m_Viewport[6] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f};
+        std::vector<uint8_t> m_PushConstants;
+        uint32_t m_LastDrawVertexCount = 0;
+        uint32_t m_LastDrawFirstVertex = 0;
+        uint32_t m_LastDrawIndexedCount = 0;
+        uint32_t m_LastDrawFirstIndex = 0;
+        int32_t m_LastDrawVertexOffset = 0;
+        uint32_t m_LastDispatchX = 0;
+        uint32_t m_LastDispatchY = 0;
+        uint32_t m_LastDispatchZ = 0;
+    };
+
+    class ShellSwapchainBase : public Swapchain
+    {
+    public:
+        ShellSwapchainBase(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle);
+
+        uint32_t acquireNextImage() override;
+        Texture *getImage(uint32_t imageIndex) const override;
+        TextureView *getImageView(uint32_t imageIndex) const override;
+        void present(uint32_t imageIndex) override;
+        void resize(uint32_t newWidth, uint32_t newHeight) override;
+        uint32_t width() const override { return m_Desc.width; }
+        uint32_t height() const override { return m_Desc.height; }
+        Format format() const override { return m_Desc.format; }
+        uint32_t imageCount() const override { return static_cast<uint32_t>(m_Images.size()); }
+
+    protected:
+        virtual TextureDesc buildSwapchainImageDesc() const;
+        void rebuildImages();
+
+        SwapchainDesc m_Desc;
+        NativeWindowHandle m_NativeWindowHandle;
+        std::vector<Scope<ShellTexture>> m_Images;
+        std::vector<Scope<ShellTextureView>> m_ImageViews;
+        uint32_t m_NextImageIndex = 0;
+    };
+
+    class ShellDeviceBase : public Device
+    {
+    public:
+        Scope<Buffer> createBuffer(const BufferDesc &desc) override;
+        Scope<Texture> createTexture(const TextureDesc &desc) override;
+        Scope<TextureView> createTextureView(Texture *texture, const TextureViewDesc &desc) override;
+        Scope<Sampler> createSampler(const SamplerDesc &desc) override;
+
+        Scope<ShaderProgram> createShaderProgram(const CompiledShaderProgramDesc &desc) override;
+        Scope<PipelineLayout> createPipelineLayout(const PipelineLayoutDesc &desc) override;
+        Scope<ResourceSet> createResourceSet(PipelineLayout *layout, uint32_t setIndex) override;
+
+        Scope<VertexInputLayout> createVertexInputLayout(const VertexInputLayoutDesc &desc) override;
+
+        Scope<GraphicsPipeline> createGraphicsPipeline(const GraphicsPipelineDesc &desc) override;
+        Scope<ComputePipeline> createComputePipeline(const ComputePipelineDesc &desc) override;
+
+        void submit(CommandList *commandList) override;
+        void endFrame(FrameContext *frameContext) override;
+    };
+} // namespace RHIInternal

--- a/Src/Render/RHI/Backends/Metal/MetalDevice.cpp
+++ b/Src/Render/RHI/Backends/Metal/MetalDevice.cpp
@@ -1,0 +1,21 @@
+#include "Render/RHI/Backends/Metal/MetalDevice.h"
+
+MetalSwapchain::MetalSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle)
+    : ShellSwapchainBase(desc, nativeWindowHandle)
+{
+}
+
+Scope<Swapchain> MetalDevice::createSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle)
+{
+    return CreateScope<MetalSwapchain>(desc, nativeWindowHandle);
+}
+
+CommandList *MetalDevice::beginCommandList()
+{
+    return &m_CommandList;
+}
+
+FrameContext *MetalDevice::beginFrame()
+{
+    return &m_FrameContext;
+}

--- a/Src/Render/RHI/Backends/Metal/MetalDevice.h
+++ b/Src/Render/RHI/Backends/Metal/MetalDevice.h
@@ -1,0 +1,30 @@
+#pragma once
+
+/// @file MetalDevice.h
+/// @brief Backend-private Metal RHI skeleton classes for Milestone 1 bring-up.
+
+#include "Render/RHI/Backends/Common/RHIShellCommon.h"
+
+class MetalCommandList final : public RHIInternal::ShellCommandListBase
+{
+};
+
+class MetalSwapchain final : public RHIInternal::ShellSwapchainBase
+{
+public:
+    MetalSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle);
+};
+
+class MetalDevice final : public RHIInternal::ShellDeviceBase
+{
+public:
+    Scope<Swapchain> createSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle) override;
+
+    CommandList *beginCommandList() override;
+    FrameContext *beginFrame() override;
+
+private:
+    MetalCommandList m_CommandList;
+    RHIInternal::ShellFrameContext m_FrameContext;
+};
+

--- a/Src/Render/RHI/Backends/OpenGL/OpenGLDevice.cpp
+++ b/Src/Render/RHI/Backends/OpenGL/OpenGLDevice.cpp
@@ -1,0 +1,21 @@
+#include "Render/RHI/Backends/OpenGL/OpenGLDevice.h"
+
+OpenGLSwapchain::OpenGLSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle)
+    : ShellSwapchainBase(desc, nativeWindowHandle)
+{
+}
+
+Scope<Swapchain> OpenGLDevice::createSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle)
+{
+    return CreateScope<OpenGLSwapchain>(desc, nativeWindowHandle);
+}
+
+CommandList *OpenGLDevice::beginCommandList()
+{
+    return &m_CommandList;
+}
+
+FrameContext *OpenGLDevice::beginFrame()
+{
+    return &m_FrameContext;
+}

--- a/Src/Render/RHI/Backends/OpenGL/OpenGLDevice.h
+++ b/Src/Render/RHI/Backends/OpenGL/OpenGLDevice.h
@@ -1,0 +1,30 @@
+#pragma once
+
+/// @file OpenGLDevice.h
+/// @brief Backend-private OpenGL RHI skeleton classes for Milestone 1 bring-up.
+
+#include "Render/RHI/Backends/Common/RHIShellCommon.h"
+
+class OpenGLCommandList final : public RHIInternal::ShellCommandListBase
+{
+};
+
+class OpenGLSwapchain final : public RHIInternal::ShellSwapchainBase
+{
+public:
+    OpenGLSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle);
+};
+
+class OpenGLDevice final : public RHIInternal::ShellDeviceBase
+{
+public:
+    Scope<Swapchain> createSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle) override;
+
+    CommandList *beginCommandList() override;
+    FrameContext *beginFrame() override;
+
+private:
+    OpenGLCommandList m_CommandList;
+    RHIInternal::ShellFrameContext m_FrameContext;
+};
+

--- a/Src/Render/RHI/Backends/Vulkan/VulkanDevice.cpp
+++ b/Src/Render/RHI/Backends/Vulkan/VulkanDevice.cpp
@@ -1,0 +1,21 @@
+#include "Render/RHI/Backends/Vulkan/VulkanDevice.h"
+
+VulkanSwapchain::VulkanSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle)
+    : ShellSwapchainBase(desc, nativeWindowHandle)
+{
+}
+
+Scope<Swapchain> VulkanDevice::createSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle)
+{
+    return CreateScope<VulkanSwapchain>(desc, nativeWindowHandle);
+}
+
+CommandList *VulkanDevice::beginCommandList()
+{
+    return &m_CommandList;
+}
+
+FrameContext *VulkanDevice::beginFrame()
+{
+    return &m_FrameContext;
+}

--- a/Src/Render/RHI/Backends/Vulkan/VulkanDevice.h
+++ b/Src/Render/RHI/Backends/Vulkan/VulkanDevice.h
@@ -1,0 +1,30 @@
+#pragma once
+
+/// @file VulkanDevice.h
+/// @brief Backend-private Vulkan RHI skeleton classes for Milestone 1 bring-up.
+
+#include "Render/RHI/Backends/Common/RHIShellCommon.h"
+
+class VulkanCommandList final : public RHIInternal::ShellCommandListBase
+{
+};
+
+class VulkanSwapchain final : public RHIInternal::ShellSwapchainBase
+{
+public:
+    VulkanSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle);
+};
+
+class VulkanDevice final : public RHIInternal::ShellDeviceBase
+{
+public:
+    Scope<Swapchain> createSwapchain(const SwapchainDesc &desc, const NativeWindowHandle &nativeWindowHandle) override;
+
+    CommandList *beginCommandList() override;
+    FrameContext *beginFrame() override;
+
+private:
+    VulkanCommandList m_CommandList;
+    RHIInternal::ShellFrameContext m_FrameContext;
+};
+

--- a/Src/Render/RHI/RHI.h
+++ b/Src/Render/RHI/RHI.h
@@ -4,6 +4,7 @@
 /// @brief Umbrella include for the public RHI interface skeleton.
 
 #include "Render/RHI/NativeWindowHandle.h"
+#include "Render/RHI/RHIFactory.h"
 #include "Render/RHI/RHIResources.h"
 #include "Render/RHI/RHIPipeline.h"
 #include "Render/RHI/RHICommandList.h"

--- a/Src/Render/RHI/RHIFactory.cpp
+++ b/Src/Render/RHI/RHIFactory.cpp
@@ -1,0 +1,72 @@
+#include "Render/RHI/RHIFactory.h"
+
+#include "Core/Diagnostics/Assert/Assert.h"
+#include "Core/Diagnostics/Logging/LogCategories.h"
+#include "Core/Diagnostics/Logging/LogMacros.h"
+#if defined(GLAB_BACKEND_METAL)
+#include "Render/RHI/Backends/Metal/MetalDevice.h"
+#endif
+#if defined(GLAB_BACKEND_OPENGL)
+#include "Render/RHI/Backends/OpenGL/OpenGLDevice.h"
+#endif
+#if defined(GLAB_BACKEND_VULKAN)
+#include "Render/RHI/Backends/Vulkan/VulkanDevice.h"
+#endif
+
+BackendType getDefaultBackendType()
+{
+#if defined(GLAB_BACKEND_OPENGL)
+    return BackendType::OpenGL;
+#elif defined(GLAB_BACKEND_METAL)
+    return BackendType::Metal;
+#elif defined(GLAB_BACKEND_VULKAN)
+    return BackendType::Vulkan;
+#else
+#error No RHI backend selected for this build configuration.
+#endif
+}
+
+const char *getBackendName(BackendType backend)
+{
+    switch (backend)
+    {
+    case BackendType::Vulkan:
+        return "Vulkan";
+    case BackendType::Metal:
+        return "Metal";
+    case BackendType::OpenGL:
+        return "OpenGL";
+    }
+
+    return "Unknown";
+}
+
+Scope<Device> createDevice(BackendType backend)
+{
+    LOG_INFO_CAT(LogCategory::Graphics, "Creating {} RHI device shell", getBackendName(backend));
+
+    switch (backend)
+    {
+    case BackendType::Vulkan:
+#if defined(GLAB_BACKEND_VULKAN)
+        return CreateScope<VulkanDevice>();
+#else
+        break;
+#endif
+    case BackendType::Metal:
+#if defined(GLAB_BACKEND_METAL)
+        return CreateScope<MetalDevice>();
+#else
+        break;
+#endif
+    case BackendType::OpenGL:
+#if defined(GLAB_BACKEND_OPENGL)
+        return CreateScope<OpenGLDevice>();
+#else
+        break;
+#endif
+    }
+
+    RTRLAB_ASSERT_MSG(false, "Requested RHI backend is not compiled into this build.");
+    return {};
+}

--- a/Src/Render/RHI/RHIFactory.h
+++ b/Src/Render/RHI/RHIFactory.h
@@ -1,0 +1,22 @@
+#pragma once
+
+/// @file RHIFactory.h
+/// @brief Public backend-selection and RHI device factory helpers.
+
+#include "Render/RHI/RHIDevice.h"
+
+/// Return the backend selected by the current build configuration.
+BackendType getDefaultBackendType();
+
+/// Human-readable backend name used for diagnostics and logging.
+const char *getBackendName(BackendType backend);
+
+/// Create a backend-specific RHI device shell for the requested backend.
+Scope<Device> createDevice(BackendType backend);
+
+/// Convenience wrapper that creates the device matching the active build backend.
+inline Scope<Device> createDefaultDevice()
+{
+    return createDevice(getDefaultBackendType());
+}
+

--- a/Src/main.cpp
+++ b/Src/main.cpp
@@ -57,7 +57,6 @@ int main(int argc, char **argv)
     spec.Name = "RTRLab";
     spec.Width = 1600;
     spec.Height = 900;
-    spec.VSync = true;
 
     Application app(spec);
     app.PushLayer(CreateScope<LabLayer>());

--- a/Tests/Common/Unit/Core/App/TestSpecifications.cpp
+++ b/Tests/Common/Unit/Core/App/TestSpecifications.cpp
@@ -10,7 +10,6 @@ TEST(SpecificationTests, ApplicationSpecificationHasExpectedDefaults)
     EXPECT_EQ(spec.Name, "RTRLab");
     EXPECT_EQ(spec.Width, 1600u);
     EXPECT_EQ(spec.Height, 900u);
-    EXPECT_TRUE(spec.VSync);
 }
 
 TEST(SpecificationTests, ApplicationSpecificationCanBeCustomized)
@@ -19,12 +18,10 @@ TEST(SpecificationTests, ApplicationSpecificationCanBeCustomized)
     spec.Name = "MyApp";
     spec.Width = 1920;
     spec.Height = 1080;
-    spec.VSync = false;
 
     EXPECT_EQ(spec.Name, "MyApp");
     EXPECT_EQ(spec.Width, 1920u);
     EXPECT_EQ(spec.Height, 1080u);
-    EXPECT_FALSE(spec.VSync);
 }
 
 TEST(SpecificationTests, WindowPropsHasExpectedDefaults)
@@ -34,7 +31,6 @@ TEST(SpecificationTests, WindowPropsHasExpectedDefaults)
     EXPECT_EQ(props.Title, "RTRLab");
     EXPECT_EQ(props.Width, 1600u);
     EXPECT_EQ(props.Height, 900u);
-    EXPECT_TRUE(props.VSync);
 }
 
 TEST(SpecificationTests, WindowPropsCanBeCustomized)
@@ -43,10 +39,8 @@ TEST(SpecificationTests, WindowPropsCanBeCustomized)
     props.Title = "Main Window";
     props.Width = 1280;
     props.Height = 720;
-    props.VSync = false;
 
     EXPECT_EQ(props.Title, "Main Window");
     EXPECT_EQ(props.Width, 1280u);
     EXPECT_EQ(props.Height, 720u);
-    EXPECT_FALSE(props.VSync);
 }


### PR DESCRIPTION
## Summary
- Add public RHI factory helpers for backend selection and device creation
- Add shared backend-internal shell infrastructure under `Render/RHI/Backends/Common`
- Add backend-private `Device`, `Swapchain`, and `CommandList` shells for Vulkan, Metal, and OpenGL
- Wire backend shell sources and headers into CMake with per-backend conditional inclusion
- Expose the new factory entry point through the public `RHI.h` umbrella include
- Update the application specification unit test to match the already-removed app/window `VSync` fields

## Why
- Establish a single backend-selection path that all three backends can compile against
- Give Vulkan, Metal, and OpenGL matching backend-private shell structures before real backend implementation starts
- Keep backend-private implementation details out of the public RHI surface while still making the creation path concrete

## Affected areas
- `Src/Render/RHI/RHI.h`
- `Src/Render/RHI/RHIFactory.h`
- `Src/Render/RHI/RHIFactory.cpp`
- `Src/Render/RHI/Backends/Common`
- `Src/Render/RHI/Backends/Vulkan`
- `Src/Render/RHI/Backends/Metal`
- `Src/Render/RHI/Backends/OpenGL`
- `CMake/Src/Sources.cmake`
- `Tests/Common/Unit/Core/App/TestSpecifications.cpp`

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- backend factory and shell code were added without changing runtime application hookup yet

## Notes
- The shared shell layer provides placeholder implementations so all backends compile against the same public headers
- Backend sources and headers are now conditionally included per compiled backend to avoid future SDK/header cross-platform issues
