### PR TITLE
Wire Application to the shell RHI frame lifecycle

### DIFF
--- a/Src/Core/App/Application.cpp
+++ b/Src/Core/App/Application.cpp
@@ -160,8 +160,7 @@ bool Application::ShouldRenderFrame() const
 
 void Application::BeginFrame()
 {
-    if (!m_Device || !m_Swapchain)
-        return;
+    RTRLAB_ASSERT_MSG(m_Device && m_Swapchain, "Application RHI must be initialized before beginning a frame.");
 
     m_SwapchainImageIndex = m_Swapchain->acquireNextImage();
     m_SwapchainImage = m_Swapchain->getImage(m_SwapchainImageIndex);
@@ -188,8 +187,8 @@ void Application::BeginFrame()
 
 void Application::EndFrame()
 {
-    if (!m_Device || !m_Swapchain || !m_CommandList || !m_FrameContext)
-        return;
+    RTRLAB_ASSERT_MSG(m_Device && m_Swapchain, "Application RHI must remain valid until the frame ends.");
+    RTRLAB_ASSERT_MSG(m_CommandList && m_FrameContext, "EndFrame requires an active frame and command list.");
 
     m_CommandList->endRendering();
 
@@ -205,8 +204,8 @@ void Application::EndFrame()
 
 void Application::PresentFrame()
 {
-    if (!m_Swapchain || !m_SwapchainImageView)
-        return;
+    RTRLAB_ASSERT_MSG(m_Swapchain, "Application swapchain must remain valid until presentation.");
+    RTRLAB_ASSERT_MSG(m_SwapchainImageView, "PresentFrame requires a valid swapchain image view from BeginFrame.");
 
     m_Swapchain->present(m_SwapchainImageIndex);
     m_ResourceStateTracker.reset();

--- a/Src/Core/App/Application.cpp
+++ b/Src/Core/App/Application.cpp
@@ -209,6 +209,7 @@ void Application::PresentFrame()
 
     m_Swapchain->present(m_SwapchainImageIndex);
     m_ResourceStateTracker.reset();
+    m_SwapchainImageIndex = std::numeric_limits<uint32_t>::max();
     m_SwapchainImage = nullptr;
     m_SwapchainImageView = nullptr;
 }

--- a/Src/Core/App/Application.cpp
+++ b/Src/Core/App/Application.cpp
@@ -50,6 +50,7 @@ Application::Application(const ApplicationSpecification &spec)
     Input::Initialize(m_Window->GetNativeHandle());
     Input::SetEventBus(&m_EventBus);
     Time::Reset();
+    InitializeRHI();
 
     s_Instance = this;
 
@@ -66,6 +67,8 @@ Application::~Application()
 
     m_LayerStack.Clear();
     // m_ImGuiLayer = nullptr;
+    m_Swapchain.reset();
+    m_Device.reset();
     m_Window.reset();
 
     Diagnostics::Logger::Shutdown();
@@ -143,6 +146,9 @@ void Application::OnWindowResize(uint32_t width, uint32_t height)
 
     m_Minimized = false;
 
+    if (m_Swapchain)
+        m_Swapchain->resize(width, height);
+
     for (auto &layer : m_LayerStack)
         layer->OnResize(width, height);
 }
@@ -154,21 +160,70 @@ bool Application::ShouldRenderFrame() const
 
 void Application::BeginFrame()
 {
-    // Explicit-RHI frame begin work will live here:
-    // - swapchain image acquire
-    // - Device::beginFrame()
-    // - Device::beginCommandList()
+    if (!m_Device || !m_Swapchain)
+        return;
+
+    m_SwapchainImageIndex = m_Swapchain->acquireNextImage();
+    m_SwapchainImage = m_Swapchain->getImage(m_SwapchainImageIndex);
+    m_SwapchainImageView = m_Swapchain->getImageView(m_SwapchainImageIndex);
+
+    m_FrameContext = m_Device->beginFrame();
+    m_CommandList = m_Device->beginCommandList();
+
+    m_ResourceStateTracker.transition(m_SwapchainImage, TextureState::RenderTarget);
+    m_ResourceStateTracker.flushBarriers(m_CommandList);
+
+    ColorAttachmentInfo colorAttachment;
+    colorAttachment.view = m_SwapchainImageView;
+    colorAttachment.loadOp = LoadOp::Clear;
+    colorAttachment.storeOp = StoreOp::Store;
+    colorAttachment.clearValue = {0.08f, 0.10f, 0.12f, 1.0f};
+
+    RenderingInfo renderingInfo;
+    renderingInfo.colorAttachments = {colorAttachment};
+    renderingInfo.renderArea = {0, 0, m_Swapchain->width(), m_Swapchain->height()};
+
+    m_CommandList->beginRendering(renderingInfo);
 }
 
 void Application::EndFrame()
 {
-    // Explicit-RHI frame end work will live here:
-    // - command submission
-    // - Device::endFrame()
+    if (!m_Device || !m_Swapchain || !m_CommandList || !m_FrameContext)
+        return;
+
+    m_CommandList->endRendering();
+
+    m_ResourceStateTracker.transition(m_SwapchainImage, TextureState::Present);
+    m_ResourceStateTracker.flushBarriers(m_CommandList);
+
+    m_Device->submit(m_CommandList);
+    m_Device->endFrame(m_FrameContext);
+
+    m_FrameContext = nullptr;
+    m_CommandList = nullptr;
 }
 
 void Application::PresentFrame()
 {
-    // Explicit-RHI present work will live here:
-    // - swapchain->present()
+    if (!m_Swapchain || !m_SwapchainImageView)
+        return;
+
+    m_Swapchain->present(m_SwapchainImageIndex);
+    m_ResourceStateTracker.reset();
+    m_SwapchainImage = nullptr;
+    m_SwapchainImageView = nullptr;
+}
+
+void Application::InitializeRHI()
+{
+    m_Device = createDefaultDevice();
+
+    SwapchainDesc swapchainDesc;
+    swapchainDesc.width = m_Window->GetWidth();
+    swapchainDesc.height = m_Window->GetHeight();
+    swapchainDesc.format = Format::BGRA8_UNORM;
+    swapchainDesc.imageCount = 2;
+    swapchainDesc.vsync = true;
+
+    m_Swapchain = m_Device->createSwapchain(swapchainDesc, m_Window->GetNativeWindowHandle());
 }

--- a/Src/Core/App/Application.h
+++ b/Src/Core/App/Application.h
@@ -24,6 +24,7 @@
 #include "Core/Event/ScopedConnection.h"
 #include "Core/App/Window.h"
 #include "Core/App/LayerStack.h"
+#include "Render/RHI/RHI.h"
 
 class ImGuiLayer;
 
@@ -74,6 +75,8 @@ private:
     void EndFrame();
     /// Present the completed frame. Future explicit-RHI swapchain present lands here.
     void PresentFrame();
+    /// Create the backend-selected device and swapchain used by the application frame loop.
+    void InitializeRHI();
 
 private:
     // Non-owning singleton-style pointer. Lifetime is managed externally by the actual Application object.
@@ -90,6 +93,15 @@ private:
     // Set to true when the window refresh callback already rendered a frame
     // so that the main loop can skip the redundant render for that tick.
     bool m_FrameRenderedThisTick = false;
+
+    Scope<Device> m_Device;
+    Scope<Swapchain> m_Swapchain;
+    ResourceStateTracker m_ResourceStateTracker;
+    FrameContext *m_FrameContext = nullptr;
+    CommandList *m_CommandList = nullptr;
+    uint32_t m_SwapchainImageIndex = 0;
+    Texture *m_SwapchainImage = nullptr;
+    TextureView *m_SwapchainImageView = nullptr;
 
     ScopedConnection m_ResizeConnection;
 };

--- a/Src/Core/App/Application.h
+++ b/Src/Core/App/Application.h
@@ -59,6 +59,10 @@ public:
     const Window &GetWindow() const { return *m_Window; }
 
     EventBus &GetEventBus() { return m_EventBus; }
+    /// Transitional accessor for the command list currently being recorded.
+    /// Returns nullptr outside the active frame-recording window and should be
+    /// removed once a dedicated renderer-facing context exists.
+    CommandList *GetCurrentCommandList() const { return m_CommandList; }
 
     static Application &Get() { return *s_Instance; }
 

--- a/Src/Core/App/Application.h
+++ b/Src/Core/App/Application.h
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <cstdint>
+#include <limits>
 
 #include "Core/Util/Base.h"
 #include "Core/Event/EventBus.h"
@@ -99,7 +100,7 @@ private:
     ResourceStateTracker m_ResourceStateTracker;
     FrameContext *m_FrameContext = nullptr;
     CommandList *m_CommandList = nullptr;
-    uint32_t m_SwapchainImageIndex = 0;
+    uint32_t m_SwapchainImageIndex = std::numeric_limits<uint32_t>::max();
     Texture *m_SwapchainImage = nullptr;
     TextureView *m_SwapchainImageView = nullptr;
 

--- a/Src/Core/App/Application.h
+++ b/Src/Core/App/Application.h
@@ -1,17 +1,17 @@
 #pragma once
 
 /// @file Application.h
-/// @brief Top-level application class 鈥?owns the window, layer stack, and main loop.
+/// @brief Top-level application class - owns the window, layer stack, and main loop.
 ///
 /// Construction order:
-///   FileSystem::Init() - Diagnostics::Logger::Init() via /Saved/logs 鈫?Window 鈫?Input 鈫?Time 鈫?ImGuiLayer (overlay)
+///   FileSystem::Init() - Diagnostics::Logger::Init() via /Saved/logs - Window - Input - Time - ImGuiLayer (overlay)
 ///
 /// Main loop (Application::Run):
 ///   1. Poll OS events
 ///   2. Update frame time
 ///   3. Begin frame
 ///   4. For each layer: OnUpdate(dt) -> OnRender()
-///   5. ImGuiLayer::Begin() -> For each layer: OnImGuiRender() 鈫?ImGuiLayer::End()
+///   5. ImGuiLayer::Begin() -> For each layer: OnImGuiRender() -> ImGuiLayer::End()
 ///   6. End frame -> present
 ///
 /// Only one Application instance may exist at a time (enforced by s_Instance).


### PR DESCRIPTION
## Summary
- Initialize the backend-selected RHI device and swapchain from `Application`
- Drive the shell RHI frame lifecycle from `Application`
- Resize the swapchain when the window framebuffer size changes
- Tighten `Application` frame lifecycle invariants with explicit asserts
- Reset per-frame swapchain image state at frame boundaries
- Add a transitional `Application::GetCurrentCommandList()` accessor for early render-path integration

## Why
- Turning the previously empty application-side frame hooks into a real RHI-driven lifecycle
- Make the main loop own acquire/begin/end/present sequencing instead of leaving it as comments/placeholders
- Create a minimal vertical slice that the next clear/present work can build on
- Expose only the smallest temporary escape hatch needed for layer/demo code while the renderer-facing interface is still taking shape

## Affected areas
- `Src/Core/App/Application.h`
- `Src/Core/App/Application.cpp`

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Application frame flow was rewired to use the shell RHI path
- No backend-specific clear/present validation was performed in this PR

## Notes
- `GetCurrentCommandList()` is an explicitly transitional accessor and is expected to be removed once a dedicated renderer-facing context exists
