### PR TITLE
Add Vulkan SDK discovery and linkage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ jobs:
       - name: Set up MSVC developer command prompt
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Set up Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
+        with:
+          vulkan-query-version: 1.4.304.1
+          vulkan-components: Vulkan-Headers, Vulkan-Loader
+          vulkan-use-cache: true
+
       - name: Cache build
         uses: actions/cache@v5
         with:
@@ -90,6 +97,13 @@ jobs:
           sudo apt-get install -y ninja-build \
             libgl-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
             libxkbcommon-dev libwayland-dev
+
+      - name: Set up Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.1
+        with:
+          vulkan-query-version: 1.4.304.1
+          vulkan-components: Vulkan-Headers, Vulkan-Loader
+          vulkan-use-cache: true
 
       - name: Cache build
         uses: actions/cache@v5

--- a/CMake/Src/App.cmake
+++ b/CMake/Src/App.cmake
@@ -22,7 +22,5 @@ set_target_properties(RTRLab PROPERTIES
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES
     ${GLAB_CORE_SOURCES}
     ${GLAB_CORE_HEADERS}
-    ${GLAB_METAL_SOURCES}
-    ${GLAB_METAL_HEADERS}
     main.cpp
 )

--- a/CMake/Src/Core.cmake
+++ b/CMake/Src/Core.cmake
@@ -95,6 +95,15 @@ if(GLAB_BACKEND_METAL)
 endif()
 
 if(GLAB_BACKEND_VULKAN)
+    set_source_files_properties(
+        ${CMAKE_CURRENT_SOURCE_DIR}/Render/RHI/Backends/Vulkan/VulkanDevice.cpp
+        PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
+    )
+
+    target_link_libraries(RTRLabCore PUBLIC
+        Vulkan::Vulkan
+    )
+
     target_compile_definitions(RTRLabCore PUBLIC
         GLAB_BACKEND_VULKAN
     )

--- a/CMake/Src/Core.cmake
+++ b/CMake/Src/Core.cmake
@@ -10,21 +10,10 @@ target_include_directories(RTRLabCore PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-set_source_files_properties(
-    ${CMAKE_CURRENT_SOURCE_DIR}/Core/App/Window.cpp
-    PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
-)
-
-if(APPLE)
+if(GLAB_CORE_SKIP_UNITY_SOURCES)
+    list(TRANSFORM GLAB_CORE_SKIP_UNITY_SOURCES PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
     set_source_files_properties(
-        ${CMAKE_CURRENT_SOURCE_DIR}/Core/App/CocoaNativeWindow.mm
-        PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
-    )
-endif()
-
-if(UNIX AND NOT APPLE)
-    set_source_files_properties(
-        ${CMAKE_CURRENT_SOURCE_DIR}/Core/App/LinuxNativeWindow.cpp
+        ${GLAB_CORE_SKIP_UNITY_SOURCES}
         PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
     )
 endif()
@@ -60,12 +49,6 @@ if(GLAB_BACKEND_OPENGL)
     target_compile_definitions(RTRLabCore PUBLIC
         GLAB_BACKEND_OPENGL
     )
-
-    set_source_files_properties(
-        ${CMAKE_CURRENT_SOURCE_DIR}/Core/App/Application.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/Core/Input/Input.cpp
-        PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
-    )
 endif()
 
 if(APPLE)
@@ -76,15 +59,6 @@ if(APPLE)
 endif()
 
 if(GLAB_BACKEND_METAL)
-    target_sources(RTRLabCore PRIVATE
-        ${GLAB_METAL_SOURCES}
-        ${GLAB_METAL_HEADERS}
-    )
-
-    set_source_files_properties(${GLAB_METAL_SOURCES}
-        PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
-    )
-
     target_link_libraries(RTRLabCore PUBLIC
         "-framework Metal"
     )
@@ -95,11 +69,6 @@ if(GLAB_BACKEND_METAL)
 endif()
 
 if(GLAB_BACKEND_VULKAN)
-    set_source_files_properties(
-        ${CMAKE_CURRENT_SOURCE_DIR}/Render/RHI/Backends/Vulkan/VulkanDevice.cpp
-        PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
-    )
-
     target_link_libraries(RTRLabCore PUBLIC
         Vulkan::Vulkan
     )

--- a/CMake/Src/Sources.cmake
+++ b/CMake/Src/Sources.cmake
@@ -177,33 +177,57 @@ set(GLAB_RENDER_HEADERS
     Render/Shader/ShaderTypes.h
 )
 
+set(GLAB_RENDER_BACKEND_VULKAN_SOURCES
+    Render/RHI/Backends/Vulkan/VulkanDevice.cpp
+)
+
+set(GLAB_RENDER_BACKEND_VULKAN_HEADERS
+    Render/RHI/Backends/Vulkan/VulkanDevice.h
+)
+
+set(GLAB_RENDER_BACKEND_METAL_SOURCES
+    Render/RHI/Backends/Metal/MetalDevice.cpp
+)
+
+set(GLAB_RENDER_BACKEND_METAL_HEADERS
+    Render/RHI/Backends/Metal/MetalDevice.h
+)
+
+set(GLAB_RENDER_BACKEND_OPENGL_SOURCES
+    Render/RHI/Backends/OpenGL/OpenGLDevice.cpp
+)
+
+set(GLAB_RENDER_BACKEND_OPENGL_HEADERS
+    Render/RHI/Backends/OpenGL/OpenGLDevice.h
+)
+
 if(GLAB_BACKEND_VULKAN)
     list(APPEND GLAB_RENDER_SOURCES
-        Render/RHI/Backends/Vulkan/VulkanDevice.cpp
+        ${GLAB_RENDER_BACKEND_VULKAN_SOURCES}
     )
 
     list(APPEND GLAB_RENDER_HEADERS
-        Render/RHI/Backends/Vulkan/VulkanDevice.h
+        ${GLAB_RENDER_BACKEND_VULKAN_HEADERS}
     )
 endif()
 
 if(GLAB_BACKEND_METAL)
     list(APPEND GLAB_RENDER_SOURCES
-        Render/RHI/Backends/Metal/MetalDevice.cpp
+        ${GLAB_RENDER_BACKEND_METAL_SOURCES}
     )
 
     list(APPEND GLAB_RENDER_HEADERS
-        Render/RHI/Backends/Metal/MetalDevice.h
+        ${GLAB_RENDER_BACKEND_METAL_HEADERS}
     )
 endif()
 
 if(GLAB_BACKEND_OPENGL)
     list(APPEND GLAB_RENDER_SOURCES
-        Render/RHI/Backends/OpenGL/OpenGLDevice.cpp
+        ${GLAB_RENDER_BACKEND_OPENGL_SOURCES}
     )
 
     list(APPEND GLAB_RENDER_HEADERS
-        Render/RHI/Backends/OpenGL/OpenGLDevice.h
+        ${GLAB_RENDER_BACKEND_OPENGL_HEADERS}
     )
 endif()
 
@@ -248,8 +272,40 @@ else()
     )
 endif()
 
-set(GLAB_METAL_SOURCES)
-set(GLAB_METAL_HEADERS)
+set(GLAB_CORE_SKIP_UNITY_SOURCES
+    Core/App/Window.cpp
+)
+
+if(APPLE)
+    list(APPEND GLAB_CORE_SKIP_UNITY_SOURCES
+        Core/App/CocoaNativeWindow.mm
+    )
+endif()
+
+if(UNIX AND NOT APPLE)
+    list(APPEND GLAB_CORE_SKIP_UNITY_SOURCES
+        Core/App/LinuxNativeWindow.cpp
+    )
+endif()
+
+if(GLAB_BACKEND_OPENGL)
+    list(APPEND GLAB_CORE_SKIP_UNITY_SOURCES
+        Core/App/Application.cpp
+        Core/Input/Input.cpp
+    )
+endif()
+
+if(GLAB_BACKEND_METAL)
+    list(APPEND GLAB_CORE_SKIP_UNITY_SOURCES
+        ${GLAB_RENDER_BACKEND_METAL_SOURCES}
+    )
+endif()
+
+if(GLAB_BACKEND_VULKAN)
+    list(APPEND GLAB_CORE_SKIP_UNITY_SOURCES
+        ${GLAB_RENDER_BACKEND_VULKAN_SOURCES}
+    )
+endif()
 
 set(GLAB_CORE_SOURCES
     ${GLAB_APP_SOURCES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ if(GLAB_BACKEND_OPENGL)
     find_package(OpenGL REQUIRED)
 endif()
 
+if(GLAB_BACKEND_VULKAN)
+    find_package(Vulkan REQUIRED)
+endif()
+
 add_subdirectory(Vendor)
 add_subdirectory(Src)
 


### PR DESCRIPTION
## Summary
- Add `find_package(Vulkan REQUIRED)` when the Vulkan backend is selected
- Link `RTRLabCore` against `Vulkan::Vulkan`
- Exclude the Vulkan backend translation unit from unity build inclusion for safer backend bring-up
- Provision the Vulkan SDK in the primary Windows and Linux CI jobs
- Keep OpenGL compatibility CI lanes unchanged

## Why
- Windows and Linux now default to the Vulkan backend, so the build system must explicitly discover and link the Vulkan SDK
- Wiring the Vulkan SDK now unblocks the next backend step without rolling back the Vulkan-first build direction
- Isolating the Vulkan backend source from unity build keeps future Vulkan implementation work less fragile

## Affected areas
- `CMakeLists.txt`
- `CMake/Src/Core.cmake`
- `.github/workflows/ci.yml`

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Local configure previously failed until the Vulkan SDK environment was available
- CI primary Windows/Linux Vulkan jobs are now configured to install the Vulkan SDK before CMake configure
- No runtime Vulkan backend validation was added in this PR

## Notes
- This PR only handles Vulkan build-system and CI provisioning
- It does not add Vulkan runtime objects or swapchain implementation yet
- OpenGL compatibility lanes remain debug-only and were intentionally left untouched
