### PR TITLE
Fix replay connection events and IsFinished semantics

### DIFF
--- a/Src/Core/Input/Replay/InputRecording.cpp
+++ b/Src/Core/Input/Replay/InputRecording.cpp
@@ -406,7 +406,6 @@ void InputReplaySession::OnBeforePollAll(InputDeviceManager&, float dt)
         m_HasTimingMismatch = true;
 
     ++m_NextFrameIndex;
-    m_IsFinished = (m_NextFrameIndex >= m_Recording.frames.size());
 }
 
 const RecordedGamepadState* InputReplaySession::FindGamepadState(const InputFrame* frame, uint8_t deviceIndex)

--- a/Src/Core/Input/Replay/ReplayDevice.cpp
+++ b/Src/Core/Input/Replay/ReplayDevice.cpp
@@ -52,6 +52,12 @@ bool ReplayKeyboardDevice::WasConnected() const
     return state ? state->isConnected : false;
 }
 
+bool ReplayKeyboardDevice::HasConnectionStateChanged() const
+{
+    const auto* previous = m_Session.GetPreviousKeyboardState();
+    return previous != nullptr && IsConnected() != WasConnected();
+}
+
 InputValue ReplayMouseDevice::GetInput(uint16_t code) const
 {
     return BoolToValue(IsMouseButtonDown(m_Session.GetMouseState(), code));
@@ -118,6 +124,12 @@ bool ReplayMouseDevice::WasConnected() const
     return state ? state->isConnected : false;
 }
 
+bool ReplayMouseDevice::HasConnectionStateChanged() const
+{
+    const auto* previous = m_Session.GetPreviousMouseState();
+    return previous != nullptr && IsConnected() != WasConnected();
+}
+
 InputValue ReplayGamepadDevice::GetInput(uint16_t code) const
 {
     return BoolToValue(IsGamepadButtonDown(m_Session.GetGamepadState(m_DeviceIndex), code));
@@ -148,4 +160,10 @@ bool ReplayGamepadDevice::WasConnected() const
 {
     const auto* state = m_Session.GetPreviousGamepadState(m_DeviceIndex);
     return state ? state->isConnected : false;
+}
+
+bool ReplayGamepadDevice::HasConnectionStateChanged() const
+{
+    const auto* previous = m_Session.GetPreviousGamepadState(m_DeviceIndex);
+    return previous != nullptr && IsConnected() != WasConnected();
 }

--- a/Src/Core/Input/Replay/ReplayDevice.h
+++ b/Src/Core/Input/Replay/ReplayDevice.h
@@ -29,6 +29,7 @@ public:
     InputValue GetPreviousInput(uint16_t code) const override;
     bool IsConnected() const override;
     bool WasConnected() const override;
+    bool HasConnectionStateChanged() const override;
 };
 
 class ReplayMouseDevice final : public ReplayDevice
@@ -44,6 +45,7 @@ public:
     InputValue GetPreviousAxis(uint16_t axisId) const override;
     bool IsConnected() const override;
     bool WasConnected() const override;
+    bool HasConnectionStateChanged() const override;
 };
 
 class ReplayGamepadDevice final : public ReplayDevice
@@ -59,4 +61,5 @@ public:
     InputValue GetPreviousAxis(uint16_t axisId) const override;
     bool IsConnected() const override;
     bool WasConnected() const override;
+    bool HasConnectionStateChanged() const override;
 };


### PR DESCRIPTION
## Summary
- Override `HasConnectionStateChanged()` in the three `ReplayDevice` subclasses so that connection/disconnection events recorded in the stream are re-published during replay.
- Stop marking `InputReplaySession` as finished in the same `OnBeforePollAll` that loads the last frame; `IsFinished()` now only becomes true once the session has actually overshot the end of the recording.

## Why
- `InputDeviceManager::PollAll` gates `DeviceConnectionChangedEvent` / `GamepadConnectedEvent` / `GamepadDisconnectedEvent` on `HasConnectionStateChanged()`. The replay devices only overrode `IsConnected()` / `WasConnected()`, so the base-class default `false` silently swallowed every connection transition during playback.
- The previous `m_IsFinished = (m_NextFrameIndex >= Frames.size())` assignment fired the same tick that the last frame was loaded, so `GetCurrentFrame() != nullptr` and `IsFinished() == true` held simultaneously. A caller that used `IsFinished()` as a stop gate could skip the final frame.

## Affected areas
- `Src/Core/Input/Replay/ReplayDevice.h` / `ReplayDevice.cpp`
- `Src/Core/Input/Replay/InputRecording.cpp`

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Existing `TestInputRecording` suite still passes (including `ReplayDevicesExposeCurrentAndPreviousRecordedState`, which polls one extra tick past the final frame before asserting `IsFinished()`).

## Notes
- First-poll connection changes are intentionally suppressed (via the `previous != nullptr` guard) to match `GamepadDevice`'s `m_HasPolledOnce` behavior; a gamepad that appears for the very first time with `isConnected=true` will not re-fire a spurious connected event.
- New tests covering replayed connection transitions and the refined `IsFinished()` boundary are worth adding as a follow-up but are out of scope for this fix.
