### PR TITLE
Migrate linear algebra math library from glm to eigen

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,4 @@
 [submodule "Vendor/eigen"]
 	path = Vendor/eigen
 	url = https://gitlab.com/libeigen/eigen.git
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "vendor/glfw"]
 	path = Vendor/glfw
 	url = https://github.com/glfw/glfw.git
-[submodule "vendor/glm"]
-	path = Vendor/glm
-	url = https://github.com/g-truc/glm.git
 [submodule "vendor/imgui"]
 	path = Vendor/imgui
 	url = https://github.com/ocornut/imgui.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 	path = Vendor/imgui
 	url = https://github.com/ocornut/imgui.git
 	branch = docking
+[submodule "Vendor/eigen"]
+	path = Vendor/eigen
+	url = https://gitlab.com/libeigen/eigen.git

--- a/CMake/Src/Core.cmake
+++ b/CMake/Src/Core.cmake
@@ -28,6 +28,7 @@ endif()
 target_link_libraries(RTRLabCore PUBLIC
     glfw
     glm
+    eigen
     imgui
     magic_enum
     nlohmann_json

--- a/CMake/Src/Core.cmake
+++ b/CMake/Src/Core.cmake
@@ -27,7 +27,6 @@ endif()
 
 target_link_libraries(RTRLabCore PUBLIC
     glfw
-    glm
     eigen
     imgui
     magic_enum
@@ -91,7 +90,6 @@ if(UNIX AND NOT APPLE)
 endif()
 
 target_compile_definitions(RTRLabCore PUBLIC
-    GLM_ENABLE_EXPERIMENTAL
     $<$<CONFIG:Debug>:RTRLAB_CONFIG_DEBUG>
     $<$<CONFIG:RelWithDebInfo>:RTRLAB_CONFIG_RELWITHDEBINFO>
     $<$<CONFIG:Release>:RTRLAB_CONFIG_RELEASE>

--- a/Docs/EN/NamingConventions.md
+++ b/Docs/EN/NamingConventions.md
@@ -50,7 +50,7 @@ Examples:
 ```cpp
 void Initialize();
 void BeginFrame();
-void SetPosition(const glm::vec3& position);
+void SetPosition(const Math::Vec3& position);
 bool ShouldRenderFrame() const;
 ```
 

--- a/Docs/Modules/SerializationSystem/CodeReview.md
+++ b/Docs/Modules/SerializationSystem/CodeReview.md
@@ -17,7 +17,7 @@ Code review of the `src/Core/Serialization/` module and its primary consumer
 - [Serialization System Code Review](#serialization-system-code-review)
   - [Table of Contents](#table-of-contents)
   - [Summary](#summary)
-  - [1. Bug Risk: GLM Deserialization Is Not Atomic](#1-bug-risk-glm-deserialization-is-not-atomic)
+  - [1. Bug Risk: Math Deserialization Is Not Atomic](#1-bug-risk-math-deserialization-is-not-atomic)
   - [2. Interface Contract: ReadFromString Does Not Guarantee tree Unchanged on Failure](#2-interface-contract-readfromstring-does-not-guarantee-tree-unchanged-on-failure)
   - [3. Compile Performance: BuiltinTraits.h Is a Heavyweight Header](#3-compile-performance-builtintraitsh-is-a-heavyweight-header)
   - [4. Interface Contract: LoadFromFile Requires Default-Constructible T](#4-interface-contract-loadfromfile-requires-default-constructible-t)
@@ -53,12 +53,12 @@ design/document mismatches.
 
 ---
 
-## 1. Bug Risk: GLM Deserialization Is Not Atomic
+## 1. Bug Risk: Math Deserialization Is Not Atomic
 
 **File**: `src/Core/Serialization/BuiltinTraits.h:172-227`
 
 ```cpp
-inline bool Deserialize(const PropertyTree &tree, glm::vec2 &v)
+inline bool Deserialize(const PropertyTree &tree, Math::Vec2 &v)
 {
     if (!tree.IsArray() || tree.Size() != 2)
         return false;
@@ -69,15 +69,15 @@ inline bool Deserialize(const PropertyTree &tree, glm::vec2 &v)
 ```
 
 The design document promises that partial failures do not commit, and most container
-traits follow that rule by deserializing into temporaries. However, `glm::vec2`, `vec3`,
-`vec4`, and `mat4` write directly into the destination object.
+traits follow that rule by deserializing into temporaries. However, `Math::Vec2`, `Vec3`,
+`Vec4`, and `Mat4` write directly into the destination object.
 
 In practice the risk is low because the shape checks are strong and `AsFloat()` accepts
 integer values, but this is still inconsistent with the atomicity story the rest of the
 framework tells.
 
 **Recommendation**: deserialize into local temporaries first, then assign on success. If
-that is intentionally out of scope, document GLM traits as in-place exceptions.
+that is intentionally out of scope, document math traits as in-place exceptions.
 
 ---
 
@@ -102,16 +102,16 @@ on success.
 
 **File**: `src/Core/Serialization/BuiltinTraits.h`
 
-This header pulls in GLM, `magic_enum`, and standard container traits in one place. Any
+This header pulls in math traits, `magic_enum`, and standard container traits in one place. Any
 consumer that needs even a small subset of built-in traits transitively pays for all of
 them.
 
-That is manageable at current scale, but `magic_enum` and GLM are both meaningful compile
+That is manageable at current scale, but `magic_enum` and the math traits are both meaningful compile
 time contributors, so this header is likely to become a build-time hotspot as adoption
 widens.
 
 **Recommendation**: split into focused headers such as `PrimitiveTraits.h`,
-`ContainerTraits.h`, `EnumTraits.h`, and `GlmTraits.h`, while keeping
+`ContainerTraits.h`, `EnumTraits.h`, and `MathTraits.h`, while keeping
 `BuiltinTraits.h` as a convenience umbrella include.
 
 ---

--- a/Docs/Modules/SerializationSystem/Design.md
+++ b/Docs/Modules/SerializationSystem/Design.md
@@ -70,7 +70,7 @@ path to YAML or binary.
 
 - **Format independence** — domain types serialize into a `PropertyTree`; backends translate that tree to JSON, YAML, or binary. Swapping formats requires zero changes to domain code.
 - **ADL-based traits** — free function pairs `Serialize` / `Deserialize` discovered via argument-dependent lookup. No base class, no virtual functions, no registration macros.
-- **Built-in trait library** — out-of-the-box support for primitives, GLM types, `enum class` (via `magic_enum`), and standard containers.
+- **Built-in trait library** — out-of-the-box support for primitives, engine math types, `enum class` (via `magic_enum`), and standard containers.
 - **Single coupling point** — `#include <json.hpp>` appears only in `JsonBackend.cpp`. No other engine file imports nlohmann/json for serialization.
 - **Consistent error handling** — unknown keys warn rather than reject, type mismatches warn and skip, partial failures never commit.
 - **Atomic load** — `LoadFromFile` deserializes into a temporary, then moves on success; the caller's value is unchanged if deserialization fails.
@@ -184,7 +184,7 @@ private:
 - `Int` is `int64_t` — covers all integer types the project uses.
 - `IsNumber()` returns true for either Int or Float, simplifying numeric deserialization.
 - `operator[](const std::string&)` on a Null tree auto-promotes to Object for ergonomic building.
-- No `glm::vec3` etc. in the tree — those are composed from arrays in the trait layer.
+- No `Math::Vec3` etc. in the tree — those are composed from arrays in the trait layer.
 - Variant-based, no heap allocation for scalars.
 - `AsFloat()` accepts `Int` and promotes — simplifies numeric deserialization without requiring `IsNumber()` checks in every trait.
 
@@ -229,7 +229,7 @@ no `.cpp` needed):
 |----------|-------|-------|
 | **Primitives** | `bool`, `int`, `int64_t`, `float`, `double`, `std::string`, `uint8_t`, `uint16_t` | Direct tree assignment; numeric Deserialize uses `IsNumber()` for int→float promotion |
 | **Named enums** | Any `enum class` via `magic_enum` | Serialize as string token; Deserialize with `enum_cast`. Opt out by providing a custom overload (e.g., `Key::Code` uses `InputNames.h`) |
-| **GLM** | `glm::vec2`, `glm::vec3`, `glm::vec4`, `glm::mat4` | Arrays: `[x,y]`, `[x,y,z]`, `[x,y,z,w]`, 16 floats column-major |
+| **Math** | `Math::Vec2`, `Math::Vec3`, `Math::Vec4`, `Math::Mat4` | Arrays: `[x,y]`, `[x,y,z]`, `[x,y,z,w]`, 16 floats column-major |
 | **Containers** | `std::vector<T>`, `std::unordered_map<std::string, T>`, `std::optional<T>` | Require `Serializable T`; optional serializes as null when empty |
 
 Enum trait default path (magic_enum):
@@ -665,7 +665,7 @@ src/
     serialization/
       PropertyTree.h / .cpp        ✅ Layer 0: intermediate representation
       SerializationTraits.h        ✅ Layer 1: Serializable concept
-      BuiltinTraits.h              ✅ Layer 1: primitives, glm, enum, containers (header-only)
+      BuiltinTraits.h              ✅ Layer 1: primitives, math, enum, containers (header-only)
       IFormatBackend.h             ✅ Layer 2: backend interface
       JsonBackend.h / .cpp         ✅ Layer 2: nlohmann/json backend
       Serialization.h              ✅ Layer 4: convenience SaveToFile/LoadFromFile (header-only)

--- a/Docs/Modules/SerializationSystem/Internals.md
+++ b/Docs/Modules/SerializationSystem/Internals.md
@@ -29,7 +29,7 @@ design rationale. This document focuses on implementation mechanics and industry
       - [3.2 ADL Discovery Mechanics](#32-adl-discovery-mechanics)
       - [3.3 Builtin Trait Catalog](#33-builtin-trait-catalog)
       - [3.4 Enum Serialization via magic\_enum](#34-enum-serialization-via-magic_enum)
-      - [3.5 GLM Type Traits](#35-glm-type-traits)
+      - [3.5 Math Type Traits](#35-math-type-traits)
       - [3.6 Container Traits and Atomicity](#36-container-traits-and-atomicity)
       - [3.7 Domain Type Traits — InputActionMap Case Study](#37-domain-type-traits--inputactionmap-case-study)
     - [4. Layer 2: Format Backends](#4-layer-2-format-backends)
@@ -262,8 +262,8 @@ simply provide a more-specific overload, which C++ overload resolution prefers.
 | Narrow ints | `uint8_t`, `uint16_t` | Int node (promoted via `static_cast<int>`) | `IsInt()` + range check (0..max) |
 | Asset refs | `Resource::AssetPath` | String (validated logical path) | `IsString()` + `TryCreate` validation |
 | Enums | any `enum class` | String via `magic_enum::enum_name` | `IsString()` + `magic_enum::enum_cast` |
-| GLM | `vec2`, `vec3`, `vec4` | Array of floats | `IsArray()` + size check |
-| GLM | `mat4` | Array of 16 floats (column-major) | `IsArray()` + `Size() == 16` |
+| Math | `Vec2`, `Vec3`, `Vec4` | Array of floats | `IsArray()` + size check |
+| Math | `Mat4` | Array of 16 floats (column-major) | `IsArray()` + `Size() == 16` |
 | Containers | `std::vector<T>` | Array of serialized `T` | Element-wise deserialize into temp |
 | Containers | `std::unordered_map<std::string, T>` | Object with string keys | Entry-wise deserialize into temp |
 | Containers | `std::optional<T>` | Null when empty, serialized T otherwise | `IsNull()` → nullopt, else deserialize |
@@ -314,19 +314,19 @@ Important caveats:
 - `magic_enum` instantiates significant compile-time templates per enum type. This is
   concentrated in `BuiltinTraits.h` — any file including it pays the compilation cost.
 
-#### 3.5 GLM Type Traits
+#### 3.5 Math Type Traits
 
-GLM vectors serialize as JSON arrays:
+Engine math vectors serialize as JSON arrays:
 
 ```
-glm::vec3{1.0, 2.0, 3.0}  →  [1.0, 2.0, 3.0]
-glm::mat4                  →  [16 floats, column-major]
+Math::Vec3{1.0, 2.0, 3.0}  →  [1.0, 2.0, 3.0]
+Math::Mat4                  →  [16 floats, column-major]
 ```
 
 Deserialization validates the array size before reading elements. For `vec3`:
 
 ```cpp
-inline bool Deserialize(const PropertyTree &tree, glm::vec3 &v)
+inline bool Deserialize(const PropertyTree &tree, Math::Vec3 &v)
 {
     if (!tree.IsArray() || tree.Size() != 3)
         return false;
@@ -337,7 +337,7 @@ inline bool Deserialize(const PropertyTree &tree, glm::vec3 &v)
 }
 ```
 
-Note: GLM traits write directly into the output parameter rather than deserializing
+Note: math traits write directly into the output parameter rather than deserializing
 into a local temporary. This means if `AsFloat()` were to throw after `v.x` is already
 written, `v` would be left in a partially modified state. In practice the preceding
 `IsArray() && Size() == 3` check prevents reaching `AsFloat()` with bad data, so the
@@ -870,7 +870,7 @@ current stage:
   shipping engines, implemented cleanly.
 
 **Architectural risks**:
-- `BuiltinTraits.h` is a compilation bottleneck — pulling in GLM, magic_enum, and all
+- `BuiltinTraits.h` is a compilation bottleneck — pulling in math traits, magic_enum, and all
   container headers into every consumer. Splitting into focused headers before the type
   count grows would prevent build time regression.
 - magic_enum token instability — currently mitigated by custom overloads for

--- a/Docs/ZH_CN/README.ZH_CN.md
+++ b/Docs/ZH_CN/README.ZH_CN.md
@@ -114,7 +114,7 @@ git submodule update --init --recursive
 当前固定的子模块版本：
 
 - `GLFW`: `3.4.0`
-- `GLM`: `1.0.3`
+- `Eigen`: `5.0.0`
 - `Dear ImGui`: `1.92.6`（`docking` 分支）
 
 ### 使用 Presets 构建
@@ -252,7 +252,7 @@ ctest --preset test-windows-release
 | 库 | 作用 | 来源 |
 | --- | --- | --- |
 | [GLFW](https://github.com/glfw/glfw) | 窗口与输入 | Git 子模块（`Vendor/glfw`，`3.4.0`） |
-| [GLM](https://github.com/g-truc/glm) | 线性代数 | Git 子模块（`Vendor/glm`，`1.0.3`） |
+| [Eigen](https://eigen.tuxfamily.org/) | 线性代数 | Git 子模块（`Vendor/eigen`，`5.0.0`） |
 | [STB Image](https://github.com/nothings/stb) | 图像加载 | `Vendor/stb/` |
 | [Dear ImGui](https://github.com/ocornut/imgui) | 调试 GUI | Git 子模块（`Vendor/imgui`，`1.92.6`，`docking` 分支） |
 | [spdlog](https://github.com/gabime/spdlog) | 日志系统 | `Vendor/spdlog/` |

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ cd RT_Rendering_Lab
 Current pinned submodule versions:
 
 - `GLFW`: `3.4.0`
-- `GLM`: `1.0.3`
+- `Eigen`: `5.0.0`
 - `Dear ImGui`: `1.92.6` (`docking` branch)
 
 ### Build with Presets
@@ -248,7 +248,7 @@ Preset defaults can override these project-level defaults. In particular, the sh
 | Library                                                    | Purpose                    | Source                                                       |
 | ---------------------------------------------------------- | -------------------------- | ------------------------------------------------------------ |
 | [GLFW](https://github.com/glfw/glfw)                       | Windowing & input          | Git submodule (`Vendor/glfw`, `3.4.0`)                       |
-| [GLM](https://github.com/g-truc/glm)                       | Linear algebra             | Git submodule (`Vendor/glm`, `1.0.3`)                        |
+| [Eigen](https://eigen.tuxfamily.org/)                      | Linear algebra             | Git submodule (`Vendor/eigen`, `5.0.0`)                      |
 | [STB Image](https://github.com/nothings/stb)               | Image loading              | `Vendor/stb/`                                                |
 | [Dear ImGui](https://github.com/ocornut/imgui)             | Debug GUI                  | Git submodule (`Vendor/imgui`, `1.92.6`, `docking` branch)   |
 | [spdlog](https://github.com/gabime/spdlog)                 | Logging                    | `Vendor/spdlog/`                                             |

--- a/Src/Core/Serialization/BuiltinTraits.h
+++ b/Src/Core/Serialization/BuiltinTraits.h
@@ -1,15 +1,15 @@
 #pragma once
 
 /// @file BuiltinTraits.h
-/// @brief Built-in Serialize/Deserialize overloads for primitives, GLM types,
-///        enums (via magic_enum), and standard containers.
+/// @brief Built-in Serialize/Deserialize overloads for primitives, Eigen vector/matrix
+///        types, enums (via magic_enum), and standard containers.
 
 #include "Core/Serialization/SerializationTraits.h"
 #include "Core/Diagnostics/Logging/LogCategories.h"
 #include "Core/Diagnostics/Logging/LogMacros.h"
 #include "Core/Resource/Catalog/AssetPath.h"
 
-#include <glm/glm.hpp>
+#include <Eigen/Core>
 #include <magic_enum.hpp>
 
 #include <optional>
@@ -184,73 +184,73 @@ bool Deserialize(const PropertyTree& tree, E& value)
 }
 
 // ---------------------------------------------------------------------
-// GLM types
+// Eigen vector / matrix types
 // ---------------------------------------------------------------------
 
-// --- glm::vec2 ---
-inline void Serialize(PropertyTree& tree, const glm::vec2& v)
+// --- Eigen::Vector2f ---
+inline void Serialize(PropertyTree& tree, const Eigen::Vector2f& v)
 {
-    tree = PropertyTree::Array{PropertyTree(v.x), PropertyTree(v.y)};
+    tree = PropertyTree::Array{PropertyTree(v.x()), PropertyTree(v.y())};
 }
 
-inline bool Deserialize(const PropertyTree& tree, glm::vec2& v)
+inline bool Deserialize(const PropertyTree& tree, Eigen::Vector2f& v)
 {
     if (!tree.IsArray() || tree.Size() != 2)
         return false;
-    v.x = static_cast<float>(tree[size_t(0)].AsFloat());
-    v.y = static_cast<float>(tree[size_t(1)].AsFloat());
+    v.x() = static_cast<float>(tree[size_t(0)].AsFloat());
+    v.y() = static_cast<float>(tree[size_t(1)].AsFloat());
     return true;
 }
 
-// --- glm::vec3 ---
-inline void Serialize(PropertyTree& tree, const glm::vec3& v)
+// --- Eigen::Vector3f ---
+inline void Serialize(PropertyTree& tree, const Eigen::Vector3f& v)
 {
-    tree = PropertyTree::Array{PropertyTree(v.x), PropertyTree(v.y), PropertyTree(v.z)};
+    tree = PropertyTree::Array{PropertyTree(v.x()), PropertyTree(v.y()), PropertyTree(v.z())};
 }
 
-inline bool Deserialize(const PropertyTree& tree, glm::vec3& v)
+inline bool Deserialize(const PropertyTree& tree, Eigen::Vector3f& v)
 {
     if (!tree.IsArray() || tree.Size() != 3)
         return false;
-    v.x = static_cast<float>(tree[size_t(0)].AsFloat());
-    v.y = static_cast<float>(tree[size_t(1)].AsFloat());
-    v.z = static_cast<float>(tree[size_t(2)].AsFloat());
+    v.x() = static_cast<float>(tree[size_t(0)].AsFloat());
+    v.y() = static_cast<float>(tree[size_t(1)].AsFloat());
+    v.z() = static_cast<float>(tree[size_t(2)].AsFloat());
     return true;
 }
 
-// --- glm::vec4 ---
-inline void Serialize(PropertyTree& tree, const glm::vec4& v)
+// --- Eigen::Vector4f ---
+inline void Serialize(PropertyTree& tree, const Eigen::Vector4f& v)
 {
-    tree = PropertyTree::Array{PropertyTree(v.x), PropertyTree(v.y), PropertyTree(v.z), PropertyTree(v.w)};
+    tree = PropertyTree::Array{PropertyTree(v.x()), PropertyTree(v.y()), PropertyTree(v.z()), PropertyTree(v.w())};
 }
 
-inline bool Deserialize(const PropertyTree& tree, glm::vec4& v)
+inline bool Deserialize(const PropertyTree& tree, Eigen::Vector4f& v)
 {
     if (!tree.IsArray() || tree.Size() != 4)
         return false;
-    v.x = static_cast<float>(tree[size_t(0)].AsFloat());
-    v.y = static_cast<float>(tree[size_t(1)].AsFloat());
-    v.z = static_cast<float>(tree[size_t(2)].AsFloat());
-    v.w = static_cast<float>(tree[size_t(3)].AsFloat());
+    v.x() = static_cast<float>(tree[size_t(0)].AsFloat());
+    v.y() = static_cast<float>(tree[size_t(1)].AsFloat());
+    v.z() = static_cast<float>(tree[size_t(2)].AsFloat());
+    v.w() = static_cast<float>(tree[size_t(3)].AsFloat());
     return true;
 }
 
-// --- glm::mat4 (16 floats, column-major) ---
-inline void Serialize(PropertyTree& tree, const glm::mat4& m)
+// --- Eigen::Matrix4f (16 floats, column-major) ---
+inline void Serialize(PropertyTree& tree, const Eigen::Matrix4f& m)
 {
     PropertyTree::Array arr;
     arr.reserve(16);
-    const float* p = &m[0][0];
+    const float* p = m.data();
     for (int i = 0; i < 16; ++i)
         arr.push_back(PropertyTree(p[i]));
     tree = std::move(arr);
 }
 
-inline bool Deserialize(const PropertyTree& tree, glm::mat4& m)
+inline bool Deserialize(const PropertyTree& tree, Eigen::Matrix4f& m)
 {
     if (!tree.IsArray() || tree.Size() != 16)
         return false;
-    float* p = &m[0][0];
+    float* p = m.data();
     for (int i = 0; i < 16; ++i)
         p[i] = static_cast<float>(tree[size_t(i)].AsFloat());
     return true;

--- a/Src/Core/Serialization/BuiltinTraits.h
+++ b/Src/Core/Serialization/BuiltinTraits.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /// @file BuiltinTraits.h
-/// @brief Built-in Serialize/Deserialize overloads for primitives, Eigen vector/matrix
+/// @brief Built-in Serialize/Deserialize overloads for primitives, engine math
 ///        types, enums (via magic_enum), and standard containers.
 
 #include "Core/Serialization/SerializationTraits.h"
@@ -9,7 +9,8 @@
 #include "Core/Diagnostics/Logging/LogMacros.h"
 #include "Core/Resource/Catalog/AssetPath.h"
 
-#include <Eigen/Core>
+#include "Core/Util/Math.h"
+
 #include <magic_enum.hpp>
 
 #include <optional>
@@ -184,16 +185,16 @@ bool Deserialize(const PropertyTree& tree, E& value)
 }
 
 // ---------------------------------------------------------------------
-// Eigen vector / matrix types
+// Engine math types
 // ---------------------------------------------------------------------
 
-// --- Eigen::Vector2f ---
-inline void Serialize(PropertyTree& tree, const Eigen::Vector2f& v)
+// --- Math::Vec2 ---
+inline void Serialize(PropertyTree& tree, const Math::Vec2& v)
 {
     tree = PropertyTree::Array{PropertyTree(v.x()), PropertyTree(v.y())};
 }
 
-inline bool Deserialize(const PropertyTree& tree, Eigen::Vector2f& v)
+inline bool Deserialize(const PropertyTree& tree, Math::Vec2& v)
 {
     if (!tree.IsArray() || tree.Size() != 2)
         return false;
@@ -202,13 +203,13 @@ inline bool Deserialize(const PropertyTree& tree, Eigen::Vector2f& v)
     return true;
 }
 
-// --- Eigen::Vector3f ---
-inline void Serialize(PropertyTree& tree, const Eigen::Vector3f& v)
+// --- Math::Vec3 ---
+inline void Serialize(PropertyTree& tree, const Math::Vec3& v)
 {
     tree = PropertyTree::Array{PropertyTree(v.x()), PropertyTree(v.y()), PropertyTree(v.z())};
 }
 
-inline bool Deserialize(const PropertyTree& tree, Eigen::Vector3f& v)
+inline bool Deserialize(const PropertyTree& tree, Math::Vec3& v)
 {
     if (!tree.IsArray() || tree.Size() != 3)
         return false;
@@ -218,13 +219,13 @@ inline bool Deserialize(const PropertyTree& tree, Eigen::Vector3f& v)
     return true;
 }
 
-// --- Eigen::Vector4f ---
-inline void Serialize(PropertyTree& tree, const Eigen::Vector4f& v)
+// --- Math::Vec4 ---
+inline void Serialize(PropertyTree& tree, const Math::Vec4& v)
 {
     tree = PropertyTree::Array{PropertyTree(v.x()), PropertyTree(v.y()), PropertyTree(v.z()), PropertyTree(v.w())};
 }
 
-inline bool Deserialize(const PropertyTree& tree, Eigen::Vector4f& v)
+inline bool Deserialize(const PropertyTree& tree, Math::Vec4& v)
 {
     if (!tree.IsArray() || tree.Size() != 4)
         return false;
@@ -235,8 +236,8 @@ inline bool Deserialize(const PropertyTree& tree, Eigen::Vector4f& v)
     return true;
 }
 
-// --- Eigen::Matrix4f (16 floats, column-major) ---
-inline void Serialize(PropertyTree& tree, const Eigen::Matrix4f& m)
+// --- Math::Mat4 (16 floats, column-major) ---
+inline void Serialize(PropertyTree& tree, const Math::Mat4& m)
 {
     PropertyTree::Array arr;
     arr.reserve(16);
@@ -246,7 +247,7 @@ inline void Serialize(PropertyTree& tree, const Eigen::Matrix4f& m)
     tree = std::move(arr);
 }
 
-inline bool Deserialize(const PropertyTree& tree, Eigen::Matrix4f& m)
+inline bool Deserialize(const PropertyTree& tree, Math::Mat4& m)
 {
     if (!tree.IsArray() || tree.Size() != 16)
         return false;

--- a/Src/Core/Util/Math.h
+++ b/Src/Core/Util/Math.h
@@ -6,7 +6,7 @@
 /// The engine keeps Eigen as the implementation layer but centralizes its
 /// render-facing aliases and projection helpers here so backend-sensitive
 /// choices stay explicit. For Vulkan/Metal-facing rendering code, prefer the
-/// explicit RH_ZO helpers rather than relying on historical glm defaults.
+/// explicit RH_ZO helpers rather than relying on historical clip-space defaults.
 
 #include <cmath>
 #include <numbers>
@@ -31,7 +31,7 @@ inline float Radians(float degrees)
     return degrees * (std::numbers::pi_v<float> / 180.0f);
 }
 
-/// Post-multiply `m` by a translation matrix built from `v`. Matches glm::translate.
+/// Post-multiply `m` by a translation matrix built from `v`.
 inline Mat4 Translate(const Mat4& m, const Vec3& v)
 {
     Mat4 result = m;
@@ -39,7 +39,7 @@ inline Mat4 Translate(const Mat4& m, const Vec3& v)
     return result;
 }
 
-/// Post-multiply `m` by a rotation around `axis` by `angleRadians`. Matches glm::rotate.
+/// Post-multiply `m` by a rotation around `axis` by `angleRadians`.
 inline Mat4 Rotate(const Mat4& m, float angleRadians, const Vec3& axis)
 {
     Mat4 rotation = Mat4::Identity();
@@ -47,7 +47,7 @@ inline Mat4 Rotate(const Mat4& m, float angleRadians, const Vec3& axis)
     return m * rotation;
 }
 
-/// Post-multiply `m` by a non-uniform scale. Matches glm::scale.
+/// Post-multiply `m` by a non-uniform scale.
 inline Mat4 Scale(const Mat4& m, const Vec3& s)
 {
     Mat4 result;
@@ -74,7 +74,7 @@ inline Mat4 PerspectiveRH_ZO(float fovyRadians, float aspect, float zNear, float
 }
 
 /// Right-handed perspective projection with NDC z in [-1, 1].
-/// Use this only when interoperating with code that explicitly expects the legacy glm RH_NO convention.
+/// Use this only when interoperating with code that explicitly expects the legacy RH_NO convention.
 inline Mat4 PerspectiveRH_NO(float fovyRadians, float aspect, float zNear, float zFar)
 {
     const float tanHalfFovy = std::tan(fovyRadians * 0.5f);
@@ -88,7 +88,7 @@ inline Mat4 PerspectiveRH_NO(float fovyRadians, float aspect, float zNear, float
     return result;
 }
 
-/// Right-handed look-at view matrix. Matches glm::lookAt (RH).
+/// Right-handed look-at view matrix.
 inline Mat4 LookAt(const Vec3& eye, const Vec3& center, const Vec3& up)
 {
     const Vec3 f = (center - eye).normalized();

--- a/Src/Core/Util/Math.h
+++ b/Src/Core/Util/Math.h
@@ -18,6 +18,15 @@
 namespace Math
 {
 
+// Shorter project-local aliases for the Eigen types used across the codebase.
+// Prefer these in new code; Eigen::VectorXf / MatrixXf still work seamlessly.
+using Vec2 = Eigen::Vector2f;
+using Vec3 = Eigen::Vector3f;
+using Vec4 = Eigen::Vector4f;
+using Mat3 = Eigen::Matrix3f;
+using Mat4 = Eigen::Matrix4f;
+using Quat = Eigen::Quaternionf;
+
 inline float Radians(float degrees)
 {
     return degrees * (std::numbers::pi_v<float> / 180.0f);

--- a/Src/Core/Util/Math.h
+++ b/Src/Core/Util/Math.h
@@ -17,8 +17,8 @@
 namespace Math
 {
 
-// Shorter project-local aliases for the Eigen types used across the codebase.
-// Prefer these in new code; Eigen::VectorXf / MatrixXf still work seamlessly.
+// Project-local math aliases used across the codebase.
+// Prefer these names at call sites so Eigen remains an implementation detail.
 using Vec2 = Eigen::Vector2f;
 using Vec3 = Eigen::Vector3f;
 using Vec4 = Eigen::Vector4f;

--- a/Src/Core/Util/Math.h
+++ b/Src/Core/Util/Math.h
@@ -1,0 +1,90 @@
+#pragma once
+
+/// @file Math.h
+/// @brief Small math helpers over Eigen that replicate the glm-compatible
+///        conventions previously used throughout the project.
+///
+/// All functions assume a right-handed coordinate system with NDC depth in
+/// [-1, 1], matching glm's default RH_NO configuration so that matrices
+/// produced here are bit-equivalent (up to floating-point rounding) to the
+/// matrices the codebase produced before the glm->Eigen migration.
+
+#include <cmath>
+#include <numbers>
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+namespace Math
+{
+
+inline float Radians(float degrees)
+{
+    return degrees * (std::numbers::pi_v<float> / 180.0f);
+}
+
+/// Post-multiply `m` by a translation matrix built from `v`. Matches glm::translate.
+inline Eigen::Matrix4f Translate(const Eigen::Matrix4f& m, const Eigen::Vector3f& v)
+{
+    Eigen::Matrix4f result = m;
+    result.col(3) = m.col(0) * v.x() + m.col(1) * v.y() + m.col(2) * v.z() + m.col(3);
+    return result;
+}
+
+/// Post-multiply `m` by a rotation around `axis` by `angleRadians`. Matches glm::rotate.
+inline Eigen::Matrix4f Rotate(const Eigen::Matrix4f& m, float angleRadians, const Eigen::Vector3f& axis)
+{
+    Eigen::Matrix4f rotation = Eigen::Matrix4f::Identity();
+    rotation.topLeftCorner<3, 3>() = Eigen::AngleAxisf(angleRadians, axis.normalized()).toRotationMatrix();
+    return m * rotation;
+}
+
+/// Post-multiply `m` by a non-uniform scale. Matches glm::scale.
+inline Eigen::Matrix4f Scale(const Eigen::Matrix4f& m, const Eigen::Vector3f& s)
+{
+    Eigen::Matrix4f result;
+    result.col(0) = m.col(0) * s.x();
+    result.col(1) = m.col(1) * s.y();
+    result.col(2) = m.col(2) * s.z();
+    result.col(3) = m.col(3);
+    return result;
+}
+
+/// Right-handed perspective projection with NDC z in [-1, 1]. Matches glm::perspective (RH_NO).
+inline Eigen::Matrix4f Perspective(float fovyRadians, float aspect, float zNear, float zFar)
+{
+    const float tanHalfFovy = std::tan(fovyRadians * 0.5f);
+
+    Eigen::Matrix4f result = Eigen::Matrix4f::Zero();
+    result(0, 0) = 1.0f / (aspect * tanHalfFovy);
+    result(1, 1) = 1.0f / tanHalfFovy;
+    result(2, 2) = -(zFar + zNear) / (zFar - zNear);
+    result(3, 2) = -1.0f;
+    result(2, 3) = -(2.0f * zFar * zNear) / (zFar - zNear);
+    return result;
+}
+
+/// Right-handed look-at view matrix. Matches glm::lookAt (RH).
+inline Eigen::Matrix4f LookAt(const Eigen::Vector3f& eye, const Eigen::Vector3f& center, const Eigen::Vector3f& up)
+{
+    const Eigen::Vector3f f = (center - eye).normalized();
+    const Eigen::Vector3f s = f.cross(up).normalized();
+    const Eigen::Vector3f u = s.cross(f);
+
+    Eigen::Matrix4f result = Eigen::Matrix4f::Identity();
+    result(0, 0) = s.x();
+    result(0, 1) = s.y();
+    result(0, 2) = s.z();
+    result(1, 0) = u.x();
+    result(1, 1) = u.y();
+    result(1, 2) = u.z();
+    result(2, 0) = -f.x();
+    result(2, 1) = -f.y();
+    result(2, 2) = -f.z();
+    result(0, 3) = -s.dot(eye);
+    result(1, 3) = -u.dot(eye);
+    result(2, 3) = f.dot(eye);
+    return result;
+}
+
+} // namespace Math

--- a/Src/Core/Util/Math.h
+++ b/Src/Core/Util/Math.h
@@ -1,13 +1,12 @@
 #pragma once
 
 /// @file Math.h
-/// @brief Small math helpers over Eigen that replicate the glm-compatible
-///        conventions previously used throughout the project.
+/// @brief Small math helpers over Eigen for the engine's render-facing math conventions.
 ///
-/// All functions assume a right-handed coordinate system with NDC depth in
-/// [-1, 1], matching glm's default RH_NO configuration so that matrices
-/// produced here are bit-equivalent (up to floating-point rounding) to the
-/// matrices the codebase produced before the glm->Eigen migration.
+/// The engine keeps Eigen as the implementation layer but centralizes its
+/// render-facing aliases and projection helpers here so backend-sensitive
+/// choices stay explicit. For Vulkan/Metal-facing rendering code, prefer the
+/// explicit RH_ZO helpers rather than relying on historical glm defaults.
 
 #include <cmath>
 #include <numbers>
@@ -33,25 +32,25 @@ inline float Radians(float degrees)
 }
 
 /// Post-multiply `m` by a translation matrix built from `v`. Matches glm::translate.
-inline Eigen::Matrix4f Translate(const Eigen::Matrix4f& m, const Eigen::Vector3f& v)
+inline Mat4 Translate(const Mat4& m, const Vec3& v)
 {
-    Eigen::Matrix4f result = m;
+    Mat4 result = m;
     result.col(3) = m.col(0) * v.x() + m.col(1) * v.y() + m.col(2) * v.z() + m.col(3);
     return result;
 }
 
 /// Post-multiply `m` by a rotation around `axis` by `angleRadians`. Matches glm::rotate.
-inline Eigen::Matrix4f Rotate(const Eigen::Matrix4f& m, float angleRadians, const Eigen::Vector3f& axis)
+inline Mat4 Rotate(const Mat4& m, float angleRadians, const Vec3& axis)
 {
-    Eigen::Matrix4f rotation = Eigen::Matrix4f::Identity();
+    Mat4 rotation = Mat4::Identity();
     rotation.topLeftCorner<3, 3>() = Eigen::AngleAxisf(angleRadians, axis.normalized()).toRotationMatrix();
     return m * rotation;
 }
 
 /// Post-multiply `m` by a non-uniform scale. Matches glm::scale.
-inline Eigen::Matrix4f Scale(const Eigen::Matrix4f& m, const Eigen::Vector3f& s)
+inline Mat4 Scale(const Mat4& m, const Vec3& s)
 {
-    Eigen::Matrix4f result;
+    Mat4 result;
     result.col(0) = m.col(0) * s.x();
     result.col(1) = m.col(1) * s.y();
     result.col(2) = m.col(2) * s.z();
@@ -59,12 +58,28 @@ inline Eigen::Matrix4f Scale(const Eigen::Matrix4f& m, const Eigen::Vector3f& s)
     return result;
 }
 
-/// Right-handed perspective projection with NDC z in [-1, 1]. Matches glm::perspective (RH_NO).
-inline Eigen::Matrix4f Perspective(float fovyRadians, float aspect, float zNear, float zFar)
+/// Right-handed perspective projection with NDC z in [0, 1].
+/// Prefer this for the engine's Vulkan/Metal render path.
+inline Mat4 PerspectiveRH_ZO(float fovyRadians, float aspect, float zNear, float zFar)
 {
     const float tanHalfFovy = std::tan(fovyRadians * 0.5f);
 
-    Eigen::Matrix4f result = Eigen::Matrix4f::Zero();
+    Mat4 result = Mat4::Zero();
+    result(0, 0) = 1.0f / (aspect * tanHalfFovy);
+    result(1, 1) = 1.0f / tanHalfFovy;
+    result(2, 2) = -zFar / (zFar - zNear);
+    result(3, 2) = -1.0f;
+    result(2, 3) = -(zFar * zNear) / (zFar - zNear);
+    return result;
+}
+
+/// Right-handed perspective projection with NDC z in [-1, 1].
+/// Use this only when interoperating with code that explicitly expects the legacy glm RH_NO convention.
+inline Mat4 PerspectiveRH_NO(float fovyRadians, float aspect, float zNear, float zFar)
+{
+    const float tanHalfFovy = std::tan(fovyRadians * 0.5f);
+
+    Mat4 result = Mat4::Zero();
     result(0, 0) = 1.0f / (aspect * tanHalfFovy);
     result(1, 1) = 1.0f / tanHalfFovy;
     result(2, 2) = -(zFar + zNear) / (zFar - zNear);
@@ -74,13 +89,13 @@ inline Eigen::Matrix4f Perspective(float fovyRadians, float aspect, float zNear,
 }
 
 /// Right-handed look-at view matrix. Matches glm::lookAt (RH).
-inline Eigen::Matrix4f LookAt(const Eigen::Vector3f& eye, const Eigen::Vector3f& center, const Eigen::Vector3f& up)
+inline Mat4 LookAt(const Vec3& eye, const Vec3& center, const Vec3& up)
 {
-    const Eigen::Vector3f f = (center - eye).normalized();
-    const Eigen::Vector3f s = f.cross(up).normalized();
-    const Eigen::Vector3f u = s.cross(f);
+    const Vec3 f = (center - eye).normalized();
+    const Vec3 s = f.cross(up).normalized();
+    const Vec3 u = s.cross(f);
 
-    Eigen::Matrix4f result = Eigen::Matrix4f::Identity();
+    Mat4 result = Mat4::Identity();
     result(0, 0) = s.x();
     result(0, 1) = s.y();
     result(0, 2) = s.z();

--- a/Src/Demos/01_HelloWindow/HelloWindow.h
+++ b/Src/Demos/01_HelloWindow/HelloWindow.h
@@ -9,7 +9,7 @@
 
 #include <cstdint>
 
-#include <glm/glm.hpp>
+#include <Eigen/Core>
 
 #include "Core/Util/Base.h"
 #include "Demos/DemoBase.h"
@@ -33,5 +33,5 @@ private:
 
     Ref<RenderTarget> m_BackBuffer;
 
-    glm::vec3 m_ClearColor{0.2f, 0.3f, 0.3f};
+    Eigen::Vector3f m_ClearColor{0.2f, 0.3f, 0.3f};
 };

--- a/Src/Demos/01_HelloWindow/HelloWindow.h
+++ b/Src/Demos/01_HelloWindow/HelloWindow.h
@@ -9,9 +9,8 @@
 
 #include <cstdint>
 
-#include <Eigen/Core>
-
 #include "Core/Util/Base.h"
+#include "Core/Util/Math.h"
 #include "Demos/DemoBase.h"
 
 class RenderTarget;
@@ -33,5 +32,5 @@ private:
 
     Ref<RenderTarget> m_BackBuffer;
 
-    Eigen::Vector3f m_ClearColor{0.2f, 0.3f, 0.3f};
+    Math::Vec3 m_ClearColor{0.2f, 0.3f, 0.3f};
 };

--- a/Src/Demos/02_HelloTriangle/HelloTriangle.cpp
+++ b/Src/Demos/02_HelloTriangle/HelloTriangle.cpp
@@ -6,14 +6,12 @@
 #include <cstddef>
 #include <utility>
 
-#include <Eigen/Core>
-
 #include "Core/App/Application.h"
-#include "Core/Util/Math.h"
 #include "Core/Diagnostics/Assert/Assert.h"
 #include "Core/Diagnostics/Logging/LogCategories.h"
 #include "Core/Diagnostics/Logging/LogMacros.h"
 #include "Core/Resource/FileSystem.h"
+#include "Core/Util/Math.h"
 #include "Core/Util/Time.h"
 #include "Render/Shader/ShaderCompiler.h"
 #include "Render/Shader/ShaderParameterWriter.h"
@@ -23,8 +21,8 @@ namespace
 {
 struct TriangleVertex
 {
-    Eigen::Vector2f m_Position;
-    Eigen::Vector4f m_Color;
+    Math::Vec2 m_Position;
+    Math::Vec4 m_Color;
 };
 
 struct DemoViewport
@@ -201,8 +199,8 @@ void HelloTriangle::CreateTriangleResources()
 
     ShaderParameterWriter parameterWriter(m_ShaderProgram->GetReflection());
 
-    const Eigen::Matrix4f viewProj = Eigen::Matrix4f::Identity();
-    const Eigen::Vector4f baseColor = Eigen::Vector4f(1.0f, 0.95f, 0.85f, 1.0f);
+    const Math::Mat4 viewProj = Math::Mat4::Identity();
+    const Math::Vec4 baseColor = Math::Vec4(1.0f, 0.95f, 0.85f, 1.0f);
 
     parameterWriter.SetMatrix4x4(*m_FrameSet, "gFrame.viewProj", viewProj);
     parameterWriter.SetFloat4(*m_MaterialSet, "gMaterial.baseColor", baseColor);
@@ -238,11 +236,10 @@ void HelloTriangle::UpdateAnimatedParameters()
     const float verticalOffset = -0.04f + (pulse - 0.5f) * 0.10f;
     const float uniformScale = 0.88f + pulse * 0.10f;
 
-    const Eigen::Vector4f tint = Eigen::Vector4f(0.70f + 0.30f * pulse, 0.80f + 0.15f * pulse, 0.90f, 1.0f);
-    const Eigen::Vector4f baseColor = Eigen::Vector4f(1.0f, 0.70f + 0.25f * pulse, 0.70f + 0.20f * pulse, 1.0f);
-    const Eigen::Matrix4f model =
-        Math::Translate(Eigen::Matrix4f::Identity(), Eigen::Vector3f(0.0f, verticalOffset, 0.0f)) *
-        Math::Scale(Eigen::Matrix4f::Identity(), Eigen::Vector3f(uniformScale, uniformScale, 1.0f));
+    const Math::Vec4 tint = Math::Vec4(0.70f + 0.30f * pulse, 0.80f + 0.15f * pulse, 0.90f, 1.0f);
+    const Math::Vec4 baseColor = Math::Vec4(1.0f, 0.70f + 0.25f * pulse, 0.70f + 0.20f * pulse, 1.0f);
+    const Math::Mat4 model = Math::Translate(Math::Mat4::Identity(), Math::Vec3(0.0f, verticalOffset, 0.0f)) *
+                             Math::Scale(Math::Mat4::Identity(), Math::Vec3(uniformScale, uniformScale, 1.0f));
 
     ShaderParameterWriter parameterWriter(m_ShaderProgram->GetReflection());
     parameterWriter.SetFloat4(*m_FrameSet, "gFrame.tint", tint);

--- a/Src/Demos/02_HelloTriangle/HelloTriangle.cpp
+++ b/Src/Demos/02_HelloTriangle/HelloTriangle.cpp
@@ -6,10 +6,10 @@
 #include <cstddef>
 #include <utility>
 
-#include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
+#include <Eigen/Core>
 
 #include "Core/App/Application.h"
+#include "Core/Util/Math.h"
 #include "Core/Diagnostics/Assert/Assert.h"
 #include "Core/Diagnostics/Logging/LogCategories.h"
 #include "Core/Diagnostics/Logging/LogMacros.h"
@@ -23,8 +23,8 @@ namespace
 {
 struct TriangleVertex
 {
-    glm::vec2 m_Position;
-    glm::vec4 m_Color;
+    Eigen::Vector2f m_Position;
+    Eigen::Vector4f m_Color;
 };
 
 struct DemoViewport
@@ -164,7 +164,8 @@ void HelloTriangle::CreateTriangleResources()
     Application& app = Application::Get();
     Device& device = app.GetDevice();
 
-    static constexpr std::array<TriangleVertex, 3> kVertices = {{
+    // Eigen vector constructors are not constexpr, so this array is only const.
+    static const std::array<TriangleVertex, 3> kVertices = {{
         {{0.0f, -0.65f}, {1.0f, 0.25f, 0.25f, 1.0f}},
         {{0.65f, 0.55f}, {0.25f, 1.0f, 0.35f, 1.0f}},
         {{-0.65f, 0.55f}, {0.25f, 0.45f, 1.0f, 1.0f}},
@@ -200,8 +201,8 @@ void HelloTriangle::CreateTriangleResources()
 
     ShaderParameterWriter parameterWriter(m_ShaderProgram->GetReflection());
 
-    const glm::mat4 viewProj = glm::mat4(1.0f);
-    const glm::vec4 baseColor = glm::vec4(1.0f, 0.95f, 0.85f, 1.0f);
+    const Eigen::Matrix4f viewProj = Eigen::Matrix4f::Identity();
+    const Eigen::Vector4f baseColor = Eigen::Vector4f(1.0f, 0.95f, 0.85f, 1.0f);
 
     parameterWriter.SetMatrix4x4(*m_FrameSet, "gFrame.viewProj", viewProj);
     parameterWriter.SetFloat4(*m_MaterialSet, "gMaterial.baseColor", baseColor);
@@ -237,10 +238,11 @@ void HelloTriangle::UpdateAnimatedParameters()
     const float verticalOffset = -0.04f + (pulse - 0.5f) * 0.10f;
     const float uniformScale = 0.88f + pulse * 0.10f;
 
-    const glm::vec4 tint = glm::vec4(0.70f + 0.30f * pulse, 0.80f + 0.15f * pulse, 0.90f, 1.0f);
-    const glm::vec4 baseColor = glm::vec4(1.0f, 0.70f + 0.25f * pulse, 0.70f + 0.20f * pulse, 1.0f);
-    const glm::mat4 model = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, verticalOffset, 0.0f)) *
-                            glm::scale(glm::mat4(1.0f), glm::vec3(uniformScale, uniformScale, 1.0f));
+    const Eigen::Vector4f tint = Eigen::Vector4f(0.70f + 0.30f * pulse, 0.80f + 0.15f * pulse, 0.90f, 1.0f);
+    const Eigen::Vector4f baseColor = Eigen::Vector4f(1.0f, 0.70f + 0.25f * pulse, 0.70f + 0.20f * pulse, 1.0f);
+    const Eigen::Matrix4f model =
+        Math::Translate(Eigen::Matrix4f::Identity(), Eigen::Vector3f(0.0f, verticalOffset, 0.0f)) *
+        Math::Scale(Eigen::Matrix4f::Identity(), Eigen::Vector3f(uniformScale, uniformScale, 1.0f));
 
     ShaderParameterWriter parameterWriter(m_ShaderProgram->GetReflection());
     parameterWriter.SetFloat4(*m_FrameSet, "gFrame.tint", tint);

--- a/Src/Render/Shader/ShaderParameterWriter.cpp
+++ b/Src/Render/Shader/ShaderParameterWriter.cpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <utility>
 
-#include <glm/glm.hpp>
+#include <Eigen/Core>
 
 #include "Core/Diagnostics/Assert/Assert.h"
 
@@ -61,14 +61,16 @@ void ShaderParameterWriter::SetFloat(ResourceSet& resourceSet, FieldHandle field
     SetConstantData(resourceSet, fieldHandle, &value, sizeof(value));
 }
 
-void ShaderParameterWriter::SetFloat4(ResourceSet& resourceSet, FieldHandle fieldHandle, const glm::vec4& value) const
+void ShaderParameterWriter::SetFloat4(ResourceSet& resourceSet,
+                                      FieldHandle fieldHandle,
+                                      const Eigen::Vector4f& value) const
 {
     SetConstantData(resourceSet, fieldHandle, &value, sizeof(value));
 }
 
 void ShaderParameterWriter::SetMatrix4x4(ResourceSet& resourceSet,
                                          FieldHandle fieldHandle,
-                                         const glm::mat4& value) const
+                                         const Eigen::Matrix4f& value) const
 {
     SetConstantData(resourceSet, fieldHandle, &value, sizeof(value));
 }
@@ -119,14 +121,18 @@ void ShaderParameterWriter::SetFloat(ResourceSet& resourceSet, std::string_view 
     SetFloat(resourceSet, fieldHandle, value);
 }
 
-void ShaderParameterWriter::SetFloat4(ResourceSet& resourceSet, std::string_view path, const glm::vec4& value) const
+void ShaderParameterWriter::SetFloat4(ResourceSet& resourceSet,
+                                      std::string_view path,
+                                      const Eigen::Vector4f& value) const
 {
     const FieldHandle fieldHandle = ResolveField(path);
     RTRLAB_ASSERT_MSG(fieldHandle.IsValid(), "SetFloat4 requires a valid reflected constant-data field path.");
     SetFloat4(resourceSet, fieldHandle, value);
 }
 
-void ShaderParameterWriter::SetMatrix4x4(ResourceSet& resourceSet, std::string_view path, const glm::mat4& value) const
+void ShaderParameterWriter::SetMatrix4x4(ResourceSet& resourceSet,
+                                         std::string_view path,
+                                         const Eigen::Matrix4f& value) const
 {
     const FieldHandle fieldHandle = ResolveField(path);
     RTRLAB_ASSERT_MSG(fieldHandle.IsValid(), "SetMatrix4x4 requires a valid reflected constant-data field path.");

--- a/Src/Render/Shader/ShaderParameterWriter.cpp
+++ b/Src/Render/Shader/ShaderParameterWriter.cpp
@@ -4,8 +4,6 @@
 #include <string>
 #include <utility>
 
-#include <Eigen/Core>
-
 #include "Core/Diagnostics/Assert/Assert.h"
 
 namespace
@@ -61,16 +59,14 @@ void ShaderParameterWriter::SetFloat(ResourceSet& resourceSet, FieldHandle field
     SetConstantData(resourceSet, fieldHandle, &value, sizeof(value));
 }
 
-void ShaderParameterWriter::SetFloat4(ResourceSet& resourceSet,
-                                      FieldHandle fieldHandle,
-                                      const Eigen::Vector4f& value) const
+void ShaderParameterWriter::SetFloat4(ResourceSet& resourceSet, FieldHandle fieldHandle, const Math::Vec4& value) const
 {
     SetConstantData(resourceSet, fieldHandle, &value, sizeof(value));
 }
 
 void ShaderParameterWriter::SetMatrix4x4(ResourceSet& resourceSet,
                                          FieldHandle fieldHandle,
-                                         const Eigen::Matrix4f& value) const
+                                         const Math::Mat4& value) const
 {
     SetConstantData(resourceSet, fieldHandle, &value, sizeof(value));
 }
@@ -121,18 +117,14 @@ void ShaderParameterWriter::SetFloat(ResourceSet& resourceSet, std::string_view 
     SetFloat(resourceSet, fieldHandle, value);
 }
 
-void ShaderParameterWriter::SetFloat4(ResourceSet& resourceSet,
-                                      std::string_view path,
-                                      const Eigen::Vector4f& value) const
+void ShaderParameterWriter::SetFloat4(ResourceSet& resourceSet, std::string_view path, const Math::Vec4& value) const
 {
     const FieldHandle fieldHandle = ResolveField(path);
     RTRLAB_ASSERT_MSG(fieldHandle.IsValid(), "SetFloat4 requires a valid reflected constant-data field path.");
     SetFloat4(resourceSet, fieldHandle, value);
 }
 
-void ShaderParameterWriter::SetMatrix4x4(ResourceSet& resourceSet,
-                                         std::string_view path,
-                                         const Eigen::Matrix4f& value) const
+void ShaderParameterWriter::SetMatrix4x4(ResourceSet& resourceSet, std::string_view path, const Math::Mat4& value) const
 {
     const FieldHandle fieldHandle = ResolveField(path);
     RTRLAB_ASSERT_MSG(fieldHandle.IsValid(), "SetMatrix4x4 requires a valid reflected constant-data field path.");

--- a/Src/Render/Shader/ShaderParameterWriter.h
+++ b/Src/Render/Shader/ShaderParameterWriter.h
@@ -11,7 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <glm/fwd.hpp>
+#include <Eigen/Core>
 
 #include "Render/RHI/RHIResources.h"
 #include "Render/Shader/ShaderTypes.h"
@@ -43,16 +43,16 @@ public:
     BindingHandle ResolveBinding(std::string_view path) const;
 
     void SetFloat(ResourceSet& resourceSet, FieldHandle fieldHandle, float value) const;
-    void SetFloat4(ResourceSet& resourceSet, FieldHandle fieldHandle, const glm::vec4& value) const;
-    void SetMatrix4x4(ResourceSet& resourceSet, FieldHandle fieldHandle, const glm::mat4& value) const;
+    void SetFloat4(ResourceSet& resourceSet, FieldHandle fieldHandle, const Eigen::Vector4f& value) const;
+    void SetMatrix4x4(ResourceSet& resourceSet, FieldHandle fieldHandle, const Eigen::Matrix4f& value) const;
     void SetTexture(ResourceSet& resourceSet, BindingHandle bindingHandle, Texture* texture) const;
     void SetSampler(ResourceSet& resourceSet, BindingHandle bindingHandle, Sampler* sampler) const;
     void SetBuffer(
         ResourceSet& resourceSet, BindingHandle bindingHandle, Buffer* buffer, uint64_t offset, uint64_t size) const;
 
     void SetFloat(ResourceSet& resourceSet, std::string_view path, float value) const;
-    void SetFloat4(ResourceSet& resourceSet, std::string_view path, const glm::vec4& value) const;
-    void SetMatrix4x4(ResourceSet& resourceSet, std::string_view path, const glm::mat4& value) const;
+    void SetFloat4(ResourceSet& resourceSet, std::string_view path, const Eigen::Vector4f& value) const;
+    void SetMatrix4x4(ResourceSet& resourceSet, std::string_view path, const Eigen::Matrix4f& value) const;
     void SetTexture(ResourceSet& resourceSet, std::string_view path, Texture* texture) const;
     void SetSampler(ResourceSet& resourceSet, std::string_view path, Sampler* sampler) const;
     void

--- a/Src/Render/Shader/ShaderParameterWriter.h
+++ b/Src/Render/Shader/ShaderParameterWriter.h
@@ -11,8 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <Eigen/Core>
-
+#include "Core/Util/Math.h"
 #include "Render/RHI/RHIResources.h"
 #include "Render/Shader/ShaderTypes.h"
 
@@ -43,16 +42,16 @@ public:
     BindingHandle ResolveBinding(std::string_view path) const;
 
     void SetFloat(ResourceSet& resourceSet, FieldHandle fieldHandle, float value) const;
-    void SetFloat4(ResourceSet& resourceSet, FieldHandle fieldHandle, const Eigen::Vector4f& value) const;
-    void SetMatrix4x4(ResourceSet& resourceSet, FieldHandle fieldHandle, const Eigen::Matrix4f& value) const;
+    void SetFloat4(ResourceSet& resourceSet, FieldHandle fieldHandle, const Math::Vec4& value) const;
+    void SetMatrix4x4(ResourceSet& resourceSet, FieldHandle fieldHandle, const Math::Mat4& value) const;
     void SetTexture(ResourceSet& resourceSet, BindingHandle bindingHandle, Texture* texture) const;
     void SetSampler(ResourceSet& resourceSet, BindingHandle bindingHandle, Sampler* sampler) const;
     void SetBuffer(
         ResourceSet& resourceSet, BindingHandle bindingHandle, Buffer* buffer, uint64_t offset, uint64_t size) const;
 
     void SetFloat(ResourceSet& resourceSet, std::string_view path, float value) const;
-    void SetFloat4(ResourceSet& resourceSet, std::string_view path, const Eigen::Vector4f& value) const;
-    void SetMatrix4x4(ResourceSet& resourceSet, std::string_view path, const Eigen::Matrix4f& value) const;
+    void SetFloat4(ResourceSet& resourceSet, std::string_view path, const Math::Vec4& value) const;
+    void SetMatrix4x4(ResourceSet& resourceSet, std::string_view path, const Math::Mat4& value) const;
     void SetTexture(ResourceSet& resourceSet, std::string_view path, Texture* texture) const;
     void SetSampler(ResourceSet& resourceSet, std::string_view path, Sampler* sampler) const;
     void

--- a/Src/Scene/Camera.cpp
+++ b/Src/Scene/Camera.cpp
@@ -3,8 +3,7 @@
 #include <algorithm>
 #include <cmath>
 
-#include <glm/gtc/matrix_transform.hpp>
-#include <glm/gtc/constants.hpp>
+#include "Core/Util/Math.h"
 
 Camera::Camera()
 {
@@ -45,7 +44,7 @@ void Camera::SetAspectRatio(float aspectRatio)
     RecalculateProjection();
 }
 
-void Camera::SetPosition(const glm::vec3& position)
+void Camera::SetPosition(const Eigen::Vector3f& position)
 {
     m_Position = position;
     RecalculateView();
@@ -66,31 +65,31 @@ void Camera::SetRotation(float yawDegrees, float pitchDegrees)
 
 void Camera::RecalculateProjection()
 {
-    m_Projection = glm::perspective(glm::radians(m_VerticalFovDegrees), m_AspectRatio, m_NearClip, m_FarClip);
+    m_Projection = Math::Perspective(Math::Radians(m_VerticalFovDegrees), m_AspectRatio, m_NearClip, m_FarClip);
 }
 
 void Camera::RecalculateView()
 {
-    m_View = glm::lookAt(m_Position, m_Position + m_Forward, m_Up);
+    m_View = Math::LookAt(m_Position, m_Position + m_Forward, m_Up);
 }
 
 void Camera::RecalculateBasis()
 {
     // Convert Euler angles (yaw, pitch) to a forward direction vector.
     // Yaw rotates around Y in the XZ plane; pitch tilts up/down.
-    glm::vec3 forward;
-    forward.x = std::cos(glm::radians(m_Yaw)) * std::cos(glm::radians(m_Pitch));
-    forward.y = std::sin(glm::radians(m_Pitch));
-    forward.z = std::sin(glm::radians(m_Yaw)) * std::cos(glm::radians(m_Pitch));
+    Eigen::Vector3f forward;
+    forward.x() = std::cos(Math::Radians(m_Yaw)) * std::cos(Math::Radians(m_Pitch));
+    forward.y() = std::sin(Math::Radians(m_Pitch));
+    forward.z() = std::sin(Math::Radians(m_Yaw)) * std::cos(Math::Radians(m_Pitch));
 
-    m_Forward = glm::normalize(forward);
+    m_Forward = forward.normalized();
 
     // When forward aligns with world-up, the usual cross product degenerates to
     // zero. Switch to a stable fallback axis so the basis stays well-defined.
-    glm::vec3 referenceUp = m_WorldUp;
-    if (std::abs(glm::dot(m_Forward, m_WorldUp)) > 0.999f)
-        referenceUp = glm::vec3(0.0f, 0.0f, 1.0f);
+    Eigen::Vector3f referenceUp = m_WorldUp;
+    if (std::abs(m_Forward.dot(m_WorldUp)) > 0.999f)
+        referenceUp = Eigen::Vector3f(0.0f, 0.0f, 1.0f);
 
-    m_Right = glm::normalize(glm::cross(m_Forward, referenceUp));
-    m_Up = glm::normalize(glm::cross(m_Right, m_Forward));
+    m_Right = m_Forward.cross(referenceUp).normalized();
+    m_Up = m_Right.cross(m_Forward).normalized();
 }

--- a/Src/Scene/Camera.cpp
+++ b/Src/Scene/Camera.cpp
@@ -44,7 +44,7 @@ void Camera::SetAspectRatio(float aspectRatio)
     RecalculateProjection();
 }
 
-void Camera::SetPosition(const Eigen::Vector3f& position)
+void Camera::SetPosition(const Math::Vec3& position)
 {
     m_Position = position;
     RecalculateView();
@@ -65,7 +65,7 @@ void Camera::SetRotation(float yawDegrees, float pitchDegrees)
 
 void Camera::RecalculateProjection()
 {
-    m_Projection = Math::Perspective(Math::Radians(m_VerticalFovDegrees), m_AspectRatio, m_NearClip, m_FarClip);
+    m_Projection = Math::PerspectiveRH_ZO(Math::Radians(m_VerticalFovDegrees), m_AspectRatio, m_NearClip, m_FarClip);
 }
 
 void Camera::RecalculateView()
@@ -77,7 +77,7 @@ void Camera::RecalculateBasis()
 {
     // Convert Euler angles (yaw, pitch) to a forward direction vector.
     // Yaw rotates around Y in the XZ plane; pitch tilts up/down.
-    Eigen::Vector3f forward;
+    Math::Vec3 forward;
     forward.x() = std::cos(Math::Radians(m_Yaw)) * std::cos(Math::Radians(m_Pitch));
     forward.y() = std::sin(Math::Radians(m_Pitch));
     forward.z() = std::sin(Math::Radians(m_Yaw)) * std::cos(Math::Radians(m_Pitch));
@@ -86,9 +86,9 @@ void Camera::RecalculateBasis()
 
     // When forward aligns with world-up, the usual cross product degenerates to
     // zero. Switch to a stable fallback axis so the basis stays well-defined.
-    Eigen::Vector3f referenceUp = m_WorldUp;
+    Math::Vec3 referenceUp = m_WorldUp;
     if (std::abs(m_Forward.dot(m_WorldUp)) > 0.999f)
-        referenceUp = Eigen::Vector3f(0.0f, 0.0f, 1.0f);
+        referenceUp = Math::Vec3(0.0f, 0.0f, 1.0f);
 
     m_Right = m_Forward.cross(referenceUp).normalized();
     m_Up = m_Right.cross(m_Forward).normalized();

--- a/Src/Scene/Camera.h
+++ b/Src/Scene/Camera.h
@@ -13,7 +13,7 @@
 ///
 /// Basis vectors (Forward, Right, Up) are derived from yaw/pitch via RecalculateBasis().
 
-#include <glm/glm.hpp>
+#include <Eigen/Core>
 
 class Camera
 {
@@ -25,20 +25,20 @@ public:
     void SetViewportSize(uint32_t width, uint32_t height);
     void SetAspectRatio(float aspectRatio);
 
-    void SetPosition(const glm::vec3& position);
+    void SetPosition(const Eigen::Vector3f& position);
     void SetRotation(float yawDegrees, float pitchDegrees);
 
-    const glm::vec3& GetPosition() const { return m_Position; }
+    const Eigen::Vector3f& GetPosition() const { return m_Position; }
     float GetYaw() const { return m_Yaw; }
     float GetPitch() const { return m_Pitch; }
 
-    const glm::vec3& GetForward() const { return m_Forward; }
-    const glm::vec3& GetRight() const { return m_Right; }
-    const glm::vec3& GetUp() const { return m_Up; }
+    const Eigen::Vector3f& GetForward() const { return m_Forward; }
+    const Eigen::Vector3f& GetRight() const { return m_Right; }
+    const Eigen::Vector3f& GetUp() const { return m_Up; }
 
-    const glm::mat4& GetProjection() const { return m_Projection; }
-    const glm::mat4& GetView() const { return m_View; }
-    glm::mat4 GetViewProjection() const { return m_Projection * m_View; }
+    const Eigen::Matrix4f& GetProjection() const { return m_Projection; }
+    const Eigen::Matrix4f& GetView() const { return m_View; }
+    Eigen::Matrix4f GetViewProjection() const { return m_Projection * m_View; }
 
     float GetVerticalFovDegrees() const { return m_VerticalFovDegrees; }
     float GetAspectRatio() const { return m_AspectRatio; }
@@ -59,16 +59,16 @@ private:
     float m_FarClip = 100.0f;
 
     // Transform
-    glm::vec3 m_Position{0.0f, 0.0f, 3.0f};
+    Eigen::Vector3f m_Position{0.0f, 0.0f, 3.0f};
     float m_Yaw = -90.0f;
     float m_Pitch = 0.0f;
 
     // Basis vectors
-    glm::vec3 m_Forward{0.0f, 0.0f, -1.0f};
-    glm::vec3 m_Right{1.0f, 0.0f, 0.0f};
-    glm::vec3 m_Up{0.0f, 1.0f, 0.0f};
-    glm::vec3 m_WorldUp{0.0f, 1.0f, 0.0f};
+    Eigen::Vector3f m_Forward{0.0f, 0.0f, -1.0f};
+    Eigen::Vector3f m_Right{1.0f, 0.0f, 0.0f};
+    Eigen::Vector3f m_Up{0.0f, 1.0f, 0.0f};
+    Eigen::Vector3f m_WorldUp{0.0f, 1.0f, 0.0f};
 
-    glm::mat4 m_Projection{1.0f};
-    glm::mat4 m_View{1.0f};
+    Eigen::Matrix4f m_Projection = Eigen::Matrix4f::Identity();
+    Eigen::Matrix4f m_View = Eigen::Matrix4f::Identity();
 };

--- a/Src/Scene/Camera.h
+++ b/Src/Scene/Camera.h
@@ -13,7 +13,7 @@
 ///
 /// Basis vectors (Forward, Right, Up) are derived from yaw/pitch via RecalculateBasis().
 
-#include <Eigen/Core>
+#include "Core/Util/Math.h"
 
 class Camera
 {
@@ -25,20 +25,20 @@ public:
     void SetViewportSize(uint32_t width, uint32_t height);
     void SetAspectRatio(float aspectRatio);
 
-    void SetPosition(const Eigen::Vector3f& position);
+    void SetPosition(const Math::Vec3& position);
     void SetRotation(float yawDegrees, float pitchDegrees);
 
-    const Eigen::Vector3f& GetPosition() const { return m_Position; }
+    const Math::Vec3& GetPosition() const { return m_Position; }
     float GetYaw() const { return m_Yaw; }
     float GetPitch() const { return m_Pitch; }
 
-    const Eigen::Vector3f& GetForward() const { return m_Forward; }
-    const Eigen::Vector3f& GetRight() const { return m_Right; }
-    const Eigen::Vector3f& GetUp() const { return m_Up; }
+    const Math::Vec3& GetForward() const { return m_Forward; }
+    const Math::Vec3& GetRight() const { return m_Right; }
+    const Math::Vec3& GetUp() const { return m_Up; }
 
-    const Eigen::Matrix4f& GetProjection() const { return m_Projection; }
-    const Eigen::Matrix4f& GetView() const { return m_View; }
-    Eigen::Matrix4f GetViewProjection() const { return m_Projection * m_View; }
+    const Math::Mat4& GetProjection() const { return m_Projection; }
+    const Math::Mat4& GetView() const { return m_View; }
+    Math::Mat4 GetViewProjection() const { return m_Projection * m_View; }
 
     float GetVerticalFovDegrees() const { return m_VerticalFovDegrees; }
     float GetAspectRatio() const { return m_AspectRatio; }
@@ -59,16 +59,16 @@ private:
     float m_FarClip = 100.0f;
 
     // Transform
-    Eigen::Vector3f m_Position{0.0f, 0.0f, 3.0f};
+    Math::Vec3 m_Position{0.0f, 0.0f, 3.0f};
     float m_Yaw = -90.0f;
     float m_Pitch = 0.0f;
 
     // Basis vectors
-    Eigen::Vector3f m_Forward{0.0f, 0.0f, -1.0f};
-    Eigen::Vector3f m_Right{1.0f, 0.0f, 0.0f};
-    Eigen::Vector3f m_Up{0.0f, 1.0f, 0.0f};
-    Eigen::Vector3f m_WorldUp{0.0f, 1.0f, 0.0f};
+    Math::Vec3 m_Forward{0.0f, 0.0f, -1.0f};
+    Math::Vec3 m_Right{1.0f, 0.0f, 0.0f};
+    Math::Vec3 m_Up{0.0f, 1.0f, 0.0f};
+    Math::Vec3 m_WorldUp{0.0f, 1.0f, 0.0f};
 
-    Eigen::Matrix4f m_Projection = Eigen::Matrix4f::Identity();
-    Eigen::Matrix4f m_View = Eigen::Matrix4f::Identity();
+    Math::Mat4 m_Projection = Math::Mat4::Identity();
+    Math::Mat4 m_View = Math::Mat4::Identity();
 };

--- a/Src/Scene/DebugCameraController.cpp
+++ b/Src/Scene/DebugCameraController.cpp
@@ -13,7 +13,7 @@ void DebugCameraController::MoveForward(double deltaTime)
 {
     if (!m_Camera)
         return;
-    Eigen::Vector3f position = m_Camera->GetPosition();
+    Math::Vec3 position = m_Camera->GetPosition();
     position += m_Camera->GetForward() * static_cast<float>(m_MoveSpeed * deltaTime);
     m_Camera->SetPosition(position);
 }
@@ -22,7 +22,7 @@ void DebugCameraController::MoveBackward(double deltaTime)
 {
     if (!m_Camera)
         return;
-    Eigen::Vector3f position = m_Camera->GetPosition();
+    Math::Vec3 position = m_Camera->GetPosition();
     position -= m_Camera->GetForward() * static_cast<float>(m_MoveSpeed * deltaTime);
     m_Camera->SetPosition(position);
 }
@@ -31,7 +31,7 @@ void DebugCameraController::MoveLeft(double deltaTime)
 {
     if (!m_Camera)
         return;
-    Eigen::Vector3f position = m_Camera->GetPosition();
+    Math::Vec3 position = m_Camera->GetPosition();
     position -= m_Camera->GetRight() * static_cast<float>(m_MoveSpeed * deltaTime);
     m_Camera->SetPosition(position);
 }
@@ -40,7 +40,7 @@ void DebugCameraController::MoveRight(double deltaTime)
 {
     if (!m_Camera)
         return;
-    Eigen::Vector3f position = m_Camera->GetPosition();
+    Math::Vec3 position = m_Camera->GetPosition();
     position += m_Camera->GetRight() * static_cast<float>(m_MoveSpeed * deltaTime);
     m_Camera->SetPosition(position);
 }
@@ -49,8 +49,8 @@ void DebugCameraController::MoveUp(double deltaTime)
 {
     if (!m_Camera)
         return;
-    Eigen::Vector3f position = m_Camera->GetPosition();
-    position += Eigen::Vector3f(0.0f, 1.0f, 0.0f) * static_cast<float>(m_MoveSpeed * deltaTime);
+    Math::Vec3 position = m_Camera->GetPosition();
+    position += Math::Vec3(0.0f, 1.0f, 0.0f) * static_cast<float>(m_MoveSpeed * deltaTime);
     m_Camera->SetPosition(position);
 }
 
@@ -58,8 +58,8 @@ void DebugCameraController::MoveDown(double deltaTime)
 {
     if (!m_Camera)
         return;
-    Eigen::Vector3f position = m_Camera->GetPosition();
-    position -= Eigen::Vector3f(0.0f, 1.0f, 0.0f) * static_cast<float>(m_MoveSpeed * deltaTime);
+    Math::Vec3 position = m_Camera->GetPosition();
+    position -= Math::Vec3(0.0f, 1.0f, 0.0f) * static_cast<float>(m_MoveSpeed * deltaTime);
     m_Camera->SetPosition(position);
 }
 

--- a/Src/Scene/DebugCameraController.cpp
+++ b/Src/Scene/DebugCameraController.cpp
@@ -13,7 +13,7 @@ void DebugCameraController::MoveForward(double deltaTime)
 {
     if (!m_Camera)
         return;
-    glm::vec3 position = m_Camera->GetPosition();
+    Eigen::Vector3f position = m_Camera->GetPosition();
     position += m_Camera->GetForward() * static_cast<float>(m_MoveSpeed * deltaTime);
     m_Camera->SetPosition(position);
 }
@@ -22,7 +22,7 @@ void DebugCameraController::MoveBackward(double deltaTime)
 {
     if (!m_Camera)
         return;
-    glm::vec3 position = m_Camera->GetPosition();
+    Eigen::Vector3f position = m_Camera->GetPosition();
     position -= m_Camera->GetForward() * static_cast<float>(m_MoveSpeed * deltaTime);
     m_Camera->SetPosition(position);
 }
@@ -31,7 +31,7 @@ void DebugCameraController::MoveLeft(double deltaTime)
 {
     if (!m_Camera)
         return;
-    glm::vec3 position = m_Camera->GetPosition();
+    Eigen::Vector3f position = m_Camera->GetPosition();
     position -= m_Camera->GetRight() * static_cast<float>(m_MoveSpeed * deltaTime);
     m_Camera->SetPosition(position);
 }
@@ -40,7 +40,7 @@ void DebugCameraController::MoveRight(double deltaTime)
 {
     if (!m_Camera)
         return;
-    glm::vec3 position = m_Camera->GetPosition();
+    Eigen::Vector3f position = m_Camera->GetPosition();
     position += m_Camera->GetRight() * static_cast<float>(m_MoveSpeed * deltaTime);
     m_Camera->SetPosition(position);
 }
@@ -49,8 +49,8 @@ void DebugCameraController::MoveUp(double deltaTime)
 {
     if (!m_Camera)
         return;
-    glm::vec3 position = m_Camera->GetPosition();
-    position += glm::vec3(0.0f, 1.0f, 0.0f) * static_cast<float>(m_MoveSpeed * deltaTime);
+    Eigen::Vector3f position = m_Camera->GetPosition();
+    position += Eigen::Vector3f(0.0f, 1.0f, 0.0f) * static_cast<float>(m_MoveSpeed * deltaTime);
     m_Camera->SetPosition(position);
 }
 
@@ -58,8 +58,8 @@ void DebugCameraController::MoveDown(double deltaTime)
 {
     if (!m_Camera)
         return;
-    glm::vec3 position = m_Camera->GetPosition();
-    position -= glm::vec3(0.0f, 1.0f, 0.0f) * static_cast<float>(m_MoveSpeed * deltaTime);
+    Eigen::Vector3f position = m_Camera->GetPosition();
+    position -= Eigen::Vector3f(0.0f, 1.0f, 0.0f) * static_cast<float>(m_MoveSpeed * deltaTime);
     m_Camera->SetPosition(position);
 }
 

--- a/Src/Scene/Light.h
+++ b/Src/Scene/Light.h
@@ -9,13 +9,13 @@
 ///
 /// The padding field ensures 16-byte alignment for potential future UBO upload.
 
-#include <glm/glm.hpp>
+#include <Eigen/Core>
 
 struct DirectionalLight
 {
-    glm::vec3 m_Direction = glm::normalize(glm::vec3(-0.5f, -1.0f, -0.3f));
+    Eigen::Vector3f m_Direction = Eigen::Vector3f(-0.5f, -1.0f, -0.3f).normalized();
     float m_Intensity = 1.0f;
 
-    glm::vec3 m_Color{1.0f, 1.0f, 1.0f};
+    Eigen::Vector3f m_Color{1.0f, 1.0f, 1.0f};
     float m_Padding = 0.0f; // Align to 16 bytes for potential future UBO layout
 };

--- a/Src/Scene/Light.h
+++ b/Src/Scene/Light.h
@@ -9,13 +9,13 @@
 ///
 /// The padding field ensures 16-byte alignment for potential future UBO upload.
 
-#include <Eigen/Core>
+#include "Core/Util/Math.h"
 
 struct DirectionalLight
 {
-    Eigen::Vector3f m_Direction = Eigen::Vector3f(-0.5f, -1.0f, -0.3f).normalized();
+    Math::Vec3 m_Direction = Math::Vec3(-0.5f, -1.0f, -0.3f).normalized();
     float m_Intensity = 1.0f;
 
-    Eigen::Vector3f m_Color{1.0f, 1.0f, 1.0f};
+    Math::Vec3 m_Color{1.0f, 1.0f, 1.0f};
     float m_Padding = 0.0f; // Align to 16 bytes for potential future UBO layout
 };

--- a/Src/Scene/Transform.h
+++ b/Src/Scene/Transform.h
@@ -7,29 +7,31 @@
 /// Rotation order is ZYX (roll, then yaw, then pitch) - standard for FPS-style objects.
 /// The matrix is recomputed on every call; caching can be added if profiling shows a need.
 
-#include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include "Core/Util/Math.h"
 
 struct Transform
 {
-    glm::vec3 m_Position{0.0f, 0.0f, 0.0f};
-    glm::vec3 m_RotationEulerDegrees{0.0f, 0.0f, 0.0f};
-    glm::vec3 m_Scale{1.0f, 1.0f, 1.0f};
+    Eigen::Vector3f m_Position{0.0f, 0.0f, 0.0f};
+    Eigen::Vector3f m_RotationEulerDegrees{0.0f, 0.0f, 0.0f};
+    Eigen::Vector3f m_Scale{1.0f, 1.0f, 1.0f};
 
     /// Compute the TRS model matrix. Rotation order: Z * Y * X.
-    glm::mat4 GetMatrix() const
+    Eigen::Matrix4f GetMatrix() const
     {
-        glm::mat4 translation = glm::translate(glm::mat4(1.0f), m_Position);
+        const Eigen::Matrix4f translation = Math::Translate(Eigen::Matrix4f::Identity(), m_Position);
 
-        glm::mat4 rotationX =
-            glm::rotate(glm::mat4(1.0f), glm::radians(m_RotationEulerDegrees.x), glm::vec3(1.0f, 0.0f, 0.0f));
-        glm::mat4 rotationY =
-            glm::rotate(glm::mat4(1.0f), glm::radians(m_RotationEulerDegrees.y), glm::vec3(0.0f, 1.0f, 0.0f));
-        glm::mat4 rotationZ =
-            glm::rotate(glm::mat4(1.0f), glm::radians(m_RotationEulerDegrees.z), glm::vec3(0.0f, 0.0f, 1.0f));
+        const Eigen::Matrix4f rotationX = Math::Rotate(
+            Eigen::Matrix4f::Identity(), Math::Radians(m_RotationEulerDegrees.x()), Eigen::Vector3f(1.0f, 0.0f, 0.0f));
+        const Eigen::Matrix4f rotationY = Math::Rotate(
+            Eigen::Matrix4f::Identity(), Math::Radians(m_RotationEulerDegrees.y()), Eigen::Vector3f(0.0f, 1.0f, 0.0f));
+        const Eigen::Matrix4f rotationZ = Math::Rotate(
+            Eigen::Matrix4f::Identity(), Math::Radians(m_RotationEulerDegrees.z()), Eigen::Vector3f(0.0f, 0.0f, 1.0f));
 
-        glm::mat4 rotation = rotationZ * rotationY * rotationX;
-        glm::mat4 scale = glm::scale(glm::mat4(1.0f), m_Scale);
+        const Eigen::Matrix4f rotation = rotationZ * rotationY * rotationX;
+        const Eigen::Matrix4f scale = Math::Scale(Eigen::Matrix4f::Identity(), m_Scale);
 
         return translation * rotation * scale;
     }

--- a/Src/Scene/Transform.h
+++ b/Src/Scene/Transform.h
@@ -7,31 +7,28 @@
 /// Rotation order is ZYX (roll, then yaw, then pitch) - standard for FPS-style objects.
 /// The matrix is recomputed on every call; caching can be added if profiling shows a need.
 
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
 #include "Core/Util/Math.h"
 
 struct Transform
 {
-    Eigen::Vector3f m_Position{0.0f, 0.0f, 0.0f};
-    Eigen::Vector3f m_RotationEulerDegrees{0.0f, 0.0f, 0.0f};
-    Eigen::Vector3f m_Scale{1.0f, 1.0f, 1.0f};
+    Math::Vec3 m_Position{0.0f, 0.0f, 0.0f};
+    Math::Vec3 m_RotationEulerDegrees{0.0f, 0.0f, 0.0f};
+    Math::Vec3 m_Scale{1.0f, 1.0f, 1.0f};
 
     /// Compute the TRS model matrix. Rotation order: Z * Y * X.
-    Eigen::Matrix4f GetMatrix() const
+    Math::Mat4 GetMatrix() const
     {
-        const Eigen::Matrix4f translation = Math::Translate(Eigen::Matrix4f::Identity(), m_Position);
+        const Math::Mat4 translation = Math::Translate(Math::Mat4::Identity(), m_Position);
 
-        const Eigen::Matrix4f rotationX = Math::Rotate(
-            Eigen::Matrix4f::Identity(), Math::Radians(m_RotationEulerDegrees.x()), Eigen::Vector3f(1.0f, 0.0f, 0.0f));
-        const Eigen::Matrix4f rotationY = Math::Rotate(
-            Eigen::Matrix4f::Identity(), Math::Radians(m_RotationEulerDegrees.y()), Eigen::Vector3f(0.0f, 1.0f, 0.0f));
-        const Eigen::Matrix4f rotationZ = Math::Rotate(
-            Eigen::Matrix4f::Identity(), Math::Radians(m_RotationEulerDegrees.z()), Eigen::Vector3f(0.0f, 0.0f, 1.0f));
+        const Math::Mat4 rotationX = Math::Rotate(
+            Math::Mat4::Identity(), Math::Radians(m_RotationEulerDegrees.x()), Math::Vec3(1.0f, 0.0f, 0.0f));
+        const Math::Mat4 rotationY = Math::Rotate(
+            Math::Mat4::Identity(), Math::Radians(m_RotationEulerDegrees.y()), Math::Vec3(0.0f, 1.0f, 0.0f));
+        const Math::Mat4 rotationZ = Math::Rotate(
+            Math::Mat4::Identity(), Math::Radians(m_RotationEulerDegrees.z()), Math::Vec3(0.0f, 0.0f, 1.0f));
 
-        const Eigen::Matrix4f rotation = rotationZ * rotationY * rotationX;
-        const Eigen::Matrix4f scale = Math::Scale(Eigen::Matrix4f::Identity(), m_Scale);
+        const Math::Mat4 rotation = rotationZ * rotationY * rotationX;
+        const Math::Mat4 scale = Math::Scale(Math::Mat4::Identity(), m_Scale);
 
         return translation * rotation * scale;
     }

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -13,7 +13,5 @@
 #include <utility>
 #include <vector>
 
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
+#include "Core/Util/Math.h"
 #include <spdlog/spdlog.h>

--- a/Src/pch.h
+++ b/Src/pch.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 
 #include <spdlog/spdlog.h>

--- a/Tests/Common/Unit/Core/Serialization/TestBuiltinTraits.cpp
+++ b/Tests/Common/Unit/Core/Serialization/TestBuiltinTraits.cpp
@@ -6,8 +6,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <Eigen/Core>
-
 #include "Core/Serialization/BuiltinTraits.h"
 #include "Core/Resource/Catalog/AssetPath.h"
 #include "MathTestUtils.h"
@@ -23,20 +21,20 @@ enum class Color
     Blue
 };
 
-void ExpectVec2Eq(const Eigen::Vector2f& lhs, const Eigen::Vector2f& rhs)
+void ExpectVec2Eq(const Math::Vec2& lhs, const Math::Vec2& rhs)
 {
     EXPECT_FLOAT_EQ(lhs.x(), rhs.x());
     EXPECT_FLOAT_EQ(lhs.y(), rhs.y());
 }
 
-void ExpectVec3Eq(const Eigen::Vector3f& lhs, const Eigen::Vector3f& rhs)
+void ExpectVec3Eq(const Math::Vec3& lhs, const Math::Vec3& rhs)
 {
     EXPECT_FLOAT_EQ(lhs.x(), rhs.x());
     EXPECT_FLOAT_EQ(lhs.y(), rhs.y());
     EXPECT_FLOAT_EQ(lhs.z(), rhs.z());
 }
 
-void ExpectVec4Eq(const Eigen::Vector4f& lhs, const Eigen::Vector4f& rhs)
+void ExpectVec4Eq(const Math::Vec4& lhs, const Math::Vec4& rhs)
 {
     EXPECT_FLOAT_EQ(lhs.x(), rhs.x());
     EXPECT_FLOAT_EQ(lhs.y(), rhs.y());
@@ -268,11 +266,11 @@ TEST(BuiltinTraitsTests, EnumDeserializeFromNonStringReturnsFalseAndLeavesOutput
 
 TEST(BuiltinTraitsTests, Vec2RoundTrip)
 {
-    const Eigen::Vector2f input(1.0f, -2.0f);
+    const Math::Vec2 input(1.0f, -2.0f);
     PropertyTree tree;
     Serialize(tree, input);
 
-    Eigen::Vector2f output = Eigen::Vector2f::Zero();
+    Math::Vec2 output = Math::Vec2::Zero();
     ASSERT_TRUE(Deserialize(tree, output));
     EXPECT_TRUE(tree.IsArray());
     EXPECT_EQ(tree.Size(), 2u);
@@ -281,11 +279,11 @@ TEST(BuiltinTraitsTests, Vec2RoundTrip)
 
 TEST(BuiltinTraitsTests, Vec3RoundTrip)
 {
-    const Eigen::Vector3f input(1.0f, -2.0f, 3.5f);
+    const Math::Vec3 input(1.0f, -2.0f, 3.5f);
     PropertyTree tree;
     Serialize(tree, input);
 
-    Eigen::Vector3f output = Eigen::Vector3f::Zero();
+    Math::Vec3 output = Math::Vec3::Zero();
     ASSERT_TRUE(Deserialize(tree, output));
     EXPECT_TRUE(tree.IsArray());
     EXPECT_EQ(tree.Size(), 3u);
@@ -294,11 +292,11 @@ TEST(BuiltinTraitsTests, Vec3RoundTrip)
 
 TEST(BuiltinTraitsTests, Vec4RoundTrip)
 {
-    const Eigen::Vector4f input(1.0f, -2.0f, 3.5f, 4.25f);
+    const Math::Vec4 input(1.0f, -2.0f, 3.5f, 4.25f);
     PropertyTree tree;
     Serialize(tree, input);
 
-    Eigen::Vector4f output = Eigen::Vector4f::Zero();
+    Math::Vec4 output = Math::Vec4::Zero();
     ASSERT_TRUE(Deserialize(tree, output));
     EXPECT_TRUE(tree.IsArray());
     EXPECT_EQ(tree.Size(), 4u);
@@ -309,7 +307,7 @@ TEST(BuiltinTraitsTests, Mat4RoundTripUsesColumnMajorLayout)
 {
     // Fill so that column-major storage is [1,2,3,4, 5,6,7,8, 9,10,11,12, 13,14,15,16],
     // matching what the previous glm-backed test exercised.
-    Eigen::Matrix4f input;
+    Math::Mat4 input;
     input << 1.0f, 5.0f, 9.0f, 13.0f, 2.0f, 6.0f, 10.0f, 14.0f, 3.0f, 7.0f, 11.0f, 15.0f, 4.0f, 8.0f, 12.0f, 16.0f;
 
     PropertyTree tree;
@@ -322,7 +320,7 @@ TEST(BuiltinTraitsTests, Mat4RoundTripUsesColumnMajorLayout)
     EXPECT_FLOAT_EQ(static_cast<float>(tree[4].AsFloat()), input(0, 1));
     EXPECT_FLOAT_EQ(static_cast<float>(tree[15].AsFloat()), input(3, 3));
 
-    Eigen::Matrix4f output = Eigen::Matrix4f::Zero();
+    Math::Mat4 output = Math::Mat4::Zero();
     ASSERT_TRUE(Deserialize(tree, output));
     ExpectMat4Near(output, input, 1e-5f);
 }
@@ -330,28 +328,28 @@ TEST(BuiltinTraitsTests, Mat4RoundTripUsesColumnMajorLayout)
 TEST(BuiltinTraitsTests, Vec3DeserializeFromTooShortArrayReturnsFalseAndLeavesOutputUnchanged)
 {
     PropertyTree tree(PropertyTree::Array{PropertyTree(1.0f), PropertyTree(2.0f)});
-    Eigen::Vector3f value(9.0f, 8.0f, 7.0f);
+    Math::Vec3 value(9.0f, 8.0f, 7.0f);
 
     EXPECT_FALSE(Deserialize(tree, value));
-    ExpectVec3Eq(value, Eigen::Vector3f(9.0f, 8.0f, 7.0f));
+    ExpectVec3Eq(value, Math::Vec3(9.0f, 8.0f, 7.0f));
 }
 
 TEST(BuiltinTraitsTests, Vec3DeserializeFromTooLongArrayReturnsFalseAndLeavesOutputUnchanged)
 {
     PropertyTree tree(
         PropertyTree::Array{PropertyTree(1.0f), PropertyTree(2.0f), PropertyTree(3.0f), PropertyTree(4.0f)});
-    Eigen::Vector3f value(9.0f, 8.0f, 7.0f);
+    Math::Vec3 value(9.0f, 8.0f, 7.0f);
 
     EXPECT_FALSE(Deserialize(tree, value));
-    ExpectVec3Eq(value, Eigen::Vector3f(9.0f, 8.0f, 7.0f));
+    ExpectVec3Eq(value, Math::Vec3(9.0f, 8.0f, 7.0f));
 }
 
 TEST(BuiltinTraitsTests, Mat4DeserializeFromTooShortArrayReturnsFalseAndLeavesOutputUnchanged)
 {
     PropertyTree::Array arr(15, PropertyTree(1.0f));
     PropertyTree tree(std::move(arr));
-    Eigen::Matrix4f value = 2.0f * Eigen::Matrix4f::Identity();
-    const Eigen::Matrix4f original = value;
+    Math::Mat4 value = 2.0f * Math::Mat4::Identity();
+    const Math::Mat4 original = value;
 
     EXPECT_FALSE(Deserialize(tree, value));
     ExpectMat4Near(value, original, 1e-5f);
@@ -361,8 +359,8 @@ TEST(BuiltinTraitsTests, Mat4DeserializeFromTooLongArrayReturnsFalseAndLeavesOut
 {
     PropertyTree::Array arr(17, PropertyTree(1.0f));
     PropertyTree tree(std::move(arr));
-    Eigen::Matrix4f value = 2.0f * Eigen::Matrix4f::Identity();
-    const Eigen::Matrix4f original = value;
+    Math::Mat4 value = 2.0f * Math::Mat4::Identity();
+    const Math::Mat4 original = value;
 
     EXPECT_FALSE(Deserialize(tree, value));
     ExpectMat4Near(value, original, 1e-5f);

--- a/Tests/Common/Unit/Core/Serialization/TestBuiltinTraits.cpp
+++ b/Tests/Common/Unit/Core/Serialization/TestBuiltinTraits.cpp
@@ -306,7 +306,7 @@ TEST(BuiltinTraitsTests, Vec4RoundTrip)
 TEST(BuiltinTraitsTests, Mat4RoundTripUsesColumnMajorLayout)
 {
     // Fill so that column-major storage is [1,2,3,4, 5,6,7,8, 9,10,11,12, 13,14,15,16],
-    // matching what the previous glm-backed test exercised.
+    // matching the previous column-major serialization expectation.
     Math::Mat4 input;
     input << 1.0f, 5.0f, 9.0f, 13.0f, 2.0f, 6.0f, 10.0f, 14.0f, 3.0f, 7.0f, 11.0f, 15.0f, 4.0f, 8.0f, 12.0f, 16.0f;
 

--- a/Tests/Common/Unit/Core/Serialization/TestBuiltinTraits.cpp
+++ b/Tests/Common/Unit/Core/Serialization/TestBuiltinTraits.cpp
@@ -6,7 +6,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <glm/glm.hpp>
+#include <Eigen/Core>
 
 #include "Core/Serialization/BuiltinTraits.h"
 #include "Core/Resource/Catalog/AssetPath.h"
@@ -23,25 +23,25 @@ enum class Color
     Blue
 };
 
-void ExpectVec2Eq(const glm::vec2& lhs, const glm::vec2& rhs)
+void ExpectVec2Eq(const Eigen::Vector2f& lhs, const Eigen::Vector2f& rhs)
 {
-    EXPECT_FLOAT_EQ(lhs.x, rhs.x);
-    EXPECT_FLOAT_EQ(lhs.y, rhs.y);
+    EXPECT_FLOAT_EQ(lhs.x(), rhs.x());
+    EXPECT_FLOAT_EQ(lhs.y(), rhs.y());
 }
 
-void ExpectVec3Eq(const glm::vec3& lhs, const glm::vec3& rhs)
+void ExpectVec3Eq(const Eigen::Vector3f& lhs, const Eigen::Vector3f& rhs)
 {
-    EXPECT_FLOAT_EQ(lhs.x, rhs.x);
-    EXPECT_FLOAT_EQ(lhs.y, rhs.y);
-    EXPECT_FLOAT_EQ(lhs.z, rhs.z);
+    EXPECT_FLOAT_EQ(lhs.x(), rhs.x());
+    EXPECT_FLOAT_EQ(lhs.y(), rhs.y());
+    EXPECT_FLOAT_EQ(lhs.z(), rhs.z());
 }
 
-void ExpectVec4Eq(const glm::vec4& lhs, const glm::vec4& rhs)
+void ExpectVec4Eq(const Eigen::Vector4f& lhs, const Eigen::Vector4f& rhs)
 {
-    EXPECT_FLOAT_EQ(lhs.x, rhs.x);
-    EXPECT_FLOAT_EQ(lhs.y, rhs.y);
-    EXPECT_FLOAT_EQ(lhs.z, rhs.z);
-    EXPECT_FLOAT_EQ(lhs.w, rhs.w);
+    EXPECT_FLOAT_EQ(lhs.x(), rhs.x());
+    EXPECT_FLOAT_EQ(lhs.y(), rhs.y());
+    EXPECT_FLOAT_EQ(lhs.z(), rhs.z());
+    EXPECT_FLOAT_EQ(lhs.w(), rhs.w());
 }
 
 } // namespace
@@ -268,11 +268,11 @@ TEST(BuiltinTraitsTests, EnumDeserializeFromNonStringReturnsFalseAndLeavesOutput
 
 TEST(BuiltinTraitsTests, Vec2RoundTrip)
 {
-    const glm::vec2 input(1.0f, -2.0f);
+    const Eigen::Vector2f input(1.0f, -2.0f);
     PropertyTree tree;
     Serialize(tree, input);
 
-    glm::vec2 output(0.0f);
+    Eigen::Vector2f output = Eigen::Vector2f::Zero();
     ASSERT_TRUE(Deserialize(tree, output));
     EXPECT_TRUE(tree.IsArray());
     EXPECT_EQ(tree.Size(), 2u);
@@ -281,11 +281,11 @@ TEST(BuiltinTraitsTests, Vec2RoundTrip)
 
 TEST(BuiltinTraitsTests, Vec3RoundTrip)
 {
-    const glm::vec3 input(1.0f, -2.0f, 3.5f);
+    const Eigen::Vector3f input(1.0f, -2.0f, 3.5f);
     PropertyTree tree;
     Serialize(tree, input);
 
-    glm::vec3 output(0.0f);
+    Eigen::Vector3f output = Eigen::Vector3f::Zero();
     ASSERT_TRUE(Deserialize(tree, output));
     EXPECT_TRUE(tree.IsArray());
     EXPECT_EQ(tree.Size(), 3u);
@@ -294,11 +294,11 @@ TEST(BuiltinTraitsTests, Vec3RoundTrip)
 
 TEST(BuiltinTraitsTests, Vec4RoundTrip)
 {
-    const glm::vec4 input(1.0f, -2.0f, 3.5f, 4.25f);
+    const Eigen::Vector4f input(1.0f, -2.0f, 3.5f, 4.25f);
     PropertyTree tree;
     Serialize(tree, input);
 
-    glm::vec4 output(0.0f);
+    Eigen::Vector4f output = Eigen::Vector4f::Zero();
     ASSERT_TRUE(Deserialize(tree, output));
     EXPECT_TRUE(tree.IsArray());
     EXPECT_EQ(tree.Size(), 4u);
@@ -307,20 +307,22 @@ TEST(BuiltinTraitsTests, Vec4RoundTrip)
 
 TEST(BuiltinTraitsTests, Mat4RoundTripUsesColumnMajorLayout)
 {
-    const glm::mat4 input(
-        1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f, 11.0f, 12.0f, 13.0f, 14.0f, 15.0f, 16.0f);
+    // Fill so that column-major storage is [1,2,3,4, 5,6,7,8, 9,10,11,12, 13,14,15,16],
+    // matching what the previous glm-backed test exercised.
+    Eigen::Matrix4f input;
+    input << 1.0f, 5.0f, 9.0f, 13.0f, 2.0f, 6.0f, 10.0f, 14.0f, 3.0f, 7.0f, 11.0f, 15.0f, 4.0f, 8.0f, 12.0f, 16.0f;
 
     PropertyTree tree;
     Serialize(tree, input);
 
     ASSERT_TRUE(tree.IsArray());
     ASSERT_EQ(tree.Size(), 16u);
-    EXPECT_FLOAT_EQ(static_cast<float>(tree[0].AsFloat()), input[0][0]);
-    EXPECT_FLOAT_EQ(static_cast<float>(tree[1].AsFloat()), input[0][1]);
-    EXPECT_FLOAT_EQ(static_cast<float>(tree[4].AsFloat()), input[1][0]);
-    EXPECT_FLOAT_EQ(static_cast<float>(tree[15].AsFloat()), input[3][3]);
+    EXPECT_FLOAT_EQ(static_cast<float>(tree[0].AsFloat()), input(0, 0));
+    EXPECT_FLOAT_EQ(static_cast<float>(tree[1].AsFloat()), input(1, 0));
+    EXPECT_FLOAT_EQ(static_cast<float>(tree[4].AsFloat()), input(0, 1));
+    EXPECT_FLOAT_EQ(static_cast<float>(tree[15].AsFloat()), input(3, 3));
 
-    glm::mat4 output(0.0f);
+    Eigen::Matrix4f output = Eigen::Matrix4f::Zero();
     ASSERT_TRUE(Deserialize(tree, output));
     ExpectMat4Near(output, input, 1e-5f);
 }
@@ -328,28 +330,28 @@ TEST(BuiltinTraitsTests, Mat4RoundTripUsesColumnMajorLayout)
 TEST(BuiltinTraitsTests, Vec3DeserializeFromTooShortArrayReturnsFalseAndLeavesOutputUnchanged)
 {
     PropertyTree tree(PropertyTree::Array{PropertyTree(1.0f), PropertyTree(2.0f)});
-    glm::vec3 value(9.0f, 8.0f, 7.0f);
+    Eigen::Vector3f value(9.0f, 8.0f, 7.0f);
 
     EXPECT_FALSE(Deserialize(tree, value));
-    ExpectVec3Eq(value, glm::vec3(9.0f, 8.0f, 7.0f));
+    ExpectVec3Eq(value, Eigen::Vector3f(9.0f, 8.0f, 7.0f));
 }
 
 TEST(BuiltinTraitsTests, Vec3DeserializeFromTooLongArrayReturnsFalseAndLeavesOutputUnchanged)
 {
     PropertyTree tree(
         PropertyTree::Array{PropertyTree(1.0f), PropertyTree(2.0f), PropertyTree(3.0f), PropertyTree(4.0f)});
-    glm::vec3 value(9.0f, 8.0f, 7.0f);
+    Eigen::Vector3f value(9.0f, 8.0f, 7.0f);
 
     EXPECT_FALSE(Deserialize(tree, value));
-    ExpectVec3Eq(value, glm::vec3(9.0f, 8.0f, 7.0f));
+    ExpectVec3Eq(value, Eigen::Vector3f(9.0f, 8.0f, 7.0f));
 }
 
 TEST(BuiltinTraitsTests, Mat4DeserializeFromTooShortArrayReturnsFalseAndLeavesOutputUnchanged)
 {
     PropertyTree::Array arr(15, PropertyTree(1.0f));
     PropertyTree tree(std::move(arr));
-    glm::mat4 value(2.0f);
-    const glm::mat4 original = value;
+    Eigen::Matrix4f value = 2.0f * Eigen::Matrix4f::Identity();
+    const Eigen::Matrix4f original = value;
 
     EXPECT_FALSE(Deserialize(tree, value));
     ExpectMat4Near(value, original, 1e-5f);
@@ -359,8 +361,8 @@ TEST(BuiltinTraitsTests, Mat4DeserializeFromTooLongArrayReturnsFalseAndLeavesOut
 {
     PropertyTree::Array arr(17, PropertyTree(1.0f));
     PropertyTree tree(std::move(arr));
-    glm::mat4 value(2.0f);
-    const glm::mat4 original = value;
+    Eigen::Matrix4f value = 2.0f * Eigen::Matrix4f::Identity();
+    const Eigen::Matrix4f original = value;
 
     EXPECT_FALSE(Deserialize(tree, value));
     ExpectMat4Near(value, original, 1e-5f);

--- a/Tests/Common/Unit/Scene/TestCamera.cpp
+++ b/Tests/Common/Unit/Scene/TestCamera.cpp
@@ -1,8 +1,10 @@
 #include <gtest/gtest.h>
-#include <glm/gtc/matrix_transform.hpp>
-#include <glm/gtx/norm.hpp>
+
 #include <cmath>
 
+#include <Eigen/Core>
+
+#include "Core/Util/Math.h"
 #include "Scene/Camera.h"
 #include "MathTestUtils.h"
 
@@ -10,25 +12,25 @@ TEST(CameraTests, DefaultBasisVectorsAreOrthogonalAndNormalized)
 {
     Camera camera;
 
-    EXPECT_NEAR(glm::length(camera.GetForward()), 1.0f, 1e-4f);
-    EXPECT_NEAR(glm::length(camera.GetRight()), 1.0f, 1e-4f);
-    EXPECT_NEAR(glm::length(camera.GetUp()), 1.0f, 1e-4f);
+    EXPECT_NEAR(camera.GetForward().norm(), 1.0f, 1e-4f);
+    EXPECT_NEAR(camera.GetRight().norm(), 1.0f, 1e-4f);
+    EXPECT_NEAR(camera.GetUp().norm(), 1.0f, 1e-4f);
 
-    EXPECT_NEAR(glm::dot(camera.GetForward(), camera.GetRight()), 0.0f, 1e-4f);
-    EXPECT_NEAR(glm::dot(camera.GetForward(), camera.GetUp()), 0.0f, 1e-4f);
-    EXPECT_NEAR(glm::dot(camera.GetRight(), camera.GetUp()), 0.0f, 1e-4f);
+    EXPECT_NEAR(camera.GetForward().dot(camera.GetRight()), 0.0f, 1e-4f);
+    EXPECT_NEAR(camera.GetForward().dot(camera.GetUp()), 0.0f, 1e-4f);
+    EXPECT_NEAR(camera.GetRight().dot(camera.GetUp()), 0.0f, 1e-4f);
 }
 
 TEST(CameraTests, DefaultConstructionBuildsConsistentViewAndProjection)
 {
     Camera camera;
 
-    glm::mat4 expectedView =
-        glm::lookAt(camera.GetPosition(), camera.GetPosition() + camera.GetForward(), camera.GetUp());
-    glm::mat4 expectedProjection = glm::perspective(glm::radians(camera.GetVerticalFovDegrees()),
-                                                    camera.GetAspectRatio(),
-                                                    camera.GetNearClip(),
-                                                    camera.GetFarClip());
+    Eigen::Matrix4f expectedView =
+        Math::LookAt(camera.GetPosition(), camera.GetPosition() + camera.GetForward(), camera.GetUp());
+    Eigen::Matrix4f expectedProjection = Math::Perspective(Math::Radians(camera.GetVerticalFovDegrees()),
+                                                           camera.GetAspectRatio(),
+                                                           camera.GetNearClip(),
+                                                           camera.GetFarClip());
 
     ExpectMat4Near(camera.GetView(), expectedView);
     ExpectMat4Near(camera.GetProjection(), expectedProjection);
@@ -57,7 +59,7 @@ TEST(CameraTests, SetViewportSizeWithZeroHeightKeepsProjectionStateUnchanged)
     Camera camera(45.0f, 16.0f / 9.0f, 0.1f, 100.0f);
 
     const float originalAspect = camera.GetAspectRatio();
-    const glm::mat4 originalProjection = camera.GetProjection();
+    const Eigen::Matrix4f originalProjection = camera.GetProjection();
 
     camera.SetViewportSize(1920, 0);
 
@@ -67,29 +69,18 @@ TEST(CameraTests, SetViewportSizeWithZeroHeightKeepsProjectionStateUnchanged)
 
 TEST(CameraTests, ExtremePitchKeepsBasisAndViewFinite)
 {
-    auto isFiniteVec3 = [](const glm::vec3& value)
-    {
-        return std::isfinite(value.x) && std::isfinite(value.y) && std::isfinite(value.z);
-    };
-    auto isFiniteVec4 = [](const glm::vec4& value)
-    {
-        return std::isfinite(value.x) && std::isfinite(value.y) && std::isfinite(value.z) && std::isfinite(value.w);
-    };
-
     Camera camera;
     camera.SetRotation(-90.0f, 90.0f);
 
-    EXPECT_TRUE(isFiniteVec3(camera.GetForward()));
-    EXPECT_TRUE(isFiniteVec3(camera.GetRight()));
-    EXPECT_TRUE(isFiniteVec3(camera.GetUp()));
+    EXPECT_TRUE(camera.GetForward().allFinite());
+    EXPECT_TRUE(camera.GetRight().allFinite());
+    EXPECT_TRUE(camera.GetUp().allFinite());
 
-    EXPECT_NEAR(glm::length2(camera.GetForward()), 1.0f, 1e-3f);
-    EXPECT_NEAR(glm::length2(camera.GetRight()), 1.0f, 1e-3f);
-    EXPECT_NEAR(glm::length2(camera.GetUp()), 1.0f, 1e-3f);
+    EXPECT_NEAR(camera.GetForward().squaredNorm(), 1.0f, 1e-3f);
+    EXPECT_NEAR(camera.GetRight().squaredNorm(), 1.0f, 1e-3f);
+    EXPECT_NEAR(camera.GetUp().squaredNorm(), 1.0f, 1e-3f);
 
-    const glm::mat4& view = camera.GetView();
-    for (int c = 0; c < 4; ++c)
-        EXPECT_TRUE(isFiniteVec4(view[c]));
+    EXPECT_TRUE(camera.GetView().allFinite());
 }
 
 TEST(CameraTests, SetAspectRatioUpdatesProjectionState)
@@ -100,7 +91,7 @@ TEST(CameraTests, SetAspectRatioUpdatesProjectionState)
     camera.SetAspectRatio(1.0f);
     auto after = camera.GetProjection();
 
-    EXPECT_NE(before[0][0], after[0][0]);
+    EXPECT_NE(before(0, 0), after(0, 0));
     EXPECT_FLOAT_EQ(camera.GetAspectRatio(), 1.0f);
 }
 
@@ -110,6 +101,6 @@ TEST(CameraTests, ViewProjectionMatchesProjectionTimesView)
     camera.SetPosition({1.0f, 2.0f, 3.0f});
     camera.SetRotation(-90.0f, 0.0f);
 
-    glm::mat4 expected = camera.GetProjection() * camera.GetView();
+    Eigen::Matrix4f expected = camera.GetProjection() * camera.GetView();
     ExpectMat4Near(camera.GetViewProjection(), expected);
 }

--- a/Tests/Common/Unit/Scene/TestCamera.cpp
+++ b/Tests/Common/Unit/Scene/TestCamera.cpp
@@ -2,11 +2,9 @@
 
 #include <cmath>
 
-#include <Eigen/Core>
-
 #include "Core/Util/Math.h"
-#include "Scene/Camera.h"
 #include "MathTestUtils.h"
+#include "Scene/Camera.h"
 
 TEST(CameraTests, DefaultBasisVectorsAreOrthogonalAndNormalized)
 {
@@ -25,9 +23,9 @@ TEST(CameraTests, DefaultConstructionBuildsConsistentViewAndProjection)
 {
     Camera camera;
 
-    Eigen::Matrix4f expectedView =
+    Math::Mat4 expectedView =
         Math::LookAt(camera.GetPosition(), camera.GetPosition() + camera.GetForward(), camera.GetUp());
-    Eigen::Matrix4f expectedProjection = Math::Perspective(Math::Radians(camera.GetVerticalFovDegrees()),
+    Math::Mat4 expectedProjection = Math::PerspectiveRH_ZO(Math::Radians(camera.GetVerticalFovDegrees()),
                                                            camera.GetAspectRatio(),
                                                            camera.GetNearClip(),
                                                            camera.GetFarClip());
@@ -59,7 +57,7 @@ TEST(CameraTests, SetViewportSizeWithZeroHeightKeepsProjectionStateUnchanged)
     Camera camera(45.0f, 16.0f / 9.0f, 0.1f, 100.0f);
 
     const float originalAspect = camera.GetAspectRatio();
-    const Eigen::Matrix4f originalProjection = camera.GetProjection();
+    const Math::Mat4 originalProjection = camera.GetProjection();
 
     camera.SetViewportSize(1920, 0);
 
@@ -101,6 +99,6 @@ TEST(CameraTests, ViewProjectionMatchesProjectionTimesView)
     camera.SetPosition({1.0f, 2.0f, 3.0f});
     camera.SetRotation(-90.0f, 0.0f);
 
-    Eigen::Matrix4f expected = camera.GetProjection() * camera.GetView();
+    Math::Mat4 expected = camera.GetProjection() * camera.GetView();
     ExpectMat4Near(camera.GetViewProjection(), expected);
 }

--- a/Tests/Common/Unit/Scene/TestDefaultCameraController.cpp
+++ b/Tests/Common/Unit/Scene/TestDefaultCameraController.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include <glm/glm.hpp>
+#include <Eigen/Core>
 
 #include "MathTestUtils.h"
 
@@ -64,12 +64,12 @@ TEST(DebugCameraControllerTests, MoveForwardMovesAlongCameraForward)
     DebugCameraController controller(&camera);
     controller.SetMoveSpeed(10.0f);
 
-    const glm::vec3 start = camera.GetPosition();
-    const glm::vec3 forward = camera.GetForward();
+    const Eigen::Vector3f start = camera.GetPosition();
+    const Eigen::Vector3f forward = camera.GetForward();
 
     controller.MoveForward(0.5f);
 
-    const glm::vec3 expected = start + forward * 5.0f;
+    const Eigen::Vector3f expected = start + forward * 5.0f;
     ExpectVec3Near(camera.GetPosition(), expected);
 }
 
@@ -81,12 +81,12 @@ TEST(DebugCameraControllerTests, MoveBackwardMovesOppositeToCameraForward)
     DebugCameraController controller(&camera);
     controller.SetMoveSpeed(8.0f);
 
-    const glm::vec3 start = camera.GetPosition();
-    const glm::vec3 forward = camera.GetForward();
+    const Eigen::Vector3f start = camera.GetPosition();
+    const Eigen::Vector3f forward = camera.GetForward();
 
     controller.MoveBackward(0.25f);
 
-    const glm::vec3 expected = start - forward * 2.0f;
+    const Eigen::Vector3f expected = start - forward * 2.0f;
     ExpectVec3Near(camera.GetPosition(), expected);
 }
 
@@ -98,12 +98,12 @@ TEST(DebugCameraControllerTests, MoveRightMovesAlongCameraRight)
     DebugCameraController controller(&camera);
     controller.SetMoveSpeed(6.0f);
 
-    const glm::vec3 start = camera.GetPosition();
-    const glm::vec3 right = camera.GetRight();
+    const Eigen::Vector3f start = camera.GetPosition();
+    const Eigen::Vector3f right = camera.GetRight();
 
     controller.MoveRight(0.5f);
 
-    const glm::vec3 expected = start + right * 3.0f;
+    const Eigen::Vector3f expected = start + right * 3.0f;
     ExpectVec3Near(camera.GetPosition(), expected);
 }
 
@@ -115,12 +115,12 @@ TEST(DebugCameraControllerTests, MoveLeftMovesOppositeToCameraRight)
     DebugCameraController controller(&camera);
     controller.SetMoveSpeed(4.0f);
 
-    const glm::vec3 start = camera.GetPosition();
-    const glm::vec3 right = camera.GetRight();
+    const Eigen::Vector3f start = camera.GetPosition();
+    const Eigen::Vector3f right = camera.GetRight();
 
     controller.MoveLeft(0.75f);
 
-    const glm::vec3 expected = start - right * 3.0f;
+    const Eigen::Vector3f expected = start - right * 3.0f;
     ExpectVec3Near(camera.GetPosition(), expected);
 }
 
@@ -133,11 +133,11 @@ TEST(DebugCameraControllerTests, MoveUpUsesWorldUpAxis)
     DebugCameraController controller(&camera);
     controller.SetMoveSpeed(5.0f);
 
-    const glm::vec3 start = camera.GetPosition();
+    const Eigen::Vector3f start = camera.GetPosition();
 
     controller.MoveUp(0.4f);
 
-    const glm::vec3 expected = start + glm::vec3(0.0f, 1.0f, 0.0f) * 2.0f;
+    const Eigen::Vector3f expected = start + Eigen::Vector3f(0.0f, 1.0f, 0.0f) * 2.0f;
     ExpectVec3Near(camera.GetPosition(), expected);
 }
 
@@ -150,11 +150,11 @@ TEST(DebugCameraControllerTests, MoveDownUsesWorldUpAxis)
     DebugCameraController controller(&camera);
     controller.SetMoveSpeed(5.0f);
 
-    const glm::vec3 start = camera.GetPosition();
+    const Eigen::Vector3f start = camera.GetPosition();
 
     controller.MoveDown(0.4f);
 
-    const glm::vec3 expected = start - glm::vec3(0.0f, 1.0f, 0.0f) * 2.0f;
+    const Eigen::Vector3f expected = start - Eigen::Vector3f(0.0f, 1.0f, 0.0f) * 2.0f;
     ExpectVec3Near(camera.GetPosition(), expected);
 }
 

--- a/Tests/Common/Unit/Scene/TestDefaultCameraController.cpp
+++ b/Tests/Common/Unit/Scene/TestDefaultCameraController.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#include <Eigen/Core>
 
 #include "MathTestUtils.h"
 
@@ -64,12 +63,12 @@ TEST(DebugCameraControllerTests, MoveForwardMovesAlongCameraForward)
     DebugCameraController controller(&camera);
     controller.SetMoveSpeed(10.0f);
 
-    const Eigen::Vector3f start = camera.GetPosition();
-    const Eigen::Vector3f forward = camera.GetForward();
+    const Math::Vec3 start = camera.GetPosition();
+    const Math::Vec3 forward = camera.GetForward();
 
     controller.MoveForward(0.5f);
 
-    const Eigen::Vector3f expected = start + forward * 5.0f;
+    const Math::Vec3 expected = start + forward * 5.0f;
     ExpectVec3Near(camera.GetPosition(), expected);
 }
 
@@ -81,12 +80,12 @@ TEST(DebugCameraControllerTests, MoveBackwardMovesOppositeToCameraForward)
     DebugCameraController controller(&camera);
     controller.SetMoveSpeed(8.0f);
 
-    const Eigen::Vector3f start = camera.GetPosition();
-    const Eigen::Vector3f forward = camera.GetForward();
+    const Math::Vec3 start = camera.GetPosition();
+    const Math::Vec3 forward = camera.GetForward();
 
     controller.MoveBackward(0.25f);
 
-    const Eigen::Vector3f expected = start - forward * 2.0f;
+    const Math::Vec3 expected = start - forward * 2.0f;
     ExpectVec3Near(camera.GetPosition(), expected);
 }
 
@@ -98,12 +97,12 @@ TEST(DebugCameraControllerTests, MoveRightMovesAlongCameraRight)
     DebugCameraController controller(&camera);
     controller.SetMoveSpeed(6.0f);
 
-    const Eigen::Vector3f start = camera.GetPosition();
-    const Eigen::Vector3f right = camera.GetRight();
+    const Math::Vec3 start = camera.GetPosition();
+    const Math::Vec3 right = camera.GetRight();
 
     controller.MoveRight(0.5f);
 
-    const Eigen::Vector3f expected = start + right * 3.0f;
+    const Math::Vec3 expected = start + right * 3.0f;
     ExpectVec3Near(camera.GetPosition(), expected);
 }
 
@@ -115,12 +114,12 @@ TEST(DebugCameraControllerTests, MoveLeftMovesOppositeToCameraRight)
     DebugCameraController controller(&camera);
     controller.SetMoveSpeed(4.0f);
 
-    const Eigen::Vector3f start = camera.GetPosition();
-    const Eigen::Vector3f right = camera.GetRight();
+    const Math::Vec3 start = camera.GetPosition();
+    const Math::Vec3 right = camera.GetRight();
 
     controller.MoveLeft(0.75f);
 
-    const Eigen::Vector3f expected = start - right * 3.0f;
+    const Math::Vec3 expected = start - right * 3.0f;
     ExpectVec3Near(camera.GetPosition(), expected);
 }
 
@@ -133,11 +132,11 @@ TEST(DebugCameraControllerTests, MoveUpUsesWorldUpAxis)
     DebugCameraController controller(&camera);
     controller.SetMoveSpeed(5.0f);
 
-    const Eigen::Vector3f start = camera.GetPosition();
+    const Math::Vec3 start = camera.GetPosition();
 
     controller.MoveUp(0.4f);
 
-    const Eigen::Vector3f expected = start + Eigen::Vector3f(0.0f, 1.0f, 0.0f) * 2.0f;
+    const Math::Vec3 expected = start + Math::Vec3(0.0f, 1.0f, 0.0f) * 2.0f;
     ExpectVec3Near(camera.GetPosition(), expected);
 }
 
@@ -150,11 +149,11 @@ TEST(DebugCameraControllerTests, MoveDownUsesWorldUpAxis)
     DebugCameraController controller(&camera);
     controller.SetMoveSpeed(5.0f);
 
-    const Eigen::Vector3f start = camera.GetPosition();
+    const Math::Vec3 start = camera.GetPosition();
 
     controller.MoveDown(0.4f);
 
-    const Eigen::Vector3f expected = start - Eigen::Vector3f(0.0f, 1.0f, 0.0f) * 2.0f;
+    const Math::Vec3 expected = start - Math::Vec3(0.0f, 1.0f, 0.0f) * 2.0f;
     ExpectVec3Near(camera.GetPosition(), expected);
 }
 

--- a/Tests/Common/Unit/Scene/TestTransform.cpp
+++ b/Tests/Common/Unit/Scene/TestTransform.cpp
@@ -1,15 +1,13 @@
 #include <gtest/gtest.h>
 
-#include <Eigen/Core>
-
 #include "Core/Util/Math.h"
-#include "Scene/Transform.h"
 #include "MathTestUtils.h"
+#include "Scene/Transform.h"
 
 TEST(TransformTests, DefaultTransformReturnsIdentity)
 {
     Transform t;
-    Eigen::Matrix4f expected = Eigen::Matrix4f::Identity();
+    Math::Mat4 expected = Math::Mat4::Identity();
 
     ExpectMat4Near(t.GetMatrix(), expected);
 }
@@ -19,7 +17,7 @@ TEST(TransformTests, TranslationOnly)
     Transform t;
     t.m_Position = {1.0f, 2.0f, 3.0f};
 
-    Eigen::Matrix4f expected = Math::Translate(Eigen::Matrix4f::Identity(), t.m_Position);
+    Math::Mat4 expected = Math::Translate(Math::Mat4::Identity(), t.m_Position);
 
     ExpectMat4Near(t.GetMatrix(), expected);
 }
@@ -29,7 +27,7 @@ TEST(TransformTests, ScaleOnly)
     Transform t;
     t.m_Scale = {2.0f, 3.0f, 4.0f};
 
-    Eigen::Matrix4f expected = Math::Scale(Eigen::Matrix4f::Identity(), t.m_Scale);
+    Math::Mat4 expected = Math::Scale(Math::Mat4::Identity(), t.m_Scale);
 
     ExpectMat4Near(t.GetMatrix(), expected);
 }
@@ -39,14 +37,11 @@ TEST(TransformTests, RotationOrderMatchesImplementation)
     Transform t;
     t.m_RotationEulerDegrees = {30.0f, 45.0f, 60.0f};
 
-    Eigen::Matrix4f rotationX =
-        Math::Rotate(Eigen::Matrix4f::Identity(), Math::Radians(30.0f), Eigen::Vector3f(1, 0, 0));
-    Eigen::Matrix4f rotationY =
-        Math::Rotate(Eigen::Matrix4f::Identity(), Math::Radians(45.0f), Eigen::Vector3f(0, 1, 0));
-    Eigen::Matrix4f rotationZ =
-        Math::Rotate(Eigen::Matrix4f::Identity(), Math::Radians(60.0f), Eigen::Vector3f(0, 0, 1));
+    Math::Mat4 rotationX = Math::Rotate(Math::Mat4::Identity(), Math::Radians(30.0f), Math::Vec3(1, 0, 0));
+    Math::Mat4 rotationY = Math::Rotate(Math::Mat4::Identity(), Math::Radians(45.0f), Math::Vec3(0, 1, 0));
+    Math::Mat4 rotationZ = Math::Rotate(Math::Mat4::Identity(), Math::Radians(60.0f), Math::Vec3(0, 0, 1));
 
-    Eigen::Matrix4f expected = rotationZ * rotationY * rotationX;
+    Math::Mat4 expected = rotationZ * rotationY * rotationX;
 
     ExpectMat4Near(t.GetMatrix(), expected);
 }
@@ -58,17 +53,14 @@ TEST(TransformTests, FullTRSCompositionMatchesImplementation)
     t.m_RotationEulerDegrees = {10.0f, 20.0f, 30.0f};
     t.m_Scale = {2.0f, 2.0f, 2.0f};
 
-    Eigen::Matrix4f translation = Math::Translate(Eigen::Matrix4f::Identity(), t.m_Position);
-    Eigen::Matrix4f rotationX =
-        Math::Rotate(Eigen::Matrix4f::Identity(), Math::Radians(10.0f), Eigen::Vector3f(1, 0, 0));
-    Eigen::Matrix4f rotationY =
-        Math::Rotate(Eigen::Matrix4f::Identity(), Math::Radians(20.0f), Eigen::Vector3f(0, 1, 0));
-    Eigen::Matrix4f rotationZ =
-        Math::Rotate(Eigen::Matrix4f::Identity(), Math::Radians(30.0f), Eigen::Vector3f(0, 0, 1));
-    Eigen::Matrix4f rotation = rotationZ * rotationY * rotationX;
-    Eigen::Matrix4f scale = Math::Scale(Eigen::Matrix4f::Identity(), t.m_Scale);
+    Math::Mat4 translation = Math::Translate(Math::Mat4::Identity(), t.m_Position);
+    Math::Mat4 rotationX = Math::Rotate(Math::Mat4::Identity(), Math::Radians(10.0f), Math::Vec3(1, 0, 0));
+    Math::Mat4 rotationY = Math::Rotate(Math::Mat4::Identity(), Math::Radians(20.0f), Math::Vec3(0, 1, 0));
+    Math::Mat4 rotationZ = Math::Rotate(Math::Mat4::Identity(), Math::Radians(30.0f), Math::Vec3(0, 0, 1));
+    Math::Mat4 rotation = rotationZ * rotationY * rotationX;
+    Math::Mat4 scale = Math::Scale(Math::Mat4::Identity(), t.m_Scale);
 
-    Eigen::Matrix4f expected = translation * rotation * scale;
+    Math::Mat4 expected = translation * rotation * scale;
 
     ExpectMat4Near(t.GetMatrix(), expected);
 }

--- a/Tests/Common/Unit/Scene/TestTransform.cpp
+++ b/Tests/Common/Unit/Scene/TestTransform.cpp
@@ -1,13 +1,15 @@
 #include <gtest/gtest.h>
-#include <glm/gtc/matrix_transform.hpp>
 
+#include <Eigen/Core>
+
+#include "Core/Util/Math.h"
 #include "Scene/Transform.h"
 #include "MathTestUtils.h"
 
 TEST(TransformTests, DefaultTransformReturnsIdentity)
 {
     Transform t;
-    glm::mat4 expected(1.0f);
+    Eigen::Matrix4f expected = Eigen::Matrix4f::Identity();
 
     ExpectMat4Near(t.GetMatrix(), expected);
 }
@@ -17,7 +19,7 @@ TEST(TransformTests, TranslationOnly)
     Transform t;
     t.m_Position = {1.0f, 2.0f, 3.0f};
 
-    glm::mat4 expected = glm::translate(glm::mat4(1.0f), t.m_Position);
+    Eigen::Matrix4f expected = Math::Translate(Eigen::Matrix4f::Identity(), t.m_Position);
 
     ExpectMat4Near(t.GetMatrix(), expected);
 }
@@ -27,7 +29,7 @@ TEST(TransformTests, ScaleOnly)
     Transform t;
     t.m_Scale = {2.0f, 3.0f, 4.0f};
 
-    glm::mat4 expected = glm::scale(glm::mat4(1.0f), t.m_Scale);
+    Eigen::Matrix4f expected = Math::Scale(Eigen::Matrix4f::Identity(), t.m_Scale);
 
     ExpectMat4Near(t.GetMatrix(), expected);
 }
@@ -37,11 +39,14 @@ TEST(TransformTests, RotationOrderMatchesImplementation)
     Transform t;
     t.m_RotationEulerDegrees = {30.0f, 45.0f, 60.0f};
 
-    glm::mat4 rotationX = glm::rotate(glm::mat4(1.0f), glm::radians(30.0f), glm::vec3(1, 0, 0));
-    glm::mat4 rotationY = glm::rotate(glm::mat4(1.0f), glm::radians(45.0f), glm::vec3(0, 1, 0));
-    glm::mat4 rotationZ = glm::rotate(glm::mat4(1.0f), glm::radians(60.0f), glm::vec3(0, 0, 1));
+    Eigen::Matrix4f rotationX =
+        Math::Rotate(Eigen::Matrix4f::Identity(), Math::Radians(30.0f), Eigen::Vector3f(1, 0, 0));
+    Eigen::Matrix4f rotationY =
+        Math::Rotate(Eigen::Matrix4f::Identity(), Math::Radians(45.0f), Eigen::Vector3f(0, 1, 0));
+    Eigen::Matrix4f rotationZ =
+        Math::Rotate(Eigen::Matrix4f::Identity(), Math::Radians(60.0f), Eigen::Vector3f(0, 0, 1));
 
-    glm::mat4 expected = rotationZ * rotationY * rotationX;
+    Eigen::Matrix4f expected = rotationZ * rotationY * rotationX;
 
     ExpectMat4Near(t.GetMatrix(), expected);
 }
@@ -53,14 +58,17 @@ TEST(TransformTests, FullTRSCompositionMatchesImplementation)
     t.m_RotationEulerDegrees = {10.0f, 20.0f, 30.0f};
     t.m_Scale = {2.0f, 2.0f, 2.0f};
 
-    glm::mat4 translation = glm::translate(glm::mat4(1.0f), t.m_Position);
-    glm::mat4 rotationX = glm::rotate(glm::mat4(1.0f), glm::radians(10.0f), glm::vec3(1, 0, 0));
-    glm::mat4 rotationY = glm::rotate(glm::mat4(1.0f), glm::radians(20.0f), glm::vec3(0, 1, 0));
-    glm::mat4 rotationZ = glm::rotate(glm::mat4(1.0f), glm::radians(30.0f), glm::vec3(0, 0, 1));
-    glm::mat4 rotation = rotationZ * rotationY * rotationX;
-    glm::mat4 scale = glm::scale(glm::mat4(1.0f), t.m_Scale);
+    Eigen::Matrix4f translation = Math::Translate(Eigen::Matrix4f::Identity(), t.m_Position);
+    Eigen::Matrix4f rotationX =
+        Math::Rotate(Eigen::Matrix4f::Identity(), Math::Radians(10.0f), Eigen::Vector3f(1, 0, 0));
+    Eigen::Matrix4f rotationY =
+        Math::Rotate(Eigen::Matrix4f::Identity(), Math::Radians(20.0f), Eigen::Vector3f(0, 1, 0));
+    Eigen::Matrix4f rotationZ =
+        Math::Rotate(Eigen::Matrix4f::Identity(), Math::Radians(30.0f), Eigen::Vector3f(0, 0, 1));
+    Eigen::Matrix4f rotation = rotationZ * rotationY * rotationX;
+    Eigen::Matrix4f scale = Math::Scale(Eigen::Matrix4f::Identity(), t.m_Scale);
 
-    glm::mat4 expected = translation * rotation * scale;
+    Eigen::Matrix4f expected = translation * rotation * scale;
 
     ExpectMat4Near(t.GetMatrix(), expected);
 }

--- a/Tests/Support/MathTestUtils.h
+++ b/Tests/Support/MathTestUtils.h
@@ -1,22 +1,23 @@
 #pragma once
 
 #include <cmath>
-#include <Eigen/Core>
 #include <gtest/gtest.h>
+
+#include "Core/Util/Math.h"
 
 inline void ExpectFloatNear(float a, float b, float eps = 1e-4f)
 {
     EXPECT_NEAR(a, b, eps);
 }
 
-inline void ExpectVec3Near(const Eigen::Vector3f& a, const Eigen::Vector3f& b, float eps = 1e-4f)
+inline void ExpectVec3Near(const Math::Vec3& a, const Math::Vec3& b, float eps = 1e-4f)
 {
     EXPECT_NEAR(a.x(), b.x(), eps);
     EXPECT_NEAR(a.y(), b.y(), eps);
     EXPECT_NEAR(a.z(), b.z(), eps);
 }
 
-inline void ExpectMat4Near(const Eigen::Matrix4f& a, const Eigen::Matrix4f& b, float eps = 1e-4f)
+inline void ExpectMat4Near(const Math::Mat4& a, const Math::Mat4& b, float eps = 1e-4f)
 {
     for (int r = 0; r < 4; ++r)
     {

--- a/Tests/Support/MathTestUtils.h
+++ b/Tests/Support/MathTestUtils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cmath>
-#include <glm/glm.hpp>
+#include <Eigen/Core>
 #include <gtest/gtest.h>
 
 inline void ExpectFloatNear(float a, float b, float eps = 1e-4f)
@@ -9,20 +9,20 @@ inline void ExpectFloatNear(float a, float b, float eps = 1e-4f)
     EXPECT_NEAR(a, b, eps);
 }
 
-inline void ExpectVec3Near(const glm::vec3& a, const glm::vec3& b, float eps = 1e-4f)
+inline void ExpectVec3Near(const Eigen::Vector3f& a, const Eigen::Vector3f& b, float eps = 1e-4f)
 {
-    EXPECT_NEAR(a.x, b.x, eps);
-    EXPECT_NEAR(a.y, b.y, eps);
-    EXPECT_NEAR(a.z, b.z, eps);
+    EXPECT_NEAR(a.x(), b.x(), eps);
+    EXPECT_NEAR(a.y(), b.y(), eps);
+    EXPECT_NEAR(a.z(), b.z(), eps);
 }
 
-inline void ExpectMat4Near(const glm::mat4& a, const glm::mat4& b, float eps = 1e-4f)
+inline void ExpectMat4Near(const Eigen::Matrix4f& a, const Eigen::Matrix4f& b, float eps = 1e-4f)
 {
-    for (int c = 0; c < 4; ++c)
+    for (int r = 0; r < 4; ++r)
     {
-        for (int r = 0; r < 4; ++r)
+        for (int c = 0; c < 4; ++c)
         {
-            EXPECT_NEAR(a[c][r], b[c][r], eps);
+            EXPECT_NEAR(a(r, c), b(r, c), eps);
         }
     }
 }

--- a/Tests/pch.h
+++ b/Tests/pch.h
@@ -4,7 +4,5 @@
 #include <string>
 #include <vector>
 
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
+#include "Core/Util/Math.h"
 #include <gtest/gtest.h>

--- a/Tests/pch.h
+++ b/Tests/pch.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
+#include <Eigen/Core>
+#include <Eigen/Geometry>
 
 #include <gtest/gtest.h>

--- a/Vendor/CMakeLists.txt
+++ b/Vendor/CMakeLists.txt
@@ -129,7 +129,6 @@ endif()
 # -----------------------------------------------------------------------------
 # Header-only dependencies
 # -----------------------------------------------------------------------------
-glab_add_header_only_vendor(glm glm)
 glab_add_header_only_vendor(eigen eigen)
 glab_add_header_only_vendor(nlohmann_json nlohmann)
 glab_add_header_only_vendor(magic_enum magic_enum)

--- a/Vendor/CMakeLists.txt
+++ b/Vendor/CMakeLists.txt
@@ -130,6 +130,7 @@ endif()
 # Header-only dependencies
 # -----------------------------------------------------------------------------
 glab_add_header_only_vendor(glm glm)
+glab_add_header_only_vendor(eigen eigen)
 glab_add_header_only_vendor(nlohmann_json nlohmann)
 glab_add_header_only_vendor(magic_enum magic_enum)
 glab_add_header_only_vendor(spdlog spdlog/include)


### PR DESCRIPTION
## Summary
- Complete the active `glm -> Eigen` migration across `Src/` and `Tests/`
- Standardize mainline math usage on the `Math::*` alias layer
- Make render projection conventions explicit with `PerspectiveRH_ZO` and `PerspectiveRH_NO`
- Switch the camera render path to `RH_ZO` for Vulkan/Metal
- Remove the unused `Vendor/glm` submodule and scrub active-project `glm` references

## Why
- Avoid leaving the codebase in a mixed `Eigen` / alias / legacy-`glm` transitional state
- Make backend-sensitive clip-space behavior explicit instead of relying on historical defaults
- Keep Eigen as the implementation library while enforcing project-local math naming at call sites
- Remove unused dependency and documentation overhead after the migration is complete

## Affected areas
- `Src/Core/Util/Math.h`
- `Src/Scene/*`
- `Src/Render/Shader/*`
- `Src/Demos/*`
- `Tests/*`
- `.gitmodules`
- `README.md`
- `Docs/Modules/SerializationSystem/*`
- `Docs/EN/NamingConventions.md`
- `Docs/ZH_CN/README.ZH_CN.md`

## Documentation
- [ ] No documentation needed
- [x] Documentation updated

## Testing
- Local project build passes after the migration

## Notes
- `Archive/` history was not migrated as part of this change
- Active project code no longer depends on `glm`
