### PR TITLE
Restore ImGui overlay rendering and demo switching

### DIFF
--- a/CMake/Src/Core.cmake
+++ b/CMake/Src/Core.cmake
@@ -65,6 +65,10 @@ if(GLAB_BACKEND_METAL)
 endif()
 
 if(GLAB_BACKEND_VULKAN)
+    target_include_directories(RTRLabCore PUBLIC
+        ${CMAKE_SOURCE_DIR}/Vendor/volk
+    )
+
     target_link_libraries(RTRLabCore PUBLIC
         volk
         vma

--- a/CMake/Src/Sources.cmake
+++ b/CMake/Src/Sources.cmake
@@ -308,11 +308,30 @@ set(GLAB_GUI_SOURCES
 
 set(GLAB_GUI_HEADERS
     GUI/ImGuiLayer.h
-    GUI/Backends/Metal/MetalImGuiBridge.h
     GUI/Panels/ConsolePanel.h
     GUI/Panels/DebugPanel.h
     GUI/Panels/DemoSelectorPanel.h
 )
+
+if(GLAB_BACKEND_METAL)
+    list(APPEND GLAB_GUI_SOURCES
+        GUI/Backends/Metal/MetalImGuiBridge.mm
+    )
+
+    list(APPEND GLAB_GUI_HEADERS
+        GUI/Backends/Metal/MetalImGuiBridge.h
+    )
+endif()
+
+if(GLAB_BACKEND_VULKAN)
+    list(APPEND GLAB_GUI_SOURCES
+        GUI/Backends/Vulkan/VulkanImGuiBridge.cpp
+    )
+
+    list(APPEND GLAB_GUI_HEADERS
+        GUI/Backends/Vulkan/VulkanImGuiBridge.h
+    )
+endif()
 
 set(GLAB_PLATFORM_SOURCES)
 if(WIN32)
@@ -352,6 +371,7 @@ endif()
 if(GLAB_BACKEND_METAL)
     list(APPEND GLAB_CORE_SKIP_UNITY_SOURCES
         ${GLAB_RENDER_BACKEND_METAL_SOURCES}
+        GUI/Backends/Metal/MetalImGuiBridge.mm
     )
 endif()
 

--- a/Src/Core/App/Application.cpp
+++ b/Src/Core/App/Application.cpp
@@ -26,6 +26,7 @@ Application::Application(const ApplicationSpecification& spec)
     LOG_INFO_CAT(LogCategory::k_Core, "Starting application: {}", spec.m_Name);
 
     RTRLAB_ASSERT_MSG(!s_Instance, "Application already exists.");
+    s_Instance = this;
 
     WindowProps props;
     props.m_Title = spec.m_Name;
@@ -53,11 +54,9 @@ Application::Application(const ApplicationSpecification& spec)
     Time::Reset();
     InitializeRHI();
 
-    s_Instance = this;
-
-    // auto imguiLayer = CreateScope<ImGuiLayer>();
-    // m_ImGuiLayer = imguiLayer.get();
-    // PushOverlay(std::move(imguiLayer));
+    auto imguiLayer = CreateScope<ImGuiLayer>();
+    m_ImGuiLayer = imguiLayer.get();
+    PushOverlay(std::move(imguiLayer));
 
     LOG_INFO_CAT(LogCategory::k_Core, "Application initialized");
 }
@@ -67,7 +66,7 @@ Application::~Application()
     LOG_INFO_CAT(LogCategory::k_Core, "Application shutting down");
 
     m_LayerStack.Clear();
-    // m_ImGuiLayer = nullptr;
+    m_ImGuiLayer = nullptr;
     m_Swapchain.reset();
     m_Device.reset();
     m_Window.reset();
@@ -92,10 +91,10 @@ void Application::RenderFrame()
 
     // Phase 3: ImGui pass - Begin/End bracket all OnImGuiRender() calls
     // so that ImGui's NewFrame/Render are issued exactly once per frame.
-    // m_ImGuiLayer->Begin();
-    // for (auto& layer : m_LayerStack)
-    //     layer->OnImGuiRender();
-    // m_ImGuiLayer->End();
+    m_ImGuiLayer->Begin();
+    for (auto& layer : m_LayerStack)
+        layer->OnImGuiRender();
+    m_ImGuiLayer->End();
 
     EndFrame();
     PresentFrame();

--- a/Src/Demos/01_HelloWindow/HelloWindow.cpp
+++ b/Src/Demos/01_HelloWindow/HelloWindow.cpp
@@ -2,6 +2,8 @@
 
 #include <imgui.h>
 
+#include "Core/App/Application.h"
+#include "Core/Diagnostics/Assert/Assert.h"
 #include "Core/Diagnostics/Logging/LogCategories.h"
 #include "Core/Diagnostics/Logging/LogMacros.h"
 
@@ -18,9 +20,40 @@ void HelloWindow::OnDetach()
     LOG_INFO_CAT(LogCategory::k_Demo, "HelloWindow demo detached");
 }
 
-void HelloWindow::OnRender() {}
+void HelloWindow::OnRender()
+{
+    Application& app = Application::Get();
+    CommandList* commandList = app.GetCurrentCommandList();
+    Texture* swapchainImage = app.GetCurrentSwapchainImage();
+    TextureView* swapchainImageView = app.GetCurrentSwapchainImageView();
+    RTRLAB_ASSERT_MSG(commandList != nullptr, "HelloWindow requires an active command list during OnRender.");
+    RTRLAB_ASSERT_MSG(swapchainImage != nullptr && swapchainImageView != nullptr,
+                      "HelloWindow requires the application to expose the active swapchain backbuffer.");
 
-void HelloWindow::OnImGuiRender() {}
+    ResourceStateTracker& resourceStateTracker = app.GetResourceStateTracker();
+    resourceStateTracker.Transition(swapchainImage, TextureState::RenderTarget);
+    resourceStateTracker.FlushBarriers(commandList);
+
+    ColorAttachmentInfo colorAttachment;
+    colorAttachment.m_View = swapchainImageView;
+    colorAttachment.m_LoadOp = LoadOp::Clear;
+    colorAttachment.m_StoreOp = StoreOp::Store;
+    colorAttachment.m_ClearValue = {m_ClearColor.x(), m_ClearColor.y(), m_ClearColor.z(), 1.0f};
+
+    RenderingInfo renderingInfo;
+    renderingInfo.m_ColorAttachments = {colorAttachment};
+    renderingInfo.m_RenderArea = {0, 0, m_ViewportWidth, m_ViewportHeight};
+
+    commandList->BeginRendering(renderingInfo);
+    commandList->EndRendering();
+}
+
+void HelloWindow::OnImGuiRender()
+{
+    ImGui::Begin("Hello Window");
+    ImGui::ColorEdit3("Clear Color", m_ClearColor.data());
+    ImGui::End();
+}
 
 void HelloWindow::OnResize(uint32_t width, uint32_t height)
 {

--- a/Src/Demos/LabLayer.cpp
+++ b/Src/Demos/LabLayer.cpp
@@ -45,6 +45,8 @@ void LabLayer::OnDetach()
 
 void LabLayer::OnUpdate(double dt)
 {
+    ApplyPendingDemoSwitch();
+
     if (m_ActiveDemo)
         m_ActiveDemo->OnUpdate(dt);
 }
@@ -57,26 +59,17 @@ void LabLayer::OnRender()
 
 void LabLayer::OnImGuiRender()
 {
-    // When DemoSelectorPanel returns true, the user picked a different demo.
-    // SetActiveDemo detaches the old demo; we then attach the new one.
-    // const auto &names = DemoRegistry::GetNames();
-    // if (m_DemoSelectorPanel.OnImGuiRender(names, m_SelectedDemoIndex))
-    // {
-    //     const auto &name = names[m_SelectedDemoIndex];
-    //     auto demo = DemoRegistry::Create(name);
-    //     if (!demo)
-    //     {
-    //         LOG_ERROR_CAT(LogCategory::k_Demo, "Failed to create demo: {}", name);
-    //         return;
-    //     }
+    // Queue the switch so the old demo survives until this frame's command buffer
+    // has finished recording and submission.
+    const auto& names = DemoRegistry::GetNames();
+    if (m_DemoSelectorPanel.OnImGuiRender(names, m_SelectedDemoIndex))
+    {
+        const auto& name = names[m_SelectedDemoIndex];
+        QueueDemoSwitch(m_SelectedDemoIndex, name);
+    }
 
-    //     SetActiveDemo(std::move(demo), name);
-    //     if (m_ActiveDemo)
-    //         m_ActiveDemo->OnAttach();
-    // }
-
-    // m_DebugPanel.OnImGuiRender();
-    // m_ConsolePanel.OnImGuiRender();
+    m_DebugPanel.OnImGuiRender();
+    m_ConsolePanel.OnImGuiRender();
 
     if (m_ActiveDemo)
         m_ActiveDemo->OnImGuiRender();
@@ -119,6 +112,36 @@ void LabLayer::RegisterBuiltInDemos()
                            });
 
     m_DemosRegistered = true;
+}
+
+void LabLayer::QueueDemoSwitch(int demoIndex, const std::string& name)
+{
+    m_PendingDemoIndex = demoIndex;
+    m_PendingDemoName = name;
+    m_HasPendingDemoSwitch = true;
+}
+
+void LabLayer::ApplyPendingDemoSwitch()
+{
+    if (!m_HasPendingDemoSwitch)
+        return;
+
+    const int demoIndex = m_PendingDemoIndex;
+    const std::string name = m_PendingDemoName;
+    m_HasPendingDemoSwitch = false;
+    m_PendingDemoName.clear();
+
+    auto demo = DemoRegistry::Create(name);
+    if (!demo)
+    {
+        LOG_ERROR_CAT(LogCategory::k_Demo, "Failed to create demo: {}", name);
+        return;
+    }
+
+    m_SelectedDemoIndex = demoIndex;
+    SetActiveDemo(std::move(demo), name);
+    if (m_ActiveDemo)
+        m_ActiveDemo->OnAttach();
 }
 
 void LabLayer::SetActiveDemo(Scope<DemoBase> demo, const std::string& name)

--- a/Src/Demos/LabLayer.cpp
+++ b/Src/Demos/LabLayer.cpp
@@ -26,11 +26,11 @@ void LabLayer::OnAttach()
     if (!m_ActiveDemo)
     {
         // Default demo
-        m_SelectedDemoIndex = 3;
-        LOG_INFO_CAT(LogCategory::k_Demo, "Loading default demo: 04 - Hello Offscreen");
-        auto defaultDemo = DemoRegistry::Create("04 - Hello Offscreen");
-        RTRLAB_ASSERT_MSG(defaultDemo, "Failed to create default demo: 04 - Hello Offscreen");
-        SetActiveDemo(std::move(defaultDemo), "04 - Hello Offscreen");
+        m_SelectedDemoIndex = 0;
+        LOG_INFO_CAT(LogCategory::k_Demo, "Loading default demo: 01 - Hello Window");
+        auto defaultDemo = DemoRegistry::Create("01 - Hello Window");
+        RTRLAB_ASSERT_MSG(defaultDemo, "Failed to create default demo: 01 - Hello Window");
+        SetActiveDemo(std::move(defaultDemo), "01 - Hello Window");
     }
 
     if (m_ActiveDemo)

--- a/Src/Demos/LabLayer.h
+++ b/Src/Demos/LabLayer.h
@@ -38,13 +38,18 @@ public:
 
 private:
     void RegisterBuiltInDemos();
+    void QueueDemoSwitch(int demoIndex, const std::string& name);
+    void ApplyPendingDemoSwitch();
     void SetActiveDemo(Scope<DemoBase> demo, const std::string& name);
 
 private:
     bool m_DemosRegistered = false;
+    bool m_HasPendingDemoSwitch = false;
 
     int m_SelectedDemoIndex = 0;
+    int m_PendingDemoIndex = 0;
     std::string m_ActiveDemoName;
+    std::string m_PendingDemoName;
     Scope<DemoBase> m_ActiveDemo;
 
     ConsolePanel m_ConsolePanel;

--- a/Src/GUI/Backends/Metal/MetalImGuiBridge.h
+++ b/Src/GUI/Backends/Metal/MetalImGuiBridge.h
@@ -7,10 +7,13 @@
 /// surface with the same lifecycle shape used by the higher-level ImGui layer:
 /// Init -> NewFrame -> RenderDrawData -> Shutdown.
 
+class Device;
+class Texture;
+
 namespace MetalImGuiBridge
 {
-void Init(void* mtlDevice);
+void Init(Device& device);
 void Shutdown();
-void NewFrame(void* drawableTexture);
-void RenderDrawData(void* drawData, void* commandBuffer, void* drawableTexture);
+void NewFrame(Texture* drawableTexture);
+void RenderDrawData(void* drawData, Device& device, Texture* drawableTexture);
 } // namespace MetalImGuiBridge

--- a/Src/GUI/Backends/Metal/MetalImGuiBridge.mm
+++ b/Src/GUI/Backends/Metal/MetalImGuiBridge.mm
@@ -3,6 +3,10 @@
 #include <imgui.h>
 #include <imgui_impl_metal.h>
 
+#include "Core/Diagnostics/Assert/Assert.h"
+#include "Render/RHI/Backends/Metal/Device/MetalDevice.h"
+#include "Render/RHI/Backends/Metal/Resources/MetalTexture.h"
+
 #import <Metal/Metal.h>
 
 namespace
@@ -12,19 +16,29 @@ MTLRenderPassDescriptor* CreateImGuiRenderPassDescriptor(id<MTLTexture> drawable
     if (!drawableTexture)
         return nil;
 
-    MTLRenderPassDescriptor* renderPassDescriptor = [MTLRenderPassDescriptor new];
+    MTLRenderPassDescriptor* renderPassDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
     renderPassDescriptor.colorAttachments[0].texture = drawableTexture;
     renderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionLoad;
     renderPassDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
     return renderPassDescriptor;
 }
+
+MetalDevice& GetMetalDevice(Device& device)
+{
+    auto* metalDevice = dynamic_cast<MetalDevice*>(&device);
+    RTRLAB_ASSERT_MSG(metalDevice != nullptr, "Metal ImGui bridge requires a MetalDevice.");
+    return *metalDevice;
+}
 } // namespace
 
 namespace MetalImGuiBridge
 {
-void Init(void* mtlDevice)
+void Init(Device& device)
 {
-    ImGui_ImplMetal_Init((__bridge id<MTLDevice>)mtlDevice);
+    MetalDevice& metalDevice = GetMetalDevice(device);
+    RTRLAB_ASSERT_MSG(metalDevice.GetData() != nullptr && metalDevice.GetData()->m_Device != nil,
+                      "Metal ImGui bridge requires an initialized Metal device.");
+    ImGui_ImplMetal_Init(metalDevice.GetData()->m_Device);
 }
 
 void Shutdown()
@@ -32,24 +46,28 @@ void Shutdown()
     ImGui_ImplMetal_Shutdown();
 }
 
-void NewFrame(void* drawableTexture)
+void NewFrame(Texture* drawableTexture)
 {
     MTLRenderPassDescriptor* renderPassDescriptor =
-        CreateImGuiRenderPassDescriptor((__bridge id<MTLTexture>)drawableTexture);
+        CreateImGuiRenderPassDescriptor(GetMetalTextureFromTexture(drawableTexture));
     if (!renderPassDescriptor)
         return;
 
     ImGui_ImplMetal_NewFrame(renderPassDescriptor);
 }
 
-void RenderDrawData(void* drawData, void* commandBuffer, void* drawableTexture)
+void RenderDrawData(void* drawData, Device& device, Texture* drawableTexture)
 {
-    if (!drawData || !commandBuffer || !drawableTexture)
+    if (!drawData || !drawableTexture)
         return;
 
-    id<MTLCommandBuffer> metalCommandBuffer = (__bridge id<MTLCommandBuffer>)commandBuffer;
+    MetalDevice& metalDevice = GetMetalDevice(device);
+    RTRLAB_ASSERT_MSG(metalDevice.GetData() != nullptr && metalDevice.GetData()->m_CurrentCommandBuffer != nil,
+                      "Metal ImGui bridge requires an active Metal command buffer.");
+
+    id<MTLCommandBuffer> metalCommandBuffer = metalDevice.GetData()->m_CurrentCommandBuffer;
     MTLRenderPassDescriptor* renderPassDescriptor =
-        CreateImGuiRenderPassDescriptor((__bridge id<MTLTexture>)drawableTexture);
+        CreateImGuiRenderPassDescriptor(GetMetalTextureFromTexture(drawableTexture));
     if (!renderPassDescriptor)
         return;
 

--- a/Src/GUI/Backends/Vulkan/VulkanImGuiBridge.cpp
+++ b/Src/GUI/Backends/Vulkan/VulkanImGuiBridge.cpp
@@ -1,0 +1,105 @@
+#include "GUI/Backends/Vulkan/VulkanImGuiBridge.h"
+
+#include <algorithm>
+
+#include <imgui.h>
+#include <imgui_impl_vulkan.h>
+
+#include "Core/Diagnostics/Assert/Assert.h"
+#include "Render/RHI/Backends/Vulkan/Command/VulkanCommandList.h"
+#include "Render/RHI/Backends/Vulkan/Common/VulkanConversions.h"
+#include "Render/RHI/Backends/Vulkan/Device/VulkanDevice.h"
+#include "Render/RHI/RHICommandList.h"
+#include "Render/RHI/RHIResources.h"
+
+using namespace VulkanRHI;
+
+namespace
+{
+VulkanDevice& GetVulkanDevice(Device& device)
+{
+    auto* vulkanDevice = dynamic_cast<VulkanDevice*>(&device);
+    RTRLAB_ASSERT_MSG(vulkanDevice != nullptr, "Vulkan ImGui bridge requires a VulkanDevice.");
+    return *vulkanDevice;
+}
+
+VulkanCommandList& GetVulkanCommandList(CommandList* commandList)
+{
+    auto* vulkanCommandList = dynamic_cast<VulkanCommandList*>(commandList);
+    RTRLAB_ASSERT_MSG(vulkanCommandList != nullptr, "Vulkan ImGui bridge requires a VulkanCommandList.");
+    return *vulkanCommandList;
+}
+
+void CheckImGuiVkResult(VkResult result)
+{
+    CheckVk(result, "Dear ImGui Vulkan backend");
+}
+} // namespace
+
+namespace VulkanImGuiBridge
+{
+void Init(Device& device, Swapchain& swapchain)
+{
+    VulkanDevice& vulkanDevice = GetVulkanDevice(device);
+    const VkFormat colorFormat = ToVkFormat(swapchain.GetFormat());
+
+    ImGui_ImplVulkan_InitInfo initInfo{};
+    initInfo.ApiVersion = VK_API_VERSION_1_3;
+    initInfo.Instance = vulkanDevice.GetVkInstance();
+    initInfo.PhysicalDevice = vulkanDevice.GetVkPhysicalDevice();
+    initInfo.Device = vulkanDevice.GetVkDevice();
+    initInfo.QueueFamily = vulkanDevice.GetGraphicsQueueFamily();
+    initInfo.Queue = vulkanDevice.GetGraphicsQueue();
+    initInfo.DescriptorPoolSize = 1024;
+    initInfo.MinImageCount = std::max(swapchain.GetImageCount(), 2u);
+    initInfo.ImageCount = std::max(swapchain.GetImageCount(), initInfo.MinImageCount);
+    initInfo.UseDynamicRendering = true;
+    initInfo.PipelineInfoMain.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
+    initInfo.PipelineInfoMain.PipelineRenderingCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO_KHR;
+    initInfo.PipelineInfoMain.PipelineRenderingCreateInfo.colorAttachmentCount = 1;
+    initInfo.PipelineInfoMain.PipelineRenderingCreateInfo.pColorAttachmentFormats = &colorFormat;
+    initInfo.CheckVkResultFn = CheckImGuiVkResult;
+
+    RTRLAB_ASSERT_MSG(ImGui_ImplVulkan_Init(&initInfo), "Failed to initialize Dear ImGui Vulkan backend.");
+}
+
+void Shutdown()
+{
+    ImGui_ImplVulkan_Shutdown();
+}
+
+void NewFrame()
+{
+    ImGui_ImplVulkan_NewFrame();
+}
+
+void RenderDrawData(void* drawData, CommandList* commandList, TextureView* targetView)
+{
+    if (!drawData)
+        return;
+
+    RTRLAB_ASSERT_MSG(targetView != nullptr, "Vulkan ImGui rendering requires a target texture view.");
+    VulkanCommandList& vulkanCommandList = GetVulkanCommandList(commandList);
+
+    Texture* targetTexture = targetView->GetTexture();
+    RTRLAB_ASSERT_MSG(targetTexture != nullptr, "Vulkan ImGui target view must reference a texture.");
+
+    RenderingInfo renderingInfo;
+    renderingInfo.m_ColorAttachments.push_back(ColorAttachmentInfo{
+        targetView,
+        LoadOp::Load,
+        StoreOp::Store,
+        {},
+    });
+    renderingInfo.m_RenderArea = Rect2D{
+        0,
+        0,
+        targetTexture->GetDesc().m_Extent.m_Width,
+        targetTexture->GetDesc().m_Extent.m_Height,
+    };
+
+    vulkanCommandList.BeginRendering(renderingInfo);
+    ImGui_ImplVulkan_RenderDrawData(static_cast<ImDrawData*>(drawData), vulkanCommandList.GetVkCommandBuffer());
+    vulkanCommandList.EndRendering();
+}
+} // namespace VulkanImGuiBridge

--- a/Src/GUI/Backends/Vulkan/VulkanImGuiBridge.h
+++ b/Src/GUI/Backends/Vulkan/VulkanImGuiBridge.h
@@ -1,0 +1,17 @@
+#pragma once
+
+/// @file VulkanImGuiBridge.h
+/// @brief C++ bridge for Dear ImGui's Vulkan backend.
+
+class CommandList;
+class Device;
+class Swapchain;
+class TextureView;
+
+namespace VulkanImGuiBridge
+{
+void Init(Device& device, Swapchain& swapchain);
+void Shutdown();
+void NewFrame();
+void RenderDrawData(void* drawData, CommandList* commandList, TextureView* targetView);
+} // namespace VulkanImGuiBridge

--- a/Src/GUI/ImGuiLayer.cpp
+++ b/Src/GUI/ImGuiLayer.cpp
@@ -3,9 +3,9 @@
 #include <imgui.h>
 #include <imgui_impl_glfw.h>
 #if defined(GLAB_BACKEND_METAL)
-// #include "GUI/Backends/Metal/MetalImGuiBridge.h"
+#include "GUI/Backends/Metal/MetalImGuiBridge.h"
 #elif defined(GLAB_BACKEND_VULKAN)
-// Vulkan renderer backend integration will be wired in once the RHI path lands.
+#include "GUI/Backends/Vulkan/VulkanImGuiBridge.h"
 #else
 #error Unsupported graphics backend
 #endif
@@ -40,19 +40,19 @@ void ImGuiLayer::OnAttach()
     GLFWwindow* window = Application::Get().GetWindow().GetNativeHandle();
 #if defined(GLAB_BACKEND_METAL)
     ImGui_ImplGlfw_InitForOther(window, true);
-    // auto *metalDevice = static_cast<MetalGraphicsDevice *>(GetDevice().get());
-    // MetalImGuiBridge::Init(metalDevice->GetMTLDevice());
+    MetalImGuiBridge::Init(Application::Get().GetDevice());
 #elif defined(GLAB_BACKEND_VULKAN)
     ImGui_ImplGlfw_InitForOther(window, true);
+    VulkanImGuiBridge::Init(Application::Get().GetDevice(), Application::Get().GetSwapchain());
 #endif
 }
 
 void ImGuiLayer::OnDetach()
 {
 #if defined(GLAB_BACKEND_METAL)
-    // MetalImGuiBridge::Shutdown();
+    MetalImGuiBridge::Shutdown();
 #elif defined(GLAB_BACKEND_VULKAN)
-    // Vulkan renderer backend shutdown will be added with the Vulkan renderer path.
+    VulkanImGuiBridge::Shutdown();
 #endif
     ImGui_ImplGlfw_Shutdown();
     ImGui::DestroyContext();
@@ -61,10 +61,9 @@ void ImGuiLayer::OnDetach()
 void ImGuiLayer::Begin()
 {
 #if defined(GLAB_BACKEND_METAL)
-    // auto *metalDevice = static_cast<MetalGraphicsDevice *>(GetDevice().get());
-    // metalDevice->GetMetalRenderCommand()->BeginImGuiFrame();
+    MetalImGuiBridge::NewFrame(Application::Get().GetCurrentSwapchainImage());
 #elif defined(GLAB_BACKEND_VULKAN)
-    // Vulkan renderer backend frame setup will be added with the Vulkan renderer path.
+    VulkanImGuiBridge::NewFrame();
 #endif
     ImGui_ImplGlfw_NewFrame();
     ImGui::NewFrame();
@@ -79,10 +78,19 @@ void ImGuiLayer::Begin()
 void ImGuiLayer::End()
 {
     ImGui::Render();
+
+    auto& app = Application::Get();
+    Texture* swapchainImage = app.GetCurrentSwapchainImage();
+    CommandList* commandList = app.GetCurrentCommandList();
+    RTRLAB_ASSERT_MSG(swapchainImage != nullptr, "ImGui rendering requires an acquired swapchain image.");
+    RTRLAB_ASSERT_MSG(commandList != nullptr, "ImGui rendering requires an active command list.");
+
+    app.GetResourceStateTracker().Transition(swapchainImage, TextureState::RenderTarget);
+    app.GetResourceStateTracker().FlushBarriers(commandList);
+
 #if defined(GLAB_BACKEND_METAL)
-    // auto *metalDevice = static_cast<MetalGraphicsDevice *>(GetDevice().get());
-    // metalDevice->GetMetalRenderCommand()->RenderImGui(ImGui::GetDrawData());
+    MetalImGuiBridge::RenderDrawData(ImGui::GetDrawData(), app.GetDevice(), swapchainImage);
 #elif defined(GLAB_BACKEND_VULKAN)
-    // Vulkan renderer backend draw submission will be added with the Vulkan renderer path.
+    VulkanImGuiBridge::RenderDrawData(ImGui::GetDrawData(), commandList, app.GetCurrentSwapchainImageView());
 #endif
 }

--- a/Src/Render/Shader/SlangReflectionJson.cpp
+++ b/Src/Render/Shader/SlangReflectionJson.cpp
@@ -103,8 +103,7 @@ std::optional<SlangReflectionBinding> SelectPreferredBinding(const Json& json, s
 
     if (preferredBinding.has_value())
     {
-        if (preferredBinding->m_Kind == "descriptorTableSlot" && !preferredBinding->m_HasExplicitSpace &&
-            inferredRegisterSpace.has_value())
+        if (!preferredBinding->m_HasExplicitSpace && inferredRegisterSpace.has_value())
         {
             preferredBinding->m_Space = *inferredRegisterSpace;
         }

--- a/Vendor/CMakeLists.txt
+++ b/Vendor/CMakeLists.txt
@@ -168,6 +168,12 @@ if(GLAB_BACKEND_METAL)
     )
 endif()
 
+if(GLAB_BACKEND_VULKAN)
+    list(APPEND GLAB_IMGUI_SOURCES
+        imgui/backends/imgui_impl_vulkan.cpp
+    )
+endif()
+
 if(GLAB_BUILD_IMGUI_DEMO)
     list(APPEND GLAB_IMGUI_SOURCES
         imgui/imgui_demo.cpp
@@ -186,5 +192,19 @@ target_include_directories(imgui PUBLIC
 target_link_libraries(imgui PRIVATE
     glfw
 )
+
+if(GLAB_BACKEND_VULKAN)
+    target_include_directories(imgui PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/volk
+    )
+
+    target_link_libraries(imgui PRIVATE
+        volk
+    )
+
+    target_compile_definitions(imgui PUBLIC
+        IMGUI_IMPL_VULKAN_USE_VOLK
+    )
+endif()
 
 glab_enable_parallel_compilation(imgui)


### PR DESCRIPTION
## Summary
- Reconnected `ImGuiLayer` into the application lifecycle and per-frame render path.
- Added Vulkan and Metal ImGui backend bridge wiring.
- Restored demo selector, debug, and console ImGui panels.
- Deferred demo switching to the next frame to avoid destroying resources during active command recording.
- Fixed `HelloWindow` so it clears the swapchain and exposes its clear color UI.
- Fixed Slang reflection parsing so Vulkan `constantBuffer` bindings inherit inferred register spaces.

## Why
- ImGui was present in the project but effectively not attached or rendered.
- Demo switching through ImGui exposed frame-lifetime and reflection issues that caused stale output or crashes.

## Affected areas
- Application
- GUI
- Vulkan and Metal backend bridge code
- Hello Window demo rendering
- Slang reflection JSON binding parsing
- CMake source and include configuration

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Built and ran locally.

## Notes
- Vulkan ImGui uses Dear ImGui’s Vulkan backend with dynamic rendering.
- Demo switches are queued from ImGui and applied at the start of the next update frame.
