### PR TITLE
Make RHI bring-up paths fail honestly

### DIFF
--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
@@ -228,6 +228,17 @@ void ValidatePipelineLayoutDesc(const PipelineLayoutDesc& desc)
     }
 }
 
+void ValidateResourceSetDesc(PipelineLayout* layout, uint32_t setIndex)
+{
+    RTRLAB_ASSERT_MSG(layout != nullptr, "ResourceSet creation requires a valid PipelineLayout.");
+    ValidatePipelineLayoutDesc(layout->GetDesc());
+
+    const std::vector<const BindingInfo*> setBindings = CollectBindingInfosForSet(layout->GetDesc(), setIndex);
+    RTRLAB_ASSERTF(!setBindings.empty(),
+                   "ResourceSet creation requires set {} to exist in the provided PipelineLayout.",
+                   setIndex);
+}
+
 PipelineLayoutDesc BuildPipelineLayoutDescFromReflection(const ShaderReflectionData& reflection)
 {
     std::string validationError;
@@ -263,11 +274,7 @@ PipelineLayoutDesc ShellShaderProgram::DerivePipelineLayoutDesc() const
 
 ShellResourceSet::ShellResourceSet(PipelineLayout* layout, uint32_t setIndex) : m_Layout(layout), m_SetIndex(setIndex)
 {
-    RTRLAB_ASSERT_MSG(m_Layout != nullptr, "ResourceSet creation requires a valid PipelineLayout.");
-
-    const std::vector<const BindingInfo*> setBindings = CollectBindingInfosForSet(m_Layout->GetDesc(), m_SetIndex);
-    RTRLAB_ASSERTF(
-        !setBindings.empty(), "ResourceSet set {} does not exist in the provided PipelineLayout.", m_SetIndex);
+    ValidateResourceSetDesc(m_Layout, m_SetIndex);
 
     if (const BindingInfo* constantBindingInfo =
             FindFirstBindingInfoForSet(m_Layout->GetDesc(), m_SetIndex, ResourceKind::UniformBuffer);
@@ -662,6 +669,7 @@ Scope<PipelineLayout> ShellDeviceBase::CreatePipelineLayout(const PipelineLayout
 
 Scope<ResourceSet> ShellDeviceBase::CreateResourceSet(PipelineLayout* layout, uint32_t setIndex)
 {
+    ValidateResourceSetDesc(layout, setIndex);
     return CreateScope<ShellResourceSet>(layout, setIndex);
 }
 

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
@@ -332,7 +332,6 @@ void ShellCommandListBase::ResetState()
     m_RenderingInfo = {};
     m_IsRendering = false;
     m_GraphicsPipeline = nullptr;
-    m_ComputePipeline = nullptr;
     m_ResourceSets.clear();
     m_MeshBinding = {};
     m_VertexOffsets.clear();
@@ -356,7 +355,10 @@ void ShellCommandListBase::BindGraphicsPipeline(GraphicsPipeline* pipeline)
 
 void ShellCommandListBase::BindComputePipeline(ComputePipeline* pipeline)
 {
-    m_ComputePipeline = pipeline;
+    (void)pipeline;
+    RTRLAB_ASSERT_MSG(false,
+                      "Compute pipelines are not implemented for the shell backend. "
+                      "Use a backend with a real compute path before binding compute work.");
 }
 
 void ShellCommandListBase::BindResourceSet(uint32_t setIndex, ResourceSet* resourceSet)
@@ -453,9 +455,12 @@ void ShellCommandListBase::CopyBufferToTexture(Buffer*, Texture*, std::span<cons
 
 void ShellCommandListBase::Dispatch(uint32_t groupX, uint32_t groupY, uint32_t groupZ)
 {
-    m_LastDispatchX = groupX;
-    m_LastDispatchY = groupY;
-    m_LastDispatchZ = groupZ;
+    (void)groupX;
+    (void)groupY;
+    (void)groupZ;
+    RTRLAB_ASSERT_MSG(false,
+                      "Dispatch is not implemented for the shell backend. "
+                      "Use a backend with a real compute path before dispatching work.");
 }
 
 void ShellCommandListBase::TextureBarrier(Texture*, TextureState, TextureState, ShaderStage, ShaderStage) {}
@@ -586,7 +591,11 @@ Scope<GraphicsPipeline> ShellDeviceBase::CreateGraphicsPipeline(const GraphicsPi
 
 Scope<ComputePipeline> ShellDeviceBase::CreateComputePipeline(const ComputePipelineDesc& desc)
 {
-    return CreateScope<ShellComputePipeline>(desc);
+    (void)desc;
+    RTRLAB_ASSERT_MSG(false,
+                      "Compute pipelines are not implemented for the shell backend. "
+                      "This backend no longer creates shell compute-pipeline placeholders.");
+    return nullptr;
 }
 
 void ShellDeviceBase::WriteBuffer(Buffer*, uint64_t, const void*, uint64_t)

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
@@ -84,6 +84,18 @@ void CollectPipelineBindings(const ReflectedField& field,
     for (const ReflectedField& child : field.m_Children)
         CollectPipelineBindings(child, childSetIndex, childHasSetIndex, bindings);
 }
+
+void ValidateTextureBinding(const TextureBinding& textureBinding)
+{
+    RTRLAB_ASSERT_MSG(textureBinding.m_Texture != nullptr || textureBinding.m_View != nullptr,
+                      "Texture bindings require a Texture or TextureView.");
+
+    if (textureBinding.m_Texture != nullptr && textureBinding.m_View != nullptr)
+    {
+        RTRLAB_ASSERT_MSG(textureBinding.m_View->GetTexture() == textureBinding.m_Texture,
+                          "TextureBinding Texture and TextureView must reference the same texture.");
+    }
+}
 } // namespace
 
 namespace RHIInternal
@@ -253,6 +265,8 @@ void ShellResourceSet::SetTextureArray(uint32_t binding, std::span<const Texture
                    m_SetIndex,
                    binding);
     (void)ValidateBindingArrayCount(*bindingInfo, textureBindings.size(), "texture");
+    for (const TextureBinding& textureBinding : textureBindings)
+        ValidateTextureBinding(textureBinding);
     m_TextureBindings[binding] = std::vector<TextureBinding>(textureBindings.begin(), textureBindings.end());
     ++m_Version;
 }

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
@@ -96,6 +96,24 @@ void ValidateTextureBinding(const TextureBinding& textureBinding)
                           "TextureBinding Texture and TextureView must reference the same texture.");
     }
 }
+
+void ValidateBufferBinding(const BufferBinding& bufferBinding)
+{
+    RTRLAB_ASSERT_MSG(bufferBinding.m_Buffer != nullptr, "Buffer bindings require a Buffer.");
+
+    const BufferDesc& desc = bufferBinding.m_Buffer->GetDesc();
+    RTRLAB_ASSERT_MSG(bufferBinding.m_Offset <= desc.m_Size, "BufferBinding offset exceeds the Buffer size.");
+    if (bufferBinding.m_Size != 0)
+    {
+        RTRLAB_ASSERT_MSG(bufferBinding.m_Size <= desc.m_Size - bufferBinding.m_Offset,
+                          "BufferBinding range exceeds the Buffer size.");
+    }
+}
+
+void ValidateSamplerBinding(const SamplerBinding& samplerBinding)
+{
+    RTRLAB_ASSERT_MSG(samplerBinding.m_Sampler != nullptr, "Sampler bindings require a Sampler.");
+}
 } // namespace
 
 namespace RHIInternal
@@ -250,6 +268,8 @@ void ShellResourceSet::SetBufferArray(uint32_t binding, std::span<const BufferBi
 {
     const BindingInfo& bindingInfo = RequireBindingInfo(binding, ResourceKind::StorageBuffer);
     (void)ValidateBindingArrayCount(bindingInfo, bufferBindings.size(), "buffer");
+    for (const BufferBinding& bufferBinding : bufferBindings)
+        ValidateBufferBinding(bufferBinding);
     m_BufferBindings[binding] = std::vector<BufferBinding>(bufferBindings.begin(), bufferBindings.end());
     ++m_Version;
 }
@@ -275,6 +295,8 @@ void ShellResourceSet::SetSamplerArray(uint32_t binding, std::span<const Sampler
 {
     const BindingInfo& bindingInfo = RequireBindingInfo(binding, ResourceKind::Sampler);
     (void)ValidateBindingArrayCount(bindingInfo, samplerBindings.size(), "sampler");
+    for (const SamplerBinding& samplerBinding : samplerBindings)
+        ValidateSamplerBinding(samplerBinding);
     m_SamplerBindings[binding] = std::vector<SamplerBinding>(samplerBindings.begin(), samplerBindings.end());
     ++m_Version;
 }

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
@@ -463,9 +463,33 @@ void ShellCommandListBase::Dispatch(uint32_t groupX, uint32_t groupY, uint32_t g
                       "Use a backend with a real compute path before dispatching work.");
 }
 
-void ShellCommandListBase::TextureBarrier(Texture*, TextureState, TextureState, ShaderStage, ShaderStage) {}
+void ShellCommandListBase::TextureBarrier(
+    Texture* texture, TextureState oldState, TextureState newState, ShaderStage srcStage, ShaderStage dstStage)
+{
+    (void)srcStage;
+    (void)dstStage;
 
-void ShellCommandListBase::BufferBarrier(Buffer*, BufferState, BufferState, ShaderStage, ShaderStage) {}
+    if (texture == nullptr || oldState == newState)
+        return;
+
+    RTRLAB_ASSERT_MSG(false,
+                      "TextureBarrier is not implemented for the shell backend. "
+                      "Use a backend with real resource-transition support before flushing texture barriers.");
+}
+
+void ShellCommandListBase::BufferBarrier(
+    Buffer* buffer, BufferState oldState, BufferState newState, ShaderStage srcStage, ShaderStage dstStage)
+{
+    (void)srcStage;
+    (void)dstStage;
+
+    if (buffer == nullptr || oldState == newState)
+        return;
+
+    RTRLAB_ASSERT_MSG(false,
+                      "BufferBarrier is not implemented for the shell backend. "
+                      "Use a backend with real resource-transition support before flushing buffer barriers.");
+}
 
 ShellSwapchainBase::ShellSwapchainBase(const SwapchainDesc& desc, const NativeWindowHandle& nativeWindowHandle)
     : m_Desc(SanitizeSwapchainDesc(desc)), m_NativeWindowHandle(nativeWindowHandle)

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
@@ -239,6 +239,21 @@ void ValidateResourceSetDesc(PipelineLayout* layout, uint32_t setIndex)
                    setIndex);
 }
 
+bool ValidateBufferWriteRequest(Buffer* buffer, uint64_t offset, const void* data, uint64_t size)
+{
+    if (size == 0)
+        return false;
+
+    RTRLAB_ASSERT_MSG(buffer != nullptr, "WriteBuffer requires a valid Buffer.");
+    RTRLAB_ASSERT_MSG(data != nullptr, "WriteBuffer requires non-null source data.");
+
+    const BufferDesc& desc = buffer->GetDesc();
+    RTRLAB_ASSERT_MSG(desc.m_MemoryUsage == MemoryUsage::CpuToGpu, "WriteBuffer requires a CpuToGpu Buffer.");
+    RTRLAB_ASSERT_MSG(offset <= desc.m_Size, "WriteBuffer offset exceeds the Buffer size.");
+    RTRLAB_ASSERT_MSG(size <= desc.m_Size - offset, "WriteBuffer range exceeds the Buffer size.");
+    return true;
+}
+
 PipelineLayoutDesc BuildPipelineLayoutDescFromReflection(const ShaderReflectionData& reflection)
 {
     std::string validationError;
@@ -692,8 +707,11 @@ Scope<ComputePipeline> ShellDeviceBase::CreateComputePipeline(const ComputePipel
     return nullptr;
 }
 
-void ShellDeviceBase::WriteBuffer(Buffer*, uint64_t, const void*, uint64_t)
+void ShellDeviceBase::WriteBuffer(Buffer* buffer, uint64_t offset, const void* data, uint64_t size)
 {
+    if (!ValidateBufferWriteRequest(buffer, offset, data, size))
+        return;
+
     RTRLAB_ASSERT_MSG(
         false, "WriteBuffer is not implemented for this backend. Use a backend with an explicit M3 upload path.");
 }

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
@@ -204,6 +204,30 @@ TextureDesc SanitizeTextureDesc(const TextureDesc& desc)
     return sanitized;
 }
 
+void ValidatePipelineLayoutDesc(const PipelineLayoutDesc& desc)
+{
+    for (const BindingInfo& binding : desc.m_Bindings)
+    {
+        RTRLAB_ASSERTF(binding.m_ArrayCount > 0,
+                       "PipelineLayout binding '{}' at set {} binding {} requires ArrayCount >= 1.",
+                       binding.m_Name,
+                       binding.m_SetIndex,
+                       binding.m_Binding);
+        RTRLAB_ASSERTF(binding.m_StageMask != ShaderStage::None,
+                       "PipelineLayout binding '{}' at set {} binding {} requires at least one shader stage.",
+                       binding.m_Name,
+                       binding.m_SetIndex,
+                       binding.m_Binding);
+    }
+
+    for (const PushConstantRangeDesc& pushConstant : desc.m_PushConstants)
+    {
+        RTRLAB_ASSERT_MSG(pushConstant.m_Size > 0, "PipelineLayout push constant ranges require a non-zero size.");
+        RTRLAB_ASSERT_MSG(pushConstant.m_StageMask != ShaderStage::None,
+                          "PipelineLayout push constant ranges require at least one shader stage.");
+    }
+}
+
 PipelineLayoutDesc BuildPipelineLayoutDescFromReflection(const ShaderReflectionData& reflection)
 {
     std::string validationError;
@@ -228,6 +252,7 @@ PipelineLayoutDesc BuildPipelineLayoutDescFromReflection(const ShaderReflectionD
               });
 
     layoutDesc.m_PushConstants = reflection.m_PushConstants;
+    ValidatePipelineLayoutDesc(layoutDesc);
     return layoutDesc;
 }
 
@@ -631,6 +656,7 @@ Scope<ShaderProgram> ShellDeviceBase::CreateShaderProgram(const CompiledShaderPr
 
 Scope<PipelineLayout> ShellDeviceBase::CreatePipelineLayout(const PipelineLayoutDesc& desc)
 {
+    ValidatePipelineLayoutDesc(desc);
     return CreateScope<ShellPipelineLayout>(desc);
 }
 

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.cpp
@@ -2,8 +2,6 @@
 #include "Render/Shader/ShaderReflection.h"
 
 #include <algorithm>
-#include <cstring>
-
 #include "Core/Diagnostics/Assert/Assert.h"
 
 namespace
@@ -345,7 +343,6 @@ void ShellCommandListBase::ResetState()
     m_Viewport[3] = 0.0f;
     m_Viewport[4] = 0.0f;
     m_Viewport[5] = 1.0f;
-    m_PushConstants.clear();
 }
 
 void ShellCommandListBase::BindGraphicsPipeline(GraphicsPipeline* pipeline)
@@ -366,15 +363,18 @@ void ShellCommandListBase::BindResourceSet(uint32_t setIndex, ResourceSet* resou
     m_ResourceSets[setIndex] = resourceSet;
 }
 
-void ShellCommandListBase::PushConstants(ShaderStage, uint32_t offset, uint32_t size, const void* data)
+void ShellCommandListBase::PushConstants(ShaderStage stageMask, uint32_t offset, uint32_t size, const void* data)
 {
-    if (size == 0 || data == nullptr)
+    (void)stageMask;
+    (void)offset;
+    (void)data;
+
+    if (size == 0)
         return;
 
-    if (offset + size > m_PushConstants.size())
-        m_PushConstants.resize(offset + size);
-
-    std::memcpy(m_PushConstants.data() + offset, data, size);
+    RTRLAB_ASSERT_MSG(false,
+                      "PushConstants is not implemented for the shell backend. "
+                      "Use a backend with real push-constant support before recording push constants.");
 }
 
 void ShellCommandListBase::BindMesh(const MeshBinding& meshBinding, const uint64_t* vertexOffsets)

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.h
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.h
@@ -207,7 +207,6 @@ protected:
     IndexType m_IndexType = IndexType::UInt32;
     Rect2D m_Scissor;
     float m_Viewport[6] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f};
-    std::vector<uint8_t> m_PushConstants;
     uint32_t m_LastDrawVertexCount = 0;
     uint32_t m_LastDrawFirstVertex = 0;
     uint32_t m_LastDrawIndexedCount = 0;

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.h
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.h
@@ -119,17 +119,6 @@ private:
     GraphicsPipelineDesc m_Desc;
 };
 
-class ShellComputePipeline final : public ComputePipeline
-{
-public:
-    explicit ShellComputePipeline(const ComputePipelineDesc& desc) : m_Desc(desc) {}
-
-    const ComputePipelineDesc& GetDesc() const override { return m_Desc; }
-
-private:
-    ComputePipelineDesc m_Desc;
-};
-
 class ShellResourceSet final : public ResourceSet
 {
 public:
@@ -210,7 +199,6 @@ protected:
     RenderingInfo m_RenderingInfo;
     bool m_IsRendering = false;
     GraphicsPipeline* m_GraphicsPipeline = nullptr;
-    ComputePipeline* m_ComputePipeline = nullptr;
     std::unordered_map<uint32_t, ResourceSet*> m_ResourceSets;
     MeshBinding m_MeshBinding;
     std::vector<uint64_t> m_VertexOffsets;
@@ -225,9 +213,6 @@ protected:
     uint32_t m_LastDrawIndexedCount = 0;
     uint32_t m_LastDrawFirstIndex = 0;
     int32_t m_LastDrawVertexOffset = 0;
-    uint32_t m_LastDispatchX = 0;
-    uint32_t m_LastDispatchY = 0;
-    uint32_t m_LastDispatchZ = 0;
 };
 
 class ShellSwapchainBase : public Swapchain

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.h
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.h
@@ -17,6 +17,7 @@ SwapchainDesc SanitizeSwapchainDesc(const SwapchainDesc& desc);
 TextureDesc SanitizeTextureDesc(const TextureDesc& desc);
 void ValidatePipelineLayoutDesc(const PipelineLayoutDesc& desc);
 void ValidateResourceSetDesc(PipelineLayout* layout, uint32_t setIndex);
+bool ValidateBufferWriteRequest(Buffer* buffer, uint64_t offset, const void* data, uint64_t size);
 PipelineLayoutDesc BuildPipelineLayoutDescFromReflection(const ShaderReflectionData& reflection);
 std::vector<const BindingInfo*> CollectBindingInfosForSet(const PipelineLayoutDesc& desc, uint32_t setIndex);
 const BindingInfo*

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.h
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.h
@@ -16,6 +16,7 @@ BufferDesc SanitizeBufferDesc(const BufferDesc& desc);
 SwapchainDesc SanitizeSwapchainDesc(const SwapchainDesc& desc);
 TextureDesc SanitizeTextureDesc(const TextureDesc& desc);
 void ValidatePipelineLayoutDesc(const PipelineLayoutDesc& desc);
+void ValidateResourceSetDesc(PipelineLayout* layout, uint32_t setIndex);
 PipelineLayoutDesc BuildPipelineLayoutDescFromReflection(const ShaderReflectionData& reflection);
 std::vector<const BindingInfo*> CollectBindingInfosForSet(const PipelineLayoutDesc& desc, uint32_t setIndex);
 const BindingInfo*

--- a/Src/Render/RHI/Backends/Common/RHIShellCommon.h
+++ b/Src/Render/RHI/Backends/Common/RHIShellCommon.h
@@ -15,6 +15,7 @@ bool IsNativeWindowHandleValid(const NativeWindowHandle& nativeWindowHandle);
 BufferDesc SanitizeBufferDesc(const BufferDesc& desc);
 SwapchainDesc SanitizeSwapchainDesc(const SwapchainDesc& desc);
 TextureDesc SanitizeTextureDesc(const TextureDesc& desc);
+void ValidatePipelineLayoutDesc(const PipelineLayoutDesc& desc);
 PipelineLayoutDesc BuildPipelineLayoutDescFromReflection(const ShaderReflectionData& reflection);
 std::vector<const BindingInfo*> CollectBindingInfosForSet(const PipelineLayoutDesc& desc, uint32_t setIndex);
 const BindingInfo*

--- a/Src/Render/RHI/Backends/Metal/Command/MetalCommandList.h
+++ b/Src/Render/RHI/Backends/Metal/Command/MetalCommandList.h
@@ -34,6 +34,16 @@ public:
     void SetViewport(float x, float y, float w, float h, float zmin, float zmax) override;
     void SetScissor(int32_t x, int32_t y, uint32_t w, uint32_t h) override;
     void Dispatch(uint32_t groupX, uint32_t groupY, uint32_t groupZ) override;
+    void TextureBarrier(Texture* texture,
+                        TextureState oldState,
+                        TextureState newState,
+                        ShaderStage srcStage,
+                        ShaderStage dstStage) override;
+    void BufferBarrier(Buffer* buffer,
+                       BufferState oldState,
+                       BufferState newState,
+                       ShaderStage srcStage,
+                       ShaderStage dstStage) override;
     void DrawIndexed(uint32_t indexCount, uint32_t firstIndex, int32_t vertexOffset) override;
     void
     CopyBuffer(Buffer* sourceBuffer, Buffer* destinationBuffer, std::span<const BufferCopyRegion> regions) override;

--- a/Src/Render/RHI/Backends/Metal/Command/MetalCommandList.mm
+++ b/Src/Render/RHI/Backends/Metal/Command/MetalCommandList.mm
@@ -297,6 +297,33 @@ void MetalCommandList::Dispatch(uint32_t, uint32_t, uint32_t)
                       "compute path.");
 }
 
+void MetalCommandList::TextureBarrier(
+    Texture* texture, TextureState oldState, TextureState newState, ShaderStage srcStage, ShaderStage dstStage)
+{
+    (void)srcStage;
+    (void)dstStage;
+
+    if (texture == nullptr || oldState == newState)
+        return;
+
+    // Metal has no Vulkan-style image layout transitions in this v1 path. The
+    // ordering between blit/render encoders inside the command buffer carries
+    // the current resource-usage dependency.
+}
+
+void MetalCommandList::BufferBarrier(
+    Buffer* buffer, BufferState oldState, BufferState newState, ShaderStage srcStage, ShaderStage dstStage)
+{
+    (void)srcStage;
+    (void)dstStage;
+
+    if (buffer == nullptr || oldState == newState)
+        return;
+
+    // See TextureBarrier: current Metal resource transitions are represented by
+    // encoder/command-buffer ordering rather than an explicit barrier command.
+}
+
 void MetalCommandList::DrawIndexed(uint32_t indexCount, uint32_t firstIndex, int32_t vertexOffset)
 {
     ShellCommandListBase::DrawIndexed(indexCount, firstIndex, vertexOffset);

--- a/Src/Render/RHI/Backends/Metal/Common/MetalConversions.mm
+++ b/Src/Render/RHI/Backends/Metal/Common/MetalConversions.mm
@@ -877,7 +877,7 @@ std::vector<MetalSetBindingPlan> BuildMetalSetBindingPlans(const PipelineLayoutD
             for (MetalBindingPlanEntry& entry : stagePlan.m_Entries)
             {
                 entry.m_ArgumentIndex = nextArgumentIndex;
-                nextArgumentIndex += std::max(entry.m_ArrayCount, 1u);
+                nextArgumentIndex += entry.m_ArrayCount;
             }
         }
     }

--- a/Src/Render/RHI/Backends/Metal/Device/MetalDevice.mm
+++ b/Src/Render/RHI/Backends/Metal/Device/MetalDevice.mm
@@ -272,6 +272,7 @@ Scope<ShaderProgram> MetalDevice::CreateShaderProgram(const CompiledShaderProgra
 
 Scope<PipelineLayout> MetalDevice::CreatePipelineLayout(const PipelineLayoutDesc& desc)
 {
+    RHIInternal::ValidatePipelineLayoutDesc(desc);
     return CreateScope<MetalPipelineLayout>(desc);
 }
 

--- a/Src/Render/RHI/Backends/Metal/Device/MetalDevice.mm
+++ b/Src/Render/RHI/Backends/Metal/Device/MetalDevice.mm
@@ -280,6 +280,7 @@ Scope<ResourceSet> MetalDevice::CreateResourceSet(PipelineLayout* layout, uint32
 {
     RTRLAB_ASSERT_MSG(m_Data != nullptr && m_Data->m_Device != nil,
                       "Metal device must be initialized before CreateResourceSet.");
+    RHIInternal::ValidateResourceSetDesc(layout, setIndex);
     return CreateScope<MetalResourceSet>(m_Data->m_Device, layout, setIndex);
 }
 

--- a/Src/Render/RHI/Backends/Metal/Device/MetalDevice.mm
+++ b/Src/Render/RHI/Backends/Metal/Device/MetalDevice.mm
@@ -412,17 +412,10 @@ Scope<ComputePipeline> MetalDevice::CreateComputePipeline(const ComputePipelineD
 void MetalDevice::WriteBuffer(Buffer* buffer, uint64_t offset, const void* data, uint64_t size)
 {
     // TRANSITIONAL(M3): Demo-only direct host upload path for early bring-up.
-    if (size == 0)
+    if (!RHIInternal::ValidateBufferWriteRequest(buffer, offset, data, size))
         return;
 
-    RTRLAB_ASSERT_MSG(buffer != nullptr, "Metal WriteBuffer requires a valid buffer.");
-    RTRLAB_ASSERT_MSG(data != nullptr, "Metal WriteBuffer requires non-null source data.");
-
     MetalBuffer& metalBuffer = GetMetalBuffer(buffer);
-    RTRLAB_ASSERT_MSG(metalBuffer.GetDesc().m_MemoryUsage == MemoryUsage::CpuToGpu,
-                      "Metal WriteBuffer currently requires a CpuToGpu buffer.");
-    RTRLAB_ASSERT_MSG(offset + size <= metalBuffer.GetDesc().m_Size,
-                      "Metal WriteBuffer range exceeds the buffer size.");
 
     std::memcpy(
         static_cast<uint8_t*>([metalBuffer.GetMetalBuffer() contents]) + offset, data, static_cast<size_t>(size));

--- a/Src/Render/RHI/Backends/Metal/Resources/MetalResourceSet.mm
+++ b/Src/Render/RHI/Backends/Metal/Resources/MetalResourceSet.mm
@@ -10,6 +10,21 @@
 
 using namespace MetalRHI;
 
+namespace
+{
+void ValidateTextureBinding(const TextureBinding& textureBinding)
+{
+    RTRLAB_ASSERT_MSG(textureBinding.m_Texture != nullptr || textureBinding.m_View != nullptr,
+                      "Metal texture bindings require a Texture or TextureView.");
+
+    if (textureBinding.m_Texture != nullptr && textureBinding.m_View != nullptr)
+    {
+        RTRLAB_ASSERT_MSG(textureBinding.m_View->GetTexture() == textureBinding.m_Texture,
+                          "Metal TextureBinding Texture and TextureView must reference the same texture.");
+    }
+}
+} // namespace
+
 MetalResourceSet::MetalResourceSet(id<MTLDevice> device, PipelineLayout* layout, uint32_t setIndex)
     : m_Device([device retain]), m_Layout(layout), m_SetIndex(setIndex)
 {
@@ -86,6 +101,8 @@ void MetalResourceSet::SetTextureArray(uint32_t binding, std::span<const Texture
                    m_SetIndex,
                    binding);
     ValidateBindingArrayCount(*bindingInfo, textureBindings.size(), "texture");
+    for (const TextureBinding& textureBinding : textureBindings)
+        ValidateTextureBinding(textureBinding);
     m_TextureBindings[binding] = std::vector<TextureBinding>(textureBindings.begin(), textureBindings.end());
     ++m_Version;
 }

--- a/Src/Render/RHI/Backends/Metal/Resources/MetalResourceSet.mm
+++ b/Src/Render/RHI/Backends/Metal/Resources/MetalResourceSet.mm
@@ -23,6 +23,24 @@ void ValidateTextureBinding(const TextureBinding& textureBinding)
                           "Metal TextureBinding Texture and TextureView must reference the same texture.");
     }
 }
+
+void ValidateBufferBinding(const BufferBinding& bufferBinding)
+{
+    RTRLAB_ASSERT_MSG(bufferBinding.m_Buffer != nullptr, "Metal buffer bindings require a Buffer.");
+
+    const BufferDesc& desc = bufferBinding.m_Buffer->GetDesc();
+    RTRLAB_ASSERT_MSG(bufferBinding.m_Offset <= desc.m_Size, "Metal BufferBinding offset exceeds the Buffer size.");
+    if (bufferBinding.m_Size != 0)
+    {
+        RTRLAB_ASSERT_MSG(bufferBinding.m_Size <= desc.m_Size - bufferBinding.m_Offset,
+                          "Metal BufferBinding range exceeds the Buffer size.");
+    }
+}
+
+void ValidateSamplerBinding(const SamplerBinding& samplerBinding)
+{
+    RTRLAB_ASSERT_MSG(samplerBinding.m_Sampler != nullptr, "Metal sampler bindings require a Sampler.");
+}
 } // namespace
 
 MetalResourceSet::MetalResourceSet(id<MTLDevice> device, PipelineLayout* layout, uint32_t setIndex)
@@ -85,6 +103,8 @@ void MetalResourceSet::SetBufferArray(uint32_t binding, std::span<const BufferBi
 {
     const BindingInfo& bindingInfo = RequireBindingInfo(binding, ResourceKind::StorageBuffer);
     ValidateBindingArrayCount(bindingInfo, bufferBindings.size(), "buffer");
+    for (const BufferBinding& bufferBinding : bufferBindings)
+        ValidateBufferBinding(bufferBinding);
     m_BufferBindings[binding] = std::vector<BufferBinding>(bufferBindings.begin(), bufferBindings.end());
     ++m_Version;
 }
@@ -111,6 +131,8 @@ void MetalResourceSet::SetSamplerArray(uint32_t binding, std::span<const Sampler
 {
     const BindingInfo& bindingInfo = RequireBindingInfo(binding, ResourceKind::Sampler);
     ValidateBindingArrayCount(bindingInfo, samplerBindings.size(), "sampler");
+    for (const SamplerBinding& samplerBinding : samplerBindings)
+        ValidateSamplerBinding(samplerBinding);
     m_SamplerBindings[binding] = std::vector<SamplerBinding>(samplerBindings.begin(), samplerBindings.end());
     ++m_Version;
 }

--- a/Src/Render/RHI/Backends/Vulkan/Common/VulkanDescriptors.cpp
+++ b/Src/Render/RHI/Backends/Vulkan/Common/VulkanDescriptors.cpp
@@ -27,7 +27,7 @@ std::vector<VkDescriptorSetLayout> CreateVkDescriptorSetLayouts(VkDevice device,
         VkDescriptorSetLayoutBinding vkBinding{};
         vkBinding.binding = binding.m_Binding;
         vkBinding.descriptorType = ToVkDescriptorType(binding.m_Kind);
-        vkBinding.descriptorCount = std::max(binding.m_ArrayCount, 1u);
+        vkBinding.descriptorCount = binding.m_ArrayCount;
         vkBinding.stageFlags = ToVkShaderStageFlags(binding.m_StageMask);
         bindingsPerSet[binding.m_SetIndex].push_back(vkBinding);
     }
@@ -53,7 +53,7 @@ VkDescriptorPool CreateVkDescriptorPoolForSet(VkDevice device, const PipelineLay
     for (const BindingInfo* bindingInfo : RHIInternal::CollectBindingInfosForSet(desc, setIndex))
     {
         const VkDescriptorType descriptorType = ToVkDescriptorType(bindingInfo->m_Kind);
-        const uint32_t descriptorCount = std::max(bindingInfo->m_ArrayCount, 1u);
+        const uint32_t descriptorCount = bindingInfo->m_ArrayCount;
 
         auto it = std::find_if(poolSizes.begin(),
                                poolSizes.end(),

--- a/Src/Render/RHI/Backends/Vulkan/Device/VulkanDevice.cpp
+++ b/Src/Render/RHI/Backends/Vulkan/Device/VulkanDevice.cpp
@@ -206,6 +206,7 @@ Scope<ShaderProgram> VulkanDevice::CreateShaderProgram(const CompiledShaderProgr
 Scope<PipelineLayout> VulkanDevice::CreatePipelineLayout(const PipelineLayoutDesc& desc)
 {
     InitializeDeviceObjects();
+    RHIInternal::ValidatePipelineLayoutDesc(desc);
 
     std::vector<VkDescriptorSetLayout> descriptorSetLayouts = CreateVkDescriptorSetLayouts(m_Device, desc);
     VkPipelineLayout pipelineLayout = CreateVkPipelineLayout(m_Device, desc, descriptorSetLayouts);

--- a/Src/Render/RHI/Backends/Vulkan/Device/VulkanDevice.cpp
+++ b/Src/Render/RHI/Backends/Vulkan/Device/VulkanDevice.cpp
@@ -216,12 +216,9 @@ Scope<PipelineLayout> VulkanDevice::CreatePipelineLayout(const PipelineLayoutDes
 Scope<ResourceSet> VulkanDevice::CreateResourceSet(PipelineLayout* layout, uint32_t setIndex)
 {
     InitializeDeviceObjects();
+    RHIInternal::ValidateResourceSetDesc(layout, setIndex);
 
     VulkanPipelineLayout& pipelineLayout = GetVulkanPipelineLayout(layout);
-    const std::vector<const BindingInfo*> setBindings =
-        RHIInternal::CollectBindingInfosForSet(pipelineLayout.GetDesc(), setIndex);
-    RTRLAB_ASSERTF(
-        !setBindings.empty(), "Vulkan CreateResourceSet requires a valid set {} in the PipelineLayout.", setIndex);
 
     VkDescriptorPool descriptorPool = CreateVkDescriptorPoolForSet(m_Device, pipelineLayout.GetDesc(), setIndex);
     VkDescriptorSet descriptorSet = AllocateVkDescriptorSet(m_Device, descriptorPool, pipelineLayout, setIndex);

--- a/Src/Render/RHI/Backends/Vulkan/Device/VulkanDevice.cpp
+++ b/Src/Render/RHI/Backends/Vulkan/Device/VulkanDevice.cpp
@@ -402,20 +402,13 @@ Scope<ComputePipeline> VulkanDevice::CreateComputePipeline(const ComputePipeline
 void VulkanDevice::WriteBuffer(Buffer* buffer, uint64_t offset, const void* data, uint64_t size)
 {
     // TRANSITIONAL(M3): Demo-only direct host upload path for early bring-up.
+    if (!RHIInternal::ValidateBufferWriteRequest(buffer, offset, data, size))
+        return;
+
     InitializeDeviceObjects();
     RTRLAB_ASSERT_MSG(m_Allocator != nullptr, "Vulkan WriteBuffer requires an initialized VMA allocator.");
 
-    if (size == 0)
-        return;
-
-    RTRLAB_ASSERT_MSG(buffer != nullptr, "Vulkan WriteBuffer requires a valid buffer.");
-    RTRLAB_ASSERT_MSG(data != nullptr, "Vulkan WriteBuffer requires non-null source data.");
-
     VulkanBuffer& vulkanBuffer = GetVulkanBuffer(buffer);
-    const BufferDesc& desc = vulkanBuffer.GetDesc();
-    RTRLAB_ASSERT_MSG(desc.m_MemoryUsage == MemoryUsage::CpuToGpu,
-                      "Vulkan WriteBuffer currently requires a CpuToGpu buffer.");
-    RTRLAB_ASSERT_MSG(offset + size <= desc.m_Size, "Vulkan WriteBuffer range exceeds the buffer size.");
 
     void* mappedData = nullptr;
     CheckVk(vmaMapMemory(m_Allocator, vulkanBuffer.GetVmaAllocation(), &mappedData), "vmaMapMemory");

--- a/Src/Render/RHI/Backends/Vulkan/Resources/VulkanResourceSet.cpp
+++ b/Src/Render/RHI/Backends/Vulkan/Resources/VulkanResourceSet.cpp
@@ -22,6 +22,24 @@ void ValidateTextureBinding(const TextureBinding& textureBinding)
                           "Vulkan TextureBinding Texture and TextureView must reference the same texture.");
     }
 }
+
+void ValidateBufferBinding(const BufferBinding& bufferBinding)
+{
+    RTRLAB_ASSERT_MSG(bufferBinding.m_Buffer != nullptr, "Vulkan buffer bindings require a Buffer.");
+
+    const BufferDesc& desc = bufferBinding.m_Buffer->GetDesc();
+    RTRLAB_ASSERT_MSG(bufferBinding.m_Offset <= desc.m_Size, "Vulkan BufferBinding offset exceeds the Buffer size.");
+    if (bufferBinding.m_Size != 0)
+    {
+        RTRLAB_ASSERT_MSG(bufferBinding.m_Size <= desc.m_Size - bufferBinding.m_Offset,
+                          "Vulkan BufferBinding range exceeds the Buffer size.");
+    }
+}
+
+void ValidateSamplerBinding(const SamplerBinding& samplerBinding)
+{
+    RTRLAB_ASSERT_MSG(samplerBinding.m_Sampler != nullptr, "Vulkan sampler bindings require a Sampler.");
+}
 } // namespace
 
 VulkanResourceSet::VulkanResourceSet(VkDevice device,
@@ -68,6 +86,8 @@ void VulkanResourceSet::SetBufferArray(uint32_t binding, std::span<const BufferB
 {
     const BindingInfo& bindingInfo = RequireBindingInfo(binding, ResourceKind::StorageBuffer);
     ValidateBindingArrayCount(bindingInfo, bufferBindings.size(), "buffer");
+    for (const BufferBinding& bufferBinding : bufferBindings)
+        ValidateBufferBinding(bufferBinding);
     m_BufferBindings[binding] = std::vector<BufferBinding>(bufferBindings.begin(), bufferBindings.end());
     WriteBufferDescriptor(bindingInfo, m_BufferBindings[binding]);
     ++m_Version;
@@ -100,6 +120,8 @@ void VulkanResourceSet::SetSamplerArray(uint32_t binding, std::span<const Sample
 {
     const BindingInfo& bindingInfo = RequireBindingInfo(binding, ResourceKind::Sampler);
     ValidateBindingArrayCount(bindingInfo, samplerBindings.size(), "sampler");
+    for (const SamplerBinding& samplerBinding : samplerBindings)
+        ValidateSamplerBinding(samplerBinding);
     m_SamplerBindings[binding] = std::vector<SamplerBinding>(samplerBindings.begin(), samplerBindings.end());
     WriteSamplerDescriptor(bindingInfo, m_SamplerBindings[binding]);
     ++m_Version;
@@ -222,7 +244,7 @@ void VulkanResourceSet::WriteBufferDescriptor(const BindingInfo& bindingInfo,
     {
         const BufferBinding& bufferBinding = bufferBindings[index];
         RTRLAB_ASSERT_MSG(bufferBinding.m_Buffer != nullptr,
-                          "Vulkan ResourceSet buffer descriptor writes require valid Buffers.");
+                          "Vulkan ResourceSet buffer descriptor writes require validated Buffers.");
         VulkanBuffer& vulkanBuffer = GetVulkanBuffer(bufferBinding.m_Buffer);
 
         VkDescriptorBufferInfo& bufferInfo = bufferInfos[index];
@@ -278,7 +300,7 @@ void VulkanResourceSet::WriteSamplerDescriptor(const BindingInfo& bindingInfo,
     {
         const SamplerBinding& samplerBinding = samplerBindings[index];
         RTRLAB_ASSERT_MSG(samplerBinding.m_Sampler != nullptr,
-                          "Vulkan ResourceSet sampler descriptor writes require valid Samplers.");
+                          "Vulkan ResourceSet sampler descriptor writes require validated Samplers.");
         VulkanSampler& vulkanSampler = GetVulkanSampler(samplerBinding.m_Sampler);
 
         VkDescriptorImageInfo& imageInfo = imageInfos[index];

--- a/Src/Render/RHI/Backends/Vulkan/Resources/VulkanResourceSet.cpp
+++ b/Src/Render/RHI/Backends/Vulkan/Resources/VulkanResourceSet.cpp
@@ -9,6 +9,21 @@
 
 using namespace VulkanRHI;
 
+namespace
+{
+void ValidateTextureBinding(const TextureBinding& textureBinding)
+{
+    RTRLAB_ASSERT_MSG(textureBinding.m_Texture != nullptr || textureBinding.m_View != nullptr,
+                      "Vulkan texture bindings require a Texture or TextureView.");
+
+    if (textureBinding.m_Texture != nullptr && textureBinding.m_View != nullptr)
+    {
+        RTRLAB_ASSERT_MSG(textureBinding.m_View->GetTexture() == textureBinding.m_Texture,
+                          "Vulkan TextureBinding Texture and TextureView must reference the same texture.");
+    }
+}
+} // namespace
+
 VulkanResourceSet::VulkanResourceSet(VkDevice device,
                                      PipelineLayout* layout,
                                      uint32_t setIndex,
@@ -72,6 +87,8 @@ void VulkanResourceSet::SetTextureArray(uint32_t binding, std::span<const Textur
     ValidateBindingArrayCount(*bindingInfo, textureBindings.size(), "texture");
 
     std::vector<TextureBinding> resolvedBindings(textureBindings.begin(), textureBindings.end());
+    for (const TextureBinding& textureBinding : resolvedBindings)
+        ValidateTextureBinding(textureBinding);
     ResolveAutoTextureViews(binding, resolvedBindings);
 
     m_TextureBindings[binding] = std::move(resolvedBindings);
@@ -232,8 +249,8 @@ void VulkanResourceSet::WriteTextureDescriptor(const BindingInfo& bindingInfo,
     for (size_t index = 0; index < textureBindings.size(); ++index)
     {
         const TextureBinding& textureBinding = textureBindings[index];
-        RTRLAB_ASSERT_MSG(textureBinding.m_View != nullptr || textureBinding.m_Texture != nullptr,
-                          "Vulkan ResourceSet texture descriptor writes require valid Textures or TextureViews.");
+        RTRLAB_ASSERT_MSG(textureBinding.m_View != nullptr,
+                          "Vulkan ResourceSet texture descriptor writes require resolved TextureViews.");
 
         VkDescriptorImageInfo& imageInfo = imageInfos[index];
         imageInfo.imageView = GetVkImageViewFromTextureView(textureBinding.m_View);

--- a/Src/Render/RHI/RHIDevice.h
+++ b/Src/Render/RHI/RHIDevice.h
@@ -43,6 +43,8 @@ public:
     // on CommandList plus staging resources instead of reaching into Device
     // for direct writes. This remains only until renderer-owned upload
     // scheduling replaces the demo path completely.
+    // Contract while it exists: size==0 is a no-op; non-zero writes require
+    // a CpuToGpu Buffer, non-null data, and a fully in-range byte span.
     virtual void WriteBuffer(Buffer* buffer, uint64_t offset, const void* data, uint64_t size) = 0;
 
     virtual CommandList* BeginCommandList() = 0;


### PR DESCRIPTION
## Summary
- Make unsupported shell RHI paths fail explicitly instead of caching fake state.
- Tighten RHI binding validation for pipeline layouts, resource sets, texture/buffer/sampler bindings, and `WriteBuffer`.
- Align Shell / Vulkan / Metal validation boundaries so invalid requests fail near the public RHI entry point.

## Why
- Focuses on RHI honesty before building higher-level renderer systems.
- Several bring-up paths previously looked successful while doing no backend work, especially shell compute, push constants, barriers, and invalid resource bindings.
- Later upload, renderer, material, and pass code needs reliable failure boundaries instead of hidden no-op behavior.

## Affected areas
- `Src/Render/RHI/Backends/Common/`
  - Shell compute, push constants, barriers, resource set validation, pipeline layout validation, `WriteBuffer` request validation.
- `Src/Render/RHI/Backends/Vulkan/`
  - Resource binding validation, pipeline layout/resource set creation validation, `WriteBuffer` contract reuse.
- `Src/Render/RHI/Backends/Metal/`
  - Explicit barrier behavior, resource binding validation, pipeline layout/resource set creation validation, `WriteBuffer` contract reuse.
- `Src/Render/RHI/RHIDevice.h`
  - Clarified transitional `WriteBuffer` contract.

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Not run. Per workflow, validation is left for manual local compile/run by reviewer.

## Notes
- `WriteBuffer` remains as a transitional demo compatibility path. It is now stricter, but not removed.
- Metal barriers remain explicit no-ops because current Metal ordering is represented by encoder/command-buffer ordering, not Vulkan-style layout transitions.
- The next step can move toward replacing demo upload helpers with a real upload path.