### PR TITLE
Extract reusable RHI upload helpers from demos

### DIFF
--- a/CMake/Src/Sources.cmake
+++ b/CMake/Src/Sources.cmake
@@ -171,6 +171,7 @@ set(GLAB_SCENE_HEADERS
 
 set(GLAB_RENDER_SOURCES
     Render/RHI/RHIFactory.cpp
+    Render/RHI/RHIUpload.cpp
     Render/RHI/ResourceStateTracker.cpp
     Render/RHI/Backends/Common/RHIShellCommon.cpp
     Render/Shader/ShaderCompiler.cpp
@@ -189,6 +190,7 @@ set(GLAB_RENDER_HEADERS
     Render/RHI/RHIPipeline.h
     Render/RHI/RHICommandList.h
     Render/RHI/RHIDevice.h
+    Render/RHI/RHIUpload.h
     Render/RHI/Backends/Common/RHIShellCommon.h
     Render/Shader/ShaderCompiler.h
     Render/Shader/ShaderReflection.h

--- a/Src/Demos/02_Triangle/TriangleDemo.cpp
+++ b/Src/Demos/02_Triangle/TriangleDemo.cpp
@@ -11,6 +11,7 @@
 #include "Core/Resource/FileSystem.h"
 #include "Core/Util/Math.h"
 #include "Demos/DemoRenderUtils.h"
+#include "Render/RHI/RHIUpload.h"
 #include "Render/Shader/ShaderParameterWriter.h"
 
 TriangleDemo::TriangleDemo(uint32_t width, uint32_t height) : m_ViewportWidth(width), m_ViewportHeight(height) {}
@@ -112,22 +113,22 @@ void TriangleDemo::CreateTriangleResources()
     }};
     static constexpr std::array<uint16_t, 3> kIndices = {0, 1, 2};
 
-    DemoRenderUtils::CreateStaticBufferPair(device,
-                                            kVertices.data(),
-                                            sizeof(kVertices),
-                                            BufferUsage::Vertex,
-                                            "TriangleDemo.VertexBuffer",
-                                            "TriangleDemo.VertexUploadBuffer",
-                                            m_VertexBuffer,
-                                            m_VertexUploadBuffer);
-    DemoRenderUtils::CreateStaticBufferPair(device,
-                                            kIndices.data(),
-                                            sizeof(kIndices),
-                                            BufferUsage::Index,
-                                            "TriangleDemo.IndexBuffer",
-                                            "TriangleDemo.IndexUploadBuffer",
-                                            m_IndexBuffer,
-                                            m_IndexUploadBuffer);
+    RHIUpload::CreateStaticBufferPair(device,
+                                      kVertices.data(),
+                                      sizeof(kVertices),
+                                      BufferUsage::Vertex,
+                                      "TriangleDemo.VertexBuffer",
+                                      "TriangleDemo.VertexUploadBuffer",
+                                      m_VertexBuffer,
+                                      m_VertexUploadBuffer);
+    RHIUpload::CreateStaticBufferPair(device,
+                                      kIndices.data(),
+                                      sizeof(kIndices),
+                                      BufferUsage::Index,
+                                      "TriangleDemo.IndexBuffer",
+                                      "TriangleDemo.IndexUploadBuffer",
+                                      m_IndexBuffer,
+                                      m_IndexUploadBuffer);
     m_GeometryUploadPending = true;
 
     m_ShaderProgram = device.CreateShaderProgram(DemoRenderUtils::CompileShaderProgramDesc(
@@ -175,18 +176,18 @@ void TriangleDemo::UploadTriangleGeometry(CommandList& commandList, ResourceStat
     if (!m_GeometryUploadPending)
         return;
 
-    DemoRenderUtils::UploadStaticBufferPair(commandList,
-                                            resourceStateTracker,
-                                            m_VertexUploadBuffer.get(),
-                                            m_VertexBuffer.get(),
-                                            m_VertexBuffer->GetDesc().m_Size,
-                                            BufferState::VertexIndex);
-    DemoRenderUtils::UploadStaticBufferPair(commandList,
-                                            resourceStateTracker,
-                                            m_IndexUploadBuffer.get(),
-                                            m_IndexBuffer.get(),
-                                            m_IndexBuffer->GetDesc().m_Size,
-                                            BufferState::VertexIndex);
+    RHIUpload::UploadStaticBufferPair(commandList,
+                                      resourceStateTracker,
+                                      m_VertexUploadBuffer.get(),
+                                      m_VertexBuffer.get(),
+                                      m_VertexBuffer->GetDesc().m_Size,
+                                      BufferState::VertexIndex);
+    RHIUpload::UploadStaticBufferPair(commandList,
+                                      resourceStateTracker,
+                                      m_IndexUploadBuffer.get(),
+                                      m_IndexBuffer.get(),
+                                      m_IndexBuffer->GetDesc().m_Size,
+                                      BufferState::VertexIndex);
     m_GeometryUploadPending = false;
 #endif
 }

--- a/Src/Demos/03_Quad/QuadDemo.cpp
+++ b/Src/Demos/03_Quad/QuadDemo.cpp
@@ -11,6 +11,7 @@
 #include "Core/Resource/FileSystem.h"
 #include "Core/Util/Math.h"
 #include "Demos/DemoRenderUtils.h"
+#include "Render/RHI/RHIUpload.h"
 #include "Render/Shader/ShaderParameterWriter.h"
 
 QuadDemo::QuadDemo(uint32_t width, uint32_t height) : m_ViewportWidth(width), m_ViewportHeight(height) {}
@@ -113,22 +114,22 @@ void QuadDemo::CreateQuadResources()
     }};
     static constexpr std::array<uint16_t, 6> kIndices = {0, 1, 2, 0, 2, 3};
 
-    DemoRenderUtils::CreateStaticBufferPair(device,
-                                            kVertices.data(),
-                                            sizeof(kVertices),
-                                            BufferUsage::Vertex,
-                                            "QuadDemo.VertexBuffer",
-                                            "QuadDemo.VertexUploadBuffer",
-                                            m_VertexBuffer,
-                                            m_VertexUploadBuffer);
-    DemoRenderUtils::CreateStaticBufferPair(device,
-                                            kIndices.data(),
-                                            sizeof(kIndices),
-                                            BufferUsage::Index,
-                                            "QuadDemo.IndexBuffer",
-                                            "QuadDemo.IndexUploadBuffer",
-                                            m_IndexBuffer,
-                                            m_IndexUploadBuffer);
+    RHIUpload::CreateStaticBufferPair(device,
+                                      kVertices.data(),
+                                      sizeof(kVertices),
+                                      BufferUsage::Vertex,
+                                      "QuadDemo.VertexBuffer",
+                                      "QuadDemo.VertexUploadBuffer",
+                                      m_VertexBuffer,
+                                      m_VertexUploadBuffer);
+    RHIUpload::CreateStaticBufferPair(device,
+                                      kIndices.data(),
+                                      sizeof(kIndices),
+                                      BufferUsage::Index,
+                                      "QuadDemo.IndexBuffer",
+                                      "QuadDemo.IndexUploadBuffer",
+                                      m_IndexBuffer,
+                                      m_IndexUploadBuffer);
     m_GeometryUploadPending = true;
 
     m_ShaderProgram = device.CreateShaderProgram(DemoRenderUtils::CompileShaderProgramDesc(
@@ -176,18 +177,18 @@ void QuadDemo::UploadQuadGeometry(CommandList& commandList, ResourceStateTracker
     if (!m_GeometryUploadPending)
         return;
 
-    DemoRenderUtils::UploadStaticBufferPair(commandList,
-                                            resourceStateTracker,
-                                            m_VertexUploadBuffer.get(),
-                                            m_VertexBuffer.get(),
-                                            m_VertexBuffer->GetDesc().m_Size,
-                                            BufferState::VertexIndex);
-    DemoRenderUtils::UploadStaticBufferPair(commandList,
-                                            resourceStateTracker,
-                                            m_IndexUploadBuffer.get(),
-                                            m_IndexBuffer.get(),
-                                            m_IndexBuffer->GetDesc().m_Size,
-                                            BufferState::VertexIndex);
+    RHIUpload::UploadStaticBufferPair(commandList,
+                                      resourceStateTracker,
+                                      m_VertexUploadBuffer.get(),
+                                      m_VertexBuffer.get(),
+                                      m_VertexBuffer->GetDesc().m_Size,
+                                      BufferState::VertexIndex);
+    RHIUpload::UploadStaticBufferPair(commandList,
+                                      resourceStateTracker,
+                                      m_IndexUploadBuffer.get(),
+                                      m_IndexBuffer.get(),
+                                      m_IndexBuffer->GetDesc().m_Size,
+                                      BufferState::VertexIndex);
     m_GeometryUploadPending = false;
 #endif
 }

--- a/Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp
+++ b/Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp
@@ -121,22 +121,22 @@ void TexturedQuadDemo::CreateTexturedQuadResources()
     }};
     static constexpr std::array<uint16_t, 6> kIndices = {0, 1, 2, 0, 2, 3};
 
-    DemoRenderUtils::CreateStaticBufferPair(device,
-                                            kVertices.data(),
-                                            sizeof(kVertices),
-                                            BufferUsage::Vertex,
-                                            "TexturedQuadDemo.VertexBuffer",
-                                            "TexturedQuadDemo.VertexUploadBuffer",
-                                            m_VertexBuffer,
-                                            m_VertexUploadBuffer);
-    DemoRenderUtils::CreateStaticBufferPair(device,
-                                            kIndices.data(),
-                                            sizeof(kIndices),
-                                            BufferUsage::Index,
-                                            "TexturedQuadDemo.IndexBuffer",
-                                            "TexturedQuadDemo.IndexUploadBuffer",
-                                            m_IndexBuffer,
-                                            m_IndexUploadBuffer);
+    RHIUpload::CreateStaticBufferPair(device,
+                                      kVertices.data(),
+                                      sizeof(kVertices),
+                                      BufferUsage::Vertex,
+                                      "TexturedQuadDemo.VertexBuffer",
+                                      "TexturedQuadDemo.VertexUploadBuffer",
+                                      m_VertexBuffer,
+                                      m_VertexUploadBuffer);
+    RHIUpload::CreateStaticBufferPair(device,
+                                      kIndices.data(),
+                                      sizeof(kIndices),
+                                      BufferUsage::Index,
+                                      "TexturedQuadDemo.IndexBuffer",
+                                      "TexturedQuadDemo.IndexUploadBuffer",
+                                      m_IndexBuffer,
+                                      m_IndexUploadBuffer);
     m_GeometryUploadPending = true;
 
     const std::filesystem::path texturePath = FileSystem::GetRootPath() / "Project" / "Textures" / "Grassy_Square.jpg";
@@ -220,18 +220,18 @@ void TexturedQuadDemo::UploadPendingResources(CommandList& commandList, Resource
 #if defined(GLAB_BACKEND_VULKAN) || defined(GLAB_BACKEND_METAL)
     if (m_GeometryUploadPending)
     {
-        DemoRenderUtils::UploadStaticBufferPair(commandList,
-                                                resourceStateTracker,
-                                                m_VertexUploadBuffer.get(),
-                                                m_VertexBuffer.get(),
-                                                m_VertexBuffer->GetDesc().m_Size,
-                                                BufferState::VertexIndex);
-        DemoRenderUtils::UploadStaticBufferPair(commandList,
-                                                resourceStateTracker,
-                                                m_IndexUploadBuffer.get(),
-                                                m_IndexBuffer.get(),
-                                                m_IndexBuffer->GetDesc().m_Size,
-                                                BufferState::VertexIndex);
+        RHIUpload::UploadStaticBufferPair(commandList,
+                                          resourceStateTracker,
+                                          m_VertexUploadBuffer.get(),
+                                          m_VertexBuffer.get(),
+                                          m_VertexBuffer->GetDesc().m_Size,
+                                          BufferState::VertexIndex);
+        RHIUpload::UploadStaticBufferPair(commandList,
+                                          resourceStateTracker,
+                                          m_IndexUploadBuffer.get(),
+                                          m_IndexBuffer.get(),
+                                          m_IndexBuffer->GetDesc().m_Size,
+                                          BufferState::VertexIndex);
         m_GeometryUploadPending = false;
     }
 

--- a/Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp
+++ b/Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp
@@ -11,6 +11,7 @@
 #include "Core/Resource/FileSystem.h"
 #include "Core/Util/Math.h"
 #include "Demos/DemoRenderUtils.h"
+#include "Render/RHI/RHIUpload.h"
 #include "Render/Shader/ShaderParameterWriter.h"
 
 TexturedQuadDemo::TexturedQuadDemo(uint32_t width, uint32_t height) : m_ViewportWidth(width), m_ViewportHeight(height)
@@ -242,27 +243,12 @@ void TexturedQuadDemo::UploadPendingResources(CommandList& commandList, Resource
 
     if (m_TextureUploadPending)
     {
-        resourceStateTracker.Transition(m_TextureUploadBuffer.get(), BufferState::CopySource);
-        resourceStateTracker.Transition(m_Texture.get(), TextureState::CopyDest);
-        resourceStateTracker.FlushBarriers(&commandList);
-
-        const TextureDesc& textureDesc = m_Texture->GetDesc();
-        const BufferTextureCopyRegion copyRegion{
-            0,
-            textureDesc.m_Extent.m_Width * 4u,
-            textureDesc.m_Extent.m_Height,
-            TextureAspect::Color,
-            0,
-            0,
-            1,
-            {},
-            textureDesc.m_Extent,
-        };
-        commandList.CopyBufferToTexture(
-            m_TextureUploadBuffer.get(), m_Texture.get(), std::span<const BufferTextureCopyRegion>(&copyRegion, 1));
-
-        resourceStateTracker.Transition(m_Texture.get(), TextureState::ShaderRead);
-        resourceStateTracker.FlushBarriers(&commandList);
+        RHIUpload::UploadFullTexture(commandList,
+                                     resourceStateTracker,
+                                     m_TextureUploadBuffer.get(),
+                                     m_Texture.get(),
+                                     4u,
+                                     TextureState::ShaderRead);
         m_TextureUploadPending = false;
     }
 #endif

--- a/Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp
+++ b/Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp
@@ -168,16 +168,10 @@ void TexturedQuadDemo::CreateTexturedQuadResources()
     samplerDesc.m_AddressW = AddressMode::Repeat;
     m_Sampler = device.CreateSampler(samplerDesc);
 
-    BufferDesc textureUploadBufferDesc;
-    textureUploadBufferDesc.m_Size = static_cast<uint64_t>(loadedImage.m_Pixels.size());
-    textureUploadBufferDesc.m_UsageMask = BufferUsage::CopySrc;
-    textureUploadBufferDesc.m_MemoryUsage = MemoryUsage::CpuToGpu;
-    textureUploadBufferDesc.m_DebugName = "TexturedQuadDemo.TextureUploadBuffer";
-    m_TextureUploadBuffer = device.CreateBuffer(textureUploadBufferDesc);
-    device.WriteBuffer(m_TextureUploadBuffer.get(),
-                       0,
-                       loadedImage.m_Pixels.data(),
-                       static_cast<uint64_t>(loadedImage.m_Pixels.size()));
+    m_TextureUploadBuffer = RHIUpload::CreateUploadBuffer(device,
+                                                          loadedImage.m_Pixels.data(),
+                                                          static_cast<uint64_t>(loadedImage.m_Pixels.size()),
+                                                          "TexturedQuadDemo.TextureUploadBuffer");
     m_TextureUploadPending = true;
 
     m_ShaderProgram = device.CreateShaderProgram(DemoRenderUtils::CompileShaderProgramDesc(

--- a/Src/Demos/05_RotatingCube/RotatingCubeDemo.cpp
+++ b/Src/Demos/05_RotatingCube/RotatingCubeDemo.cpp
@@ -11,6 +11,7 @@
 #include "Core/Resource/FileSystem.h"
 #include "Core/Util/Math.h"
 #include "Demos/DemoRenderUtils.h"
+#include "Render/RHI/RHIUpload.h"
 #include "Render/Shader/ShaderParameterWriter.h"
 
 RotatingCubeDemo::RotatingCubeDemo(uint32_t width, uint32_t height) : m_ViewportWidth(width), m_ViewportHeight(height)
@@ -171,22 +172,22 @@ void RotatingCubeDemo::CreateCubeResources()
         12, 13, 14, 12, 14, 15, 16, 17, 18, 16, 18, 19, 20, 21, 22, 20, 22, 23,
     };
 
-    DemoRenderUtils::CreateStaticBufferPair(device,
-                                            kVertices.data(),
-                                            sizeof(kVertices),
-                                            BufferUsage::Vertex,
-                                            "RotatingCube.VertexBuffer",
-                                            "RotatingCube.VertexUploadBuffer",
-                                            m_VertexBuffer,
-                                            m_VertexUploadBuffer);
-    DemoRenderUtils::CreateStaticBufferPair(device,
-                                            kIndices.data(),
-                                            sizeof(kIndices),
-                                            BufferUsage::Index,
-                                            "RotatingCube.IndexBuffer",
-                                            "RotatingCube.IndexUploadBuffer",
-                                            m_IndexBuffer,
-                                            m_IndexUploadBuffer);
+    RHIUpload::CreateStaticBufferPair(device,
+                                      kVertices.data(),
+                                      sizeof(kVertices),
+                                      BufferUsage::Vertex,
+                                      "RotatingCube.VertexBuffer",
+                                      "RotatingCube.VertexUploadBuffer",
+                                      m_VertexBuffer,
+                                      m_VertexUploadBuffer);
+    RHIUpload::CreateStaticBufferPair(device,
+                                      kIndices.data(),
+                                      sizeof(kIndices),
+                                      BufferUsage::Index,
+                                      "RotatingCube.IndexBuffer",
+                                      "RotatingCube.IndexUploadBuffer",
+                                      m_IndexBuffer,
+                                      m_IndexUploadBuffer);
     m_GeometryUploadPending = true;
     CreateDepthResources();
 
@@ -262,18 +263,18 @@ void RotatingCubeDemo::UploadCubeGeometry(CommandList& commandList, ResourceStat
     if (!m_GeometryUploadPending)
         return;
 
-    DemoRenderUtils::UploadStaticBufferPair(commandList,
-                                            resourceStateTracker,
-                                            m_VertexUploadBuffer.get(),
-                                            m_VertexBuffer.get(),
-                                            m_VertexBuffer->GetDesc().m_Size,
-                                            BufferState::VertexIndex);
-    DemoRenderUtils::UploadStaticBufferPair(commandList,
-                                            resourceStateTracker,
-                                            m_IndexUploadBuffer.get(),
-                                            m_IndexBuffer.get(),
-                                            m_IndexBuffer->GetDesc().m_Size,
-                                            BufferState::VertexIndex);
+    RHIUpload::UploadStaticBufferPair(commandList,
+                                      resourceStateTracker,
+                                      m_VertexUploadBuffer.get(),
+                                      m_VertexBuffer.get(),
+                                      m_VertexBuffer->GetDesc().m_Size,
+                                      BufferState::VertexIndex);
+    RHIUpload::UploadStaticBufferPair(commandList,
+                                      resourceStateTracker,
+                                      m_IndexUploadBuffer.get(),
+                                      m_IndexBuffer.get(),
+                                      m_IndexBuffer->GetDesc().m_Size,
+                                      BufferState::VertexIndex);
     m_GeometryUploadPending = false;
 #endif
 }

--- a/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
+++ b/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
@@ -214,16 +214,10 @@ void TexturedRotatingCubeDemo::CreateCubeResources()
     samplerDesc.m_AddressW = AddressMode::Repeat;
     m_Sampler = device.CreateSampler(samplerDesc);
 
-    BufferDesc textureUploadBufferDesc;
-    textureUploadBufferDesc.m_Size = static_cast<uint64_t>(loadedImage.m_Pixels.size());
-    textureUploadBufferDesc.m_UsageMask = BufferUsage::CopySrc;
-    textureUploadBufferDesc.m_MemoryUsage = MemoryUsage::CpuToGpu;
-    textureUploadBufferDesc.m_DebugName = "TexturedRotatingCube.TextureUploadBuffer";
-    m_TextureUploadBuffer = device.CreateBuffer(textureUploadBufferDesc);
-    device.WriteBuffer(m_TextureUploadBuffer.get(),
-                       0,
-                       loadedImage.m_Pixels.data(),
-                       static_cast<uint64_t>(loadedImage.m_Pixels.size()));
+    m_TextureUploadBuffer = RHIUpload::CreateUploadBuffer(device,
+                                                          loadedImage.m_Pixels.data(),
+                                                          static_cast<uint64_t>(loadedImage.m_Pixels.size()),
+                                                          "TexturedRotatingCube.TextureUploadBuffer");
     m_TextureUploadPending = true;
 
     m_ShaderProgram = device.CreateShaderProgram(DemoRenderUtils::CompileShaderProgramDesc(

--- a/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
+++ b/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
@@ -166,22 +166,22 @@ void TexturedRotatingCubeDemo::CreateCubeResources()
         12, 13, 14, 12, 14, 15, 16, 17, 18, 16, 18, 19, 20, 21, 22, 20, 22, 23,
     };
 
-    DemoRenderUtils::CreateStaticBufferPair(device,
-                                            kVertices.data(),
-                                            sizeof(kVertices),
-                                            BufferUsage::Vertex,
-                                            "TexturedRotatingCube.VertexBuffer",
-                                            "TexturedRotatingCube.VertexUploadBuffer",
-                                            m_VertexBuffer,
-                                            m_VertexUploadBuffer);
-    DemoRenderUtils::CreateStaticBufferPair(device,
-                                            kIndices.data(),
-                                            sizeof(kIndices),
-                                            BufferUsage::Index,
-                                            "TexturedRotatingCube.IndexBuffer",
-                                            "TexturedRotatingCube.IndexUploadBuffer",
-                                            m_IndexBuffer,
-                                            m_IndexUploadBuffer);
+    RHIUpload::CreateStaticBufferPair(device,
+                                      kVertices.data(),
+                                      sizeof(kVertices),
+                                      BufferUsage::Vertex,
+                                      "TexturedRotatingCube.VertexBuffer",
+                                      "TexturedRotatingCube.VertexUploadBuffer",
+                                      m_VertexBuffer,
+                                      m_VertexUploadBuffer);
+    RHIUpload::CreateStaticBufferPair(device,
+                                      kIndices.data(),
+                                      sizeof(kIndices),
+                                      BufferUsage::Index,
+                                      "TexturedRotatingCube.IndexBuffer",
+                                      "TexturedRotatingCube.IndexUploadBuffer",
+                                      m_IndexBuffer,
+                                      m_IndexUploadBuffer);
     m_GeometryUploadPending = true;
     CreateDepthResources();
 
@@ -296,18 +296,18 @@ void TexturedRotatingCubeDemo::UploadPendingResources(CommandList& commandList,
 #if defined(GLAB_BACKEND_VULKAN) || defined(GLAB_BACKEND_METAL)
     if (m_GeometryUploadPending)
     {
-        DemoRenderUtils::UploadStaticBufferPair(commandList,
-                                                resourceStateTracker,
-                                                m_VertexUploadBuffer.get(),
-                                                m_VertexBuffer.get(),
-                                                m_VertexBuffer->GetDesc().m_Size,
-                                                BufferState::VertexIndex);
-        DemoRenderUtils::UploadStaticBufferPair(commandList,
-                                                resourceStateTracker,
-                                                m_IndexUploadBuffer.get(),
-                                                m_IndexBuffer.get(),
-                                                m_IndexBuffer->GetDesc().m_Size,
-                                                BufferState::VertexIndex);
+        RHIUpload::UploadStaticBufferPair(commandList,
+                                          resourceStateTracker,
+                                          m_VertexUploadBuffer.get(),
+                                          m_VertexBuffer.get(),
+                                          m_VertexBuffer->GetDesc().m_Size,
+                                          BufferState::VertexIndex);
+        RHIUpload::UploadStaticBufferPair(commandList,
+                                          resourceStateTracker,
+                                          m_IndexUploadBuffer.get(),
+                                          m_IndexBuffer.get(),
+                                          m_IndexBuffer->GetDesc().m_Size,
+                                          BufferState::VertexIndex);
         m_GeometryUploadPending = false;
     }
 

--- a/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
+++ b/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
@@ -11,6 +11,7 @@
 #include "Core/Resource/FileSystem.h"
 #include "Core/Util/Math.h"
 #include "Demos/DemoRenderUtils.h"
+#include "Render/RHI/RHIUpload.h"
 #include "Render/Shader/ShaderParameterWriter.h"
 
 TexturedRotatingCubeDemo::TexturedRotatingCubeDemo(uint32_t width, uint32_t height)
@@ -318,27 +319,12 @@ void TexturedRotatingCubeDemo::UploadPendingResources(CommandList& commandList,
 
     if (m_TextureUploadPending)
     {
-        resourceStateTracker.Transition(m_TextureUploadBuffer.get(), BufferState::CopySource);
-        resourceStateTracker.Transition(m_Texture.get(), TextureState::CopyDest);
-        resourceStateTracker.FlushBarriers(&commandList);
-
-        const TextureDesc& textureDesc = m_Texture->GetDesc();
-        const BufferTextureCopyRegion copyRegion{
-            0,
-            textureDesc.m_Extent.m_Width * 4u,
-            textureDesc.m_Extent.m_Height,
-            TextureAspect::Color,
-            0,
-            0,
-            1,
-            {},
-            textureDesc.m_Extent,
-        };
-        commandList.CopyBufferToTexture(
-            m_TextureUploadBuffer.get(), m_Texture.get(), std::span<const BufferTextureCopyRegion>(&copyRegion, 1));
-
-        resourceStateTracker.Transition(m_Texture.get(), TextureState::ShaderRead);
-        resourceStateTracker.FlushBarriers(&commandList);
+        RHIUpload::UploadFullTexture(commandList,
+                                     resourceStateTracker,
+                                     m_TextureUploadBuffer.get(),
+                                     m_Texture.get(),
+                                     4u,
+                                     TextureState::ShaderRead);
         m_TextureUploadPending = false;
     }
 #endif

--- a/Src/Demos/DemoRenderUtils.cpp
+++ b/Src/Demos/DemoRenderUtils.cpp
@@ -7,6 +7,7 @@
 #include "Core/App/Application.h"
 #include "Core/Diagnostics/Assert/Assert.h"
 #include "Core/Resource/FileSystem.h"
+#include "Render/RHI/RHIUpload.h"
 
 namespace DemoRenderUtils
 {
@@ -86,23 +87,8 @@ void CreateStaticBufferPair(Device& device,
                             Scope<Buffer>& targetBuffer,
                             Scope<Buffer>& uploadBuffer)
 {
-    RTRLAB_ASSERT_MSG(data != nullptr, "Static demo buffer creation requires non-null source data.");
-    RTRLAB_ASSERT_MSG(size > 0, "Static demo buffer creation requires a non-zero byte size.");
-
-    BufferDesc targetDesc;
-    targetDesc.m_Size = size;
-    targetDesc.m_UsageMask = targetUsage | BufferUsage::CopyDst;
-    targetDesc.m_MemoryUsage = MemoryUsage::GpuOnly;
-    targetDesc.m_DebugName = targetDebugName;
-    targetBuffer = device.CreateBuffer(targetDesc);
-
-    BufferDesc uploadDesc;
-    uploadDesc.m_Size = size;
-    uploadDesc.m_UsageMask = BufferUsage::CopySrc;
-    uploadDesc.m_MemoryUsage = MemoryUsage::CpuToGpu;
-    uploadDesc.m_DebugName = uploadDebugName;
-    uploadBuffer = device.CreateBuffer(uploadDesc);
-    device.WriteBuffer(uploadBuffer.get(), 0, data, size);
+    RHIUpload::CreateStaticBufferPair(
+        device, data, size, targetUsage, targetDebugName, uploadDebugName, targetBuffer, uploadBuffer);
 }
 
 void UploadStaticBufferPair(CommandList& commandList,
@@ -112,19 +98,7 @@ void UploadStaticBufferPair(CommandList& commandList,
                             uint64_t size,
                             BufferState finalState)
 {
-    RTRLAB_ASSERT_MSG(uploadBuffer != nullptr && targetBuffer != nullptr,
-                      "Static demo buffer upload requires both upload and target buffers.");
-    RTRLAB_ASSERT_MSG(size > 0, "Static demo buffer upload requires a non-zero byte size.");
-
-    resourceStateTracker.Transition(uploadBuffer, BufferState::CopySource);
-    resourceStateTracker.Transition(targetBuffer, BufferState::CopyDest);
-    resourceStateTracker.FlushBarriers(&commandList);
-
-    const BufferCopyRegion copyRegion{0, 0, size};
-    commandList.CopyBuffer(uploadBuffer, targetBuffer, std::span<const BufferCopyRegion>(&copyRegion, 1));
-
-    resourceStateTracker.Transition(targetBuffer, finalState);
-    resourceStateTracker.FlushBarriers(&commandList);
+    RHIUpload::UploadStaticBufferPair(commandList, resourceStateTracker, uploadBuffer, targetBuffer, size, finalState);
 }
 
 LoadedImage LoadTextureFileRGBA8(const std::filesystem::path& texturePath, std::string_view debugOwner)

--- a/Src/Demos/DemoRenderUtils.cpp
+++ b/Src/Demos/DemoRenderUtils.cpp
@@ -7,7 +7,6 @@
 #include "Core/App/Application.h"
 #include "Core/Diagnostics/Assert/Assert.h"
 #include "Core/Resource/FileSystem.h"
-#include "Render/RHI/RHIUpload.h"
 
 namespace DemoRenderUtils
 {
@@ -76,29 +75,6 @@ CompiledShaderProgramDesc CompileShaderProgramDesc(const ShaderCompileRequest& r
                    debugOwner,
                    compileResult.m_ErrorMessage);
     return std::move(compileResult.m_Program);
-}
-
-void CreateStaticBufferPair(Device& device,
-                            const void* data,
-                            uint64_t size,
-                            BufferUsage targetUsage,
-                            const char* targetDebugName,
-                            const char* uploadDebugName,
-                            Scope<Buffer>& targetBuffer,
-                            Scope<Buffer>& uploadBuffer)
-{
-    RHIUpload::CreateStaticBufferPair(
-        device, data, size, targetUsage, targetDebugName, uploadDebugName, targetBuffer, uploadBuffer);
-}
-
-void UploadStaticBufferPair(CommandList& commandList,
-                            ResourceStateTracker& resourceStateTracker,
-                            Buffer* uploadBuffer,
-                            Buffer* targetBuffer,
-                            uint64_t size,
-                            BufferState finalState)
-{
-    RHIUpload::UploadStaticBufferPair(commandList, resourceStateTracker, uploadBuffer, targetBuffer, size, finalState);
 }
 
 LoadedImage LoadTextureFileRGBA8(const std::filesystem::path& texturePath, std::string_view debugOwner)

--- a/Src/Demos/DemoRenderUtils.h
+++ b/Src/Demos/DemoRenderUtils.h
@@ -52,21 +52,5 @@ FindRequiredSetIndex(const PipelineLayoutDesc& layoutDesc, std::string_view bind
 ShaderCompileRequest BuildGraphicsShaderCompileRequest(const std::filesystem::path& shaderPath);
 CompiledShaderProgramDesc CompileShaderProgramDesc(const ShaderCompileRequest& request, std::string_view debugOwner);
 
-void CreateStaticBufferPair(Device& device,
-                            const void* data,
-                            uint64_t size,
-                            BufferUsage targetUsage,
-                            const char* targetDebugName,
-                            const char* uploadDebugName,
-                            Scope<Buffer>& targetBuffer,
-                            Scope<Buffer>& uploadBuffer);
-
-void UploadStaticBufferPair(CommandList& commandList,
-                            ResourceStateTracker& resourceStateTracker,
-                            Buffer* uploadBuffer,
-                            Buffer* targetBuffer,
-                            uint64_t size,
-                            BufferState finalState);
-
 LoadedImage LoadTextureFileRGBA8(const std::filesystem::path& texturePath, std::string_view debugOwner);
 } // namespace DemoRenderUtils

--- a/Src/Render/RHI/RHIUpload.cpp
+++ b/Src/Render/RHI/RHIUpload.cpp
@@ -6,6 +6,21 @@
 
 namespace RHIUpload
 {
+Scope<Buffer> CreateUploadBuffer(Device& device, const void* data, uint64_t size, const char* debugName)
+{
+    RTRLAB_ASSERT_MSG(data != nullptr, "Upload buffer creation requires non-null source data.");
+    RTRLAB_ASSERT_MSG(size > 0, "Upload buffer creation requires a non-zero byte size.");
+
+    BufferDesc uploadDesc;
+    uploadDesc.m_Size = size;
+    uploadDesc.m_UsageMask = BufferUsage::CopySrc;
+    uploadDesc.m_MemoryUsage = MemoryUsage::CpuToGpu;
+    uploadDesc.m_DebugName = debugName;
+    Scope<Buffer> uploadBuffer = device.CreateBuffer(uploadDesc);
+    device.WriteBuffer(uploadBuffer.get(), 0, data, size);
+    return uploadBuffer;
+}
+
 void CreateStaticBufferPair(Device& device,
                             const void* data,
                             uint64_t size,
@@ -25,13 +40,7 @@ void CreateStaticBufferPair(Device& device,
     targetDesc.m_DebugName = targetDebugName;
     targetBuffer = device.CreateBuffer(targetDesc);
 
-    BufferDesc uploadDesc;
-    uploadDesc.m_Size = size;
-    uploadDesc.m_UsageMask = BufferUsage::CopySrc;
-    uploadDesc.m_MemoryUsage = MemoryUsage::CpuToGpu;
-    uploadDesc.m_DebugName = uploadDebugName;
-    uploadBuffer = device.CreateBuffer(uploadDesc);
-    device.WriteBuffer(uploadBuffer.get(), 0, data, size);
+    uploadBuffer = CreateUploadBuffer(device, data, size, uploadDebugName);
 }
 
 void UploadStaticBufferPair(CommandList& commandList,

--- a/Src/Render/RHI/RHIUpload.cpp
+++ b/Src/Render/RHI/RHIUpload.cpp
@@ -1,0 +1,58 @@
+#include "Render/RHI/RHIUpload.h"
+
+#include <span>
+
+#include "Core/Diagnostics/Assert/Assert.h"
+
+namespace RHIUpload
+{
+void CreateStaticBufferPair(Device& device,
+                            const void* data,
+                            uint64_t size,
+                            BufferUsage targetUsage,
+                            const char* targetDebugName,
+                            const char* uploadDebugName,
+                            Scope<Buffer>& targetBuffer,
+                            Scope<Buffer>& uploadBuffer)
+{
+    RTRLAB_ASSERT_MSG(data != nullptr, "Static buffer creation requires non-null source data.");
+    RTRLAB_ASSERT_MSG(size > 0, "Static buffer creation requires a non-zero byte size.");
+
+    BufferDesc targetDesc;
+    targetDesc.m_Size = size;
+    targetDesc.m_UsageMask = targetUsage | BufferUsage::CopyDst;
+    targetDesc.m_MemoryUsage = MemoryUsage::GpuOnly;
+    targetDesc.m_DebugName = targetDebugName;
+    targetBuffer = device.CreateBuffer(targetDesc);
+
+    BufferDesc uploadDesc;
+    uploadDesc.m_Size = size;
+    uploadDesc.m_UsageMask = BufferUsage::CopySrc;
+    uploadDesc.m_MemoryUsage = MemoryUsage::CpuToGpu;
+    uploadDesc.m_DebugName = uploadDebugName;
+    uploadBuffer = device.CreateBuffer(uploadDesc);
+    device.WriteBuffer(uploadBuffer.get(), 0, data, size);
+}
+
+void UploadStaticBufferPair(CommandList& commandList,
+                            ResourceStateTracker& resourceStateTracker,
+                            Buffer* uploadBuffer,
+                            Buffer* targetBuffer,
+                            uint64_t size,
+                            BufferState finalState)
+{
+    RTRLAB_ASSERT_MSG(uploadBuffer != nullptr && targetBuffer != nullptr,
+                      "Static buffer upload requires both upload and target buffers.");
+    RTRLAB_ASSERT_MSG(size > 0, "Static buffer upload requires a non-zero byte size.");
+
+    resourceStateTracker.Transition(uploadBuffer, BufferState::CopySource);
+    resourceStateTracker.Transition(targetBuffer, BufferState::CopyDest);
+    resourceStateTracker.FlushBarriers(&commandList);
+
+    const BufferCopyRegion copyRegion{0, 0, size};
+    commandList.CopyBuffer(uploadBuffer, targetBuffer, std::span<const BufferCopyRegion>(&copyRegion, 1));
+
+    resourceStateTracker.Transition(targetBuffer, finalState);
+    resourceStateTracker.FlushBarriers(&commandList);
+}
+} // namespace RHIUpload

--- a/Src/Render/RHI/RHIUpload.cpp
+++ b/Src/Render/RHI/RHIUpload.cpp
@@ -55,4 +55,42 @@ void UploadStaticBufferPair(CommandList& commandList,
     resourceStateTracker.Transition(targetBuffer, finalState);
     resourceStateTracker.FlushBarriers(&commandList);
 }
+
+void UploadFullTexture(CommandList& commandList,
+                       ResourceStateTracker& resourceStateTracker,
+                       Buffer* uploadBuffer,
+                       Texture* targetTexture,
+                       uint32_t bytesPerPixel,
+                       TextureState finalState)
+{
+    RTRLAB_ASSERT_MSG(uploadBuffer != nullptr && targetTexture != nullptr,
+                      "Texture upload requires both upload buffer and target texture.");
+    RTRLAB_ASSERT_MSG(bytesPerPixel > 0, "Texture upload requires a non-zero byte stride per pixel.");
+
+    const TextureDesc& textureDesc = targetTexture->GetDesc();
+    RTRLAB_ASSERT_MSG(textureDesc.m_Extent.m_Width > 0 && textureDesc.m_Extent.m_Height > 0 &&
+                          textureDesc.m_Extent.m_Depth > 0,
+                      "Texture upload requires a non-zero target texture extent.");
+
+    resourceStateTracker.Transition(uploadBuffer, BufferState::CopySource);
+    resourceStateTracker.Transition(targetTexture, TextureState::CopyDest);
+    resourceStateTracker.FlushBarriers(&commandList);
+
+    const BufferTextureCopyRegion copyRegion{
+        0,
+        textureDesc.m_Extent.m_Width * bytesPerPixel,
+        textureDesc.m_Extent.m_Height,
+        TextureAspect::Color,
+        0,
+        0,
+        1,
+        {},
+        textureDesc.m_Extent,
+    };
+    commandList.CopyBufferToTexture(
+        uploadBuffer, targetTexture, std::span<const BufferTextureCopyRegion>(&copyRegion, 1));
+
+    resourceStateTracker.Transition(targetTexture, finalState);
+    resourceStateTracker.FlushBarriers(&commandList);
+}
 } // namespace RHIUpload

--- a/Src/Render/RHI/RHIUpload.h
+++ b/Src/Render/RHI/RHIUpload.h
@@ -25,4 +25,11 @@ void UploadStaticBufferPair(CommandList& commandList,
                             Buffer* targetBuffer,
                             uint64_t size,
                             BufferState finalState);
+
+void UploadFullTexture(CommandList& commandList,
+                       ResourceStateTracker& resourceStateTracker,
+                       Buffer* uploadBuffer,
+                       Texture* targetTexture,
+                       uint32_t bytesPerPixel,
+                       TextureState finalState);
 } // namespace RHIUpload

--- a/Src/Render/RHI/RHIUpload.h
+++ b/Src/Render/RHI/RHIUpload.h
@@ -10,6 +10,8 @@
 
 namespace RHIUpload
 {
+Scope<Buffer> CreateUploadBuffer(Device& device, const void* data, uint64_t size, const char* debugName);
+
 void CreateStaticBufferPair(Device& device,
                             const void* data,
                             uint64_t size,

--- a/Src/Render/RHI/RHIUpload.h
+++ b/Src/Render/RHI/RHIUpload.h
@@ -1,0 +1,28 @@
+#pragma once
+
+/// @file RHIUpload.h
+/// @brief Small explicit-upload helpers shared by early renderer and demo paths.
+
+#include <cstdint>
+
+#include "Core/Util/Base.h"
+#include "Render/RHI/RHI.h"
+
+namespace RHIUpload
+{
+void CreateStaticBufferPair(Device& device,
+                            const void* data,
+                            uint64_t size,
+                            BufferUsage targetUsage,
+                            const char* targetDebugName,
+                            const char* uploadDebugName,
+                            Scope<Buffer>& targetBuffer,
+                            Scope<Buffer>& uploadBuffer);
+
+void UploadStaticBufferPair(CommandList& commandList,
+                            ResourceStateTracker& resourceStateTracker,
+                            Buffer* uploadBuffer,
+                            Buffer* targetBuffer,
+                            uint64_t size,
+                            BufferState finalState);
+} // namespace RHIUpload


### PR DESCRIPTION
## Summary
- Added `RHIUpload` as a reusable RHI-side upload helper module.
- Moved static buffer upload pair creation/upload logic out of demo utilities.
- Added shared helpers for upload buffer creation and full texture upload.
- Updated demos to call `RHIUpload` directly for geometry and texture uploads.
- Removed obsolete upload wrapper APIs from `DemoRenderUtils`.

## Why
- Demo code had repeated upload setup logic for buffers and textures.
- Upload behavior belongs closer to RHI infrastructure than demo utility code.
- This keeps `DemoRenderUtils` focused on demo-facing helpers instead of resource transfer mechanics.

## Affected areas
- `Src/Render/RHI/RHIUpload.h`
- `Src/Render/RHI/RHIUpload.cpp`
- `CMake/Src/Sources.cmake`
- Demo upload call sites in triangle, quad, textured quad, rotating cube, and textured rotating cube demos
- `Src/Demos/DemoRenderUtils.h`
- `Src/Demos/DemoRenderUtils.cpp`

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Not run; per workflow, compile/runtime validation is left for manual local verification.

## Notes
- This PR intentionally stops at upload infrastructure.
- Texture/view/sampler construction cleanup should be handled separately as the next part, since that is resource creation policy rather than upload behavior.