### PR TITLE
Clean up demo texture resource construction

### DIFF
--- a/Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp
+++ b/Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp
@@ -143,21 +143,13 @@ void TexturedQuadDemo::CreateTexturedQuadResources()
     const DemoRenderUtils::LoadedImage loadedImage =
         DemoRenderUtils::LoadTextureFileRGBA8(texturePath, "TexturedQuadDemo");
 
-    TextureDesc textureDesc;
-    textureDesc.m_Type = TextureType::Tex2D;
-    textureDesc.m_Format = Format::RGBA8_UNORM;
-    textureDesc.m_Extent = {loadedImage.m_Width, loadedImage.m_Height, 1};
-    textureDesc.m_MipLevels = 1;
-    textureDesc.m_ArrayLayers = 1;
-    textureDesc.m_UsageMask = TextureUsage::Sampled | TextureUsage::CopyDst;
-    textureDesc.m_DebugName = "TexturedQuadDemo.ColorTexture";
-    m_Texture = device.CreateTexture(textureDesc);
-
-    TextureViewDesc textureViewDesc;
-    textureViewDesc.m_Type = TextureType::Tex2D;
-    textureViewDesc.m_Format = textureDesc.m_Format;
-    textureViewDesc.m_Aspect = TextureAspect::Color;
-    m_TextureView = device.CreateTextureView(m_Texture.get(), textureViewDesc);
+    DemoRenderUtils::CreateRGBA8Texture2DWithView(device,
+                                                  loadedImage.m_Width,
+                                                  loadedImage.m_Height,
+                                                  "TexturedQuadDemo.ColorTexture",
+                                                  "TexturedQuadDemo.ColorTextureView",
+                                                  m_Texture,
+                                                  m_TextureView);
 
     SamplerDesc samplerDesc;
     samplerDesc.m_MinFilter = FilterMode::Linear;

--- a/Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp
+++ b/Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp
@@ -111,6 +111,7 @@ void TexturedQuadDemo::CreateTexturedQuadResources()
 #if defined(GLAB_BACKEND_VULKAN) || defined(GLAB_BACKEND_METAL)
     Application& app = Application::Get();
     Device& device = app.GetDevice();
+    const std::filesystem::path rootPath = FileSystem::GetRootPath();
 
     using DemoRenderUtils::TexturedVertex;
     static const std::array<TexturedVertex, 4> kVertices = {{
@@ -139,13 +140,13 @@ void TexturedQuadDemo::CreateTexturedQuadResources()
                                       m_IndexUploadBuffer);
     m_GeometryUploadPending = true;
 
-    const std::filesystem::path texturePath = FileSystem::GetRootPath() / "Project" / "Textures" / "Grassy_Square.jpg";
-    const DemoRenderUtils::LoadedImage loadedImage =
+    const std::filesystem::path texturePath = rootPath / "Project" / "Textures" / "Grassy_Square.jpg";
+    const DemoRenderUtils::LoadedImage textureImage =
         DemoRenderUtils::LoadTextureFileRGBA8(texturePath, "TexturedQuadDemo");
 
     DemoRenderUtils::CreateRGBA8Texture2DWithView(device,
-                                                  loadedImage.m_Width,
-                                                  loadedImage.m_Height,
+                                                  textureImage.m_Width,
+                                                  textureImage.m_Height,
                                                   "TexturedQuadDemo.ColorTexture",
                                                   "TexturedQuadDemo.ColorTextureView",
                                                   m_Texture,
@@ -154,15 +155,14 @@ void TexturedQuadDemo::CreateTexturedQuadResources()
     m_Sampler = DemoRenderUtils::CreateLinearRepeatSampler(device, "TexturedQuadDemo.LinearRepeatSampler");
 
     m_TextureUploadBuffer = RHIUpload::CreateUploadBuffer(device,
-                                                          loadedImage.m_Pixels.data(),
-                                                          static_cast<uint64_t>(loadedImage.m_Pixels.size()),
+                                                          textureImage.m_Pixels.data(),
+                                                          static_cast<uint64_t>(textureImage.m_Pixels.size()),
                                                           "TexturedQuadDemo.TextureUploadBuffer");
     m_TextureUploadPending = true;
 
+    const std::filesystem::path shaderPath = rootPath / "Project" / "Shaders" / "DemoTextured.slang";
     m_ShaderProgram = device.CreateShaderProgram(DemoRenderUtils::CompileShaderProgramDesc(
-        DemoRenderUtils::BuildGraphicsShaderCompileRequest(FileSystem::GetRootPath() / "Project" / "Shaders" /
-                                                           "DemoTextured.slang"),
-        "TexturedQuadDemo"));
+        DemoRenderUtils::BuildGraphicsShaderCompileRequest(shaderPath), "TexturedQuadDemo"));
     m_PipelineLayout = device.CreatePipelineLayout(m_ShaderProgram->DerivePipelineLayoutDesc());
     const PipelineLayoutDesc& pipelineLayoutDesc = m_PipelineLayout->GetDesc();
     m_FrameSetIndex = DemoRenderUtils::FindRequiredSetIndex(pipelineLayoutDesc, "gFrame", "TexturedQuadDemo");

--- a/Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp
+++ b/Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp
@@ -151,14 +151,7 @@ void TexturedQuadDemo::CreateTexturedQuadResources()
                                                   m_Texture,
                                                   m_TextureView);
 
-    SamplerDesc samplerDesc;
-    samplerDesc.m_MinFilter = FilterMode::Linear;
-    samplerDesc.m_MagFilter = FilterMode::Linear;
-    samplerDesc.m_MipFilter = MipFilterMode::Linear;
-    samplerDesc.m_AddressU = AddressMode::Repeat;
-    samplerDesc.m_AddressV = AddressMode::Repeat;
-    samplerDesc.m_AddressW = AddressMode::Repeat;
-    m_Sampler = device.CreateSampler(samplerDesc);
+    m_Sampler = DemoRenderUtils::CreateLinearRepeatSampler(device, "TexturedQuadDemo.LinearRepeatSampler");
 
     m_TextureUploadBuffer = RHIUpload::CreateUploadBuffer(device,
                                                           loadedImage.m_Pixels.data(),

--- a/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
+++ b/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
@@ -197,14 +197,7 @@ void TexturedRotatingCubeDemo::CreateCubeResources()
                                                   m_Texture,
                                                   m_TextureView);
 
-    SamplerDesc samplerDesc;
-    samplerDesc.m_MinFilter = FilterMode::Linear;
-    samplerDesc.m_MagFilter = FilterMode::Linear;
-    samplerDesc.m_MipFilter = MipFilterMode::Linear;
-    samplerDesc.m_AddressU = AddressMode::Repeat;
-    samplerDesc.m_AddressV = AddressMode::Repeat;
-    samplerDesc.m_AddressW = AddressMode::Repeat;
-    m_Sampler = device.CreateSampler(samplerDesc);
+    m_Sampler = DemoRenderUtils::CreateLinearRepeatSampler(device, "TexturedRotatingCube.LinearRepeatSampler");
 
     m_TextureUploadBuffer = RHIUpload::CreateUploadBuffer(device,
                                                           loadedImage.m_Pixels.data(),

--- a/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
+++ b/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
@@ -140,6 +140,7 @@ void TexturedRotatingCubeDemo::CreateCubeResources()
 #if defined(GLAB_BACKEND_VULKAN) || defined(GLAB_BACKEND_METAL)
     Application& app = Application::Get();
     Device& device = app.GetDevice();
+    const std::filesystem::path rootPath = FileSystem::GetRootPath();
 
     using DemoRenderUtils::TexturedVertex;
     static const std::array<TexturedVertex, 24> kVertices = {{
@@ -183,15 +184,14 @@ void TexturedRotatingCubeDemo::CreateCubeResources()
                                       m_IndexBuffer,
                                       m_IndexUploadBuffer);
     m_GeometryUploadPending = true;
-    CreateDepthResources();
 
-    const std::filesystem::path texturePath = FileSystem::GetRootPath() / "Project" / "Textures" / "Grassy_Square.jpg";
-    const DemoRenderUtils::LoadedImage loadedImage =
+    const std::filesystem::path texturePath = rootPath / "Project" / "Textures" / "Grassy_Square.jpg";
+    const DemoRenderUtils::LoadedImage textureImage =
         DemoRenderUtils::LoadTextureFileRGBA8(texturePath, "TexturedRotatingCube");
 
     DemoRenderUtils::CreateRGBA8Texture2DWithView(device,
-                                                  loadedImage.m_Width,
-                                                  loadedImage.m_Height,
+                                                  textureImage.m_Width,
+                                                  textureImage.m_Height,
                                                   "TexturedRotatingCube.ColorTexture",
                                                   "TexturedRotatingCube.ColorTextureView",
                                                   m_Texture,
@@ -200,15 +200,16 @@ void TexturedRotatingCubeDemo::CreateCubeResources()
     m_Sampler = DemoRenderUtils::CreateLinearRepeatSampler(device, "TexturedRotatingCube.LinearRepeatSampler");
 
     m_TextureUploadBuffer = RHIUpload::CreateUploadBuffer(device,
-                                                          loadedImage.m_Pixels.data(),
-                                                          static_cast<uint64_t>(loadedImage.m_Pixels.size()),
+                                                          textureImage.m_Pixels.data(),
+                                                          static_cast<uint64_t>(textureImage.m_Pixels.size()),
                                                           "TexturedRotatingCube.TextureUploadBuffer");
     m_TextureUploadPending = true;
 
+    CreateDepthResources();
+
+    const std::filesystem::path shaderPath = rootPath / "Project" / "Shaders" / "DemoTextured.slang";
     m_ShaderProgram = device.CreateShaderProgram(DemoRenderUtils::CompileShaderProgramDesc(
-        DemoRenderUtils::BuildGraphicsShaderCompileRequest(FileSystem::GetRootPath() / "Project" / "Shaders" /
-                                                           "DemoTextured.slang"),
-        "TexturedRotatingCube"));
+        DemoRenderUtils::BuildGraphicsShaderCompileRequest(shaderPath), "TexturedRotatingCube"));
     m_PipelineLayout = device.CreatePipelineLayout(m_ShaderProgram->DerivePipelineLayoutDesc());
     const PipelineLayoutDesc& pipelineLayoutDesc = m_PipelineLayout->GetDesc();
     m_FrameSetIndex = DemoRenderUtils::FindRequiredSetIndex(pipelineLayoutDesc, "gFrame", "TexturedRotatingCube");

--- a/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
+++ b/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
@@ -189,21 +189,13 @@ void TexturedRotatingCubeDemo::CreateCubeResources()
     const DemoRenderUtils::LoadedImage loadedImage =
         DemoRenderUtils::LoadTextureFileRGBA8(texturePath, "TexturedRotatingCube");
 
-    TextureDesc textureDesc;
-    textureDesc.m_Type = TextureType::Tex2D;
-    textureDesc.m_Format = Format::RGBA8_UNORM;
-    textureDesc.m_Extent = {loadedImage.m_Width, loadedImage.m_Height, 1};
-    textureDesc.m_MipLevels = 1;
-    textureDesc.m_ArrayLayers = 1;
-    textureDesc.m_UsageMask = TextureUsage::Sampled | TextureUsage::CopyDst;
-    textureDesc.m_DebugName = "TexturedRotatingCube.ColorTexture";
-    m_Texture = device.CreateTexture(textureDesc);
-
-    TextureViewDesc textureViewDesc;
-    textureViewDesc.m_Type = TextureType::Tex2D;
-    textureViewDesc.m_Format = textureDesc.m_Format;
-    textureViewDesc.m_Aspect = TextureAspect::Color;
-    m_TextureView = device.CreateTextureView(m_Texture.get(), textureViewDesc);
+    DemoRenderUtils::CreateRGBA8Texture2DWithView(device,
+                                                  loadedImage.m_Width,
+                                                  loadedImage.m_Height,
+                                                  "TexturedRotatingCube.ColorTexture",
+                                                  "TexturedRotatingCube.ColorTextureView",
+                                                  m_Texture,
+                                                  m_TextureView);
 
     SamplerDesc samplerDesc;
     samplerDesc.m_MinFilter = FilterMode::Linear;

--- a/Src/Demos/DemoRenderUtils.cpp
+++ b/Src/Demos/DemoRenderUtils.cpp
@@ -98,4 +98,31 @@ LoadedImage LoadTextureFileRGBA8(const std::filesystem::path& texturePath, std::
     stbi_image_free(pixels);
     return image;
 }
+
+void CreateRGBA8Texture2DWithView(Device& device,
+                                  uint32_t width,
+                                  uint32_t height,
+                                  const char* textureDebugName,
+                                  const char* viewDebugName,
+                                  Scope<Texture>& texture,
+                                  Scope<TextureView>& textureView)
+{
+    (void)viewDebugName;
+
+    TextureDesc textureDesc;
+    textureDesc.m_Type = TextureType::Tex2D;
+    textureDesc.m_Format = Format::RGBA8_UNORM;
+    textureDesc.m_Extent = {width, height, 1};
+    textureDesc.m_MipLevels = 1;
+    textureDesc.m_ArrayLayers = 1;
+    textureDesc.m_UsageMask = TextureUsage::Sampled | TextureUsage::CopyDst;
+    textureDesc.m_DebugName = textureDebugName;
+    texture = device.CreateTexture(textureDesc);
+
+    TextureViewDesc textureViewDesc;
+    textureViewDesc.m_Type = TextureType::Tex2D;
+    textureViewDesc.m_Format = textureDesc.m_Format;
+    textureViewDesc.m_Aspect = TextureAspect::Color;
+    textureView = device.CreateTextureView(texture.get(), textureViewDesc);
+}
 } // namespace DemoRenderUtils

--- a/Src/Demos/DemoRenderUtils.cpp
+++ b/Src/Demos/DemoRenderUtils.cpp
@@ -125,4 +125,18 @@ void CreateRGBA8Texture2DWithView(Device& device,
     textureViewDesc.m_Aspect = TextureAspect::Color;
     textureView = device.CreateTextureView(texture.get(), textureViewDesc);
 }
+
+Scope<Sampler> CreateLinearRepeatSampler(Device& device, const char* debugName)
+{
+    (void)debugName;
+
+    SamplerDesc samplerDesc;
+    samplerDesc.m_MinFilter = FilterMode::Linear;
+    samplerDesc.m_MagFilter = FilterMode::Linear;
+    samplerDesc.m_MipFilter = MipFilterMode::Linear;
+    samplerDesc.m_AddressU = AddressMode::Repeat;
+    samplerDesc.m_AddressV = AddressMode::Repeat;
+    samplerDesc.m_AddressW = AddressMode::Repeat;
+    return device.CreateSampler(samplerDesc);
+}
 } // namespace DemoRenderUtils

--- a/Src/Demos/DemoRenderUtils.h
+++ b/Src/Demos/DemoRenderUtils.h
@@ -61,4 +61,5 @@ void CreateRGBA8Texture2DWithView(Device& device,
                                   const char* viewDebugName,
                                   Scope<Texture>& texture,
                                   Scope<TextureView>& textureView);
+Scope<Sampler> CreateLinearRepeatSampler(Device& device, const char* debugName);
 } // namespace DemoRenderUtils

--- a/Src/Demos/DemoRenderUtils.h
+++ b/Src/Demos/DemoRenderUtils.h
@@ -53,4 +53,12 @@ ShaderCompileRequest BuildGraphicsShaderCompileRequest(const std::filesystem::pa
 CompiledShaderProgramDesc CompileShaderProgramDesc(const ShaderCompileRequest& request, std::string_view debugOwner);
 
 LoadedImage LoadTextureFileRGBA8(const std::filesystem::path& texturePath, std::string_view debugOwner);
+
+void CreateRGBA8Texture2DWithView(Device& device,
+                                  uint32_t width,
+                                  uint32_t height,
+                                  const char* textureDebugName,
+                                  const char* viewDebugName,
+                                  Scope<Texture>& texture,
+                                  Scope<TextureView>& textureView);
 } // namespace DemoRenderUtils


### PR DESCRIPTION
## Summary
- Added demo helpers for creating RGBA8 2D textures with color views and linear repeat samplers.
- Updated textured quad and textured rotating cube demos to share texture/view and sampler setup.
- Simplified textured demo initialization flow around image loading, texture creation, upload buffer creation, and shader path setup.

## Why
- The textured demos repeated the same texture/view and sampler descriptor setup.
- Keeping these helpers in `DemoRenderUtils` makes the demo resource policy explicit without expanding `RHIUpload` beyond upload mechanics.
- The textured demo setup now reads more like the resource workflow it performs.

## Affected areas
- `Src/Demos/DemoRenderUtils.h`
- `Src/Demos/DemoRenderUtils.cpp`
- `Src/Demos/04_TexturedQuad/TexturedQuadDemo.cpp`
- `Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp`

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Not run; per workflow, compile/runtime validation is left for manual local verification.

## Notes
- This PR intentionally keeps texture/view/sampler construction in demo-facing helpers rather than upload infrastructure.
- `TextureViewDesc` and `SamplerDesc` currently do not expose debug names, so the helper debug-name parameters are reserved for call-site clarity.