### PR TITLE
Add minimal forward renderer layer

### DIFF
--- a/CMake/Src/Sources.cmake
+++ b/CMake/Src/Sources.cmake
@@ -192,6 +192,10 @@ set(GLAB_RENDER_HEADERS
     Render/RHI/RHIDevice.h
     Render/RHI/RHIUpload.h
     Render/RHI/Backends/Common/RHIShellCommon.h
+    Render/Renderer/FrameGlobals.h
+    Render/Renderer/Material.h
+    Render/Renderer/Mesh.h
+    Render/Renderer/RenderObject.h
     Render/Shader/ShaderCompiler.h
     Render/Shader/ShaderReflection.h
     Render/Shader/SlangCompiler.h

--- a/CMake/Src/Sources.cmake
+++ b/CMake/Src/Sources.cmake
@@ -174,6 +174,7 @@ set(GLAB_RENDER_SOURCES
     Render/RHI/RHIUpload.cpp
     Render/RHI/ResourceStateTracker.cpp
     Render/RHI/Backends/Common/RHIShellCommon.cpp
+    Render/Renderer/ForwardRenderer.cpp
     Render/Shader/ShaderCompiler.cpp
     Render/Shader/ShaderReflection.cpp
     Render/Shader/SlangCompiler.cpp
@@ -192,6 +193,7 @@ set(GLAB_RENDER_HEADERS
     Render/RHI/RHIDevice.h
     Render/RHI/RHIUpload.h
     Render/RHI/Backends/Common/RHIShellCommon.h
+    Render/Renderer/ForwardRenderer.h
     Render/Renderer/FrameGlobals.h
     Render/Renderer/Material.h
     Render/Renderer/Mesh.h

--- a/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
+++ b/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp
@@ -12,7 +12,6 @@
 #include "Core/Util/Math.h"
 #include "Demos/DemoRenderUtils.h"
 #include "Render/RHI/RHIUpload.h"
-#include "Render/Shader/ShaderParameterWriter.h"
 
 TexturedRotatingCubeDemo::TexturedRotatingCubeDemo(uint32_t width, uint32_t height)
     : m_ViewportWidth(width), m_ViewportHeight(height)
@@ -28,13 +27,12 @@ void TexturedRotatingCubeDemo::OnAttach()
 void TexturedRotatingCubeDemo::OnDetach()
 {
     ForgetTrackedResources();
-    m_GraphicsPipeline.reset();
-    m_VertexInputLayout.reset();
     m_ObjectSet.reset();
     m_MaterialSet.reset();
-    m_FrameSet.reset();
-    m_PipelineLayout.reset();
-    m_ShaderProgram.reset();
+    m_Renderer.Reset();
+    m_RenderObject = {};
+    m_Material = {};
+    m_Mesh = {};
     m_DepthView.reset();
     m_DepthTexture.reset();
     m_Sampler.reset();
@@ -58,7 +56,8 @@ void TexturedRotatingCubeDemo::OnUpdate(double dt)
 void TexturedRotatingCubeDemo::OnRender()
 {
 #if defined(GLAB_BACKEND_VULKAN) || defined(GLAB_BACKEND_METAL)
-    if (!m_GraphicsPipeline || !m_VertexBuffer || !m_IndexBuffer || !m_DepthView || !m_MaterialSet)
+    if (!m_Renderer.IsInitialized() || !m_VertexBuffer || !m_IndexBuffer || !m_DepthView ||
+        m_RenderObject.m_Mesh == nullptr || m_RenderObject.m_Material == nullptr)
         return;
 
     Application& app = Application::Get();
@@ -98,17 +97,7 @@ void TexturedRotatingCubeDemo::OnRender()
     commandList->SetViewport(
         0.0f, 0.0f, static_cast<float>(m_ViewportWidth), static_cast<float>(m_ViewportHeight), 0.0f, 1.0f);
     commandList->SetScissor(0, 0, m_ViewportWidth, m_ViewportHeight);
-    commandList->BindGraphicsPipeline(m_GraphicsPipeline.get());
-    commandList->BindResourceSet(m_FrameSetIndex, m_FrameSet.get());
-    commandList->BindResourceSet(m_MaterialSetIndex, m_MaterialSet.get());
-    commandList->BindResourceSet(m_ObjectSetIndex, m_ObjectSet.get());
-
-    MeshBinding meshBinding;
-    meshBinding.m_VertexBuffers = {m_VertexBuffer.get()};
-    meshBinding.m_IndexBuffer = m_IndexBuffer.get();
-    meshBinding.m_IndexType = IndexType::UInt16;
-    commandList->BindMesh(meshBinding);
-    commandList->DrawIndexed(36, 0, 0);
+    m_Renderer.DrawObject(*commandList, m_RenderObject);
     commandList->EndRendering();
 #endif
 }
@@ -122,12 +111,9 @@ void TexturedRotatingCubeDemo::OnResize(uint32_t width, uint32_t height)
     m_ViewportHeight = height;
 
 #if defined(GLAB_BACKEND_VULKAN) || defined(GLAB_BACKEND_METAL)
-    if (m_FrameSet != nullptr)
+    if (m_Renderer.GetFrameSet() != nullptr)
     {
-        ShaderParameterWriter parameterWriter(m_ShaderProgram->GetReflection());
-        parameterWriter.SetMatrix4x4(*m_FrameSet,
-                                     "gFrame.viewProj",
-                                     DemoRenderUtils::BuildOrbitViewProjection(m_ViewportWidth, m_ViewportHeight));
+        UpdateShaderParameters();
     }
 
     if (m_DepthTexture != nullptr)
@@ -208,42 +194,33 @@ void TexturedRotatingCubeDemo::CreateCubeResources()
     CreateDepthResources();
 
     const std::filesystem::path shaderPath = rootPath / "Project" / "Shaders" / "DemoTextured.slang";
-    m_ShaderProgram = device.CreateShaderProgram(DemoRenderUtils::CompileShaderProgramDesc(
-        DemoRenderUtils::BuildGraphicsShaderCompileRequest(shaderPath), "TexturedRotatingCube"));
-    m_PipelineLayout = device.CreatePipelineLayout(m_ShaderProgram->DerivePipelineLayoutDesc());
-    const PipelineLayoutDesc& pipelineLayoutDesc = m_PipelineLayout->GetDesc();
-    m_FrameSetIndex = DemoRenderUtils::FindRequiredSetIndex(pipelineLayoutDesc, "gFrame", "TexturedRotatingCube");
-    m_MaterialSetIndex = DemoRenderUtils::FindRequiredSetIndex(pipelineLayoutDesc, "gMaterial", "TexturedRotatingCube");
-    m_ObjectSetIndex = DemoRenderUtils::FindRequiredSetIndex(pipelineLayoutDesc, "gObject", "TexturedRotatingCube");
+    Renderer::ForwardRendererDesc rendererDesc;
+    rendererDesc.m_ShaderPath = shaderPath;
+    rendererDesc.m_ColorFormat = app.GetSwapchain().GetFormat();
+    rendererDesc.m_DepthFormat = Format::D32_SFLOAT;
+    rendererDesc.m_VertexStride = static_cast<uint32_t>(sizeof(TexturedVertex));
+    rendererDesc.m_PositionOffset = static_cast<uint32_t>(offsetof(TexturedVertex, m_Position));
+    rendererDesc.m_UVOffset = static_cast<uint32_t>(offsetof(TexturedVertex, m_UV));
+    rendererDesc.m_DebugName = "TexturedRotatingCube";
+    m_Renderer.Initialize(device, rendererDesc);
 
-    m_FrameSet = device.CreateResourceSet(m_PipelineLayout.get(), m_FrameSetIndex);
-    m_MaterialSet = device.CreateResourceSet(m_PipelineLayout.get(), m_MaterialSetIndex);
-    m_ObjectSet = device.CreateResourceSet(m_PipelineLayout.get(), m_ObjectSetIndex);
+    m_MaterialSet = m_Renderer.CreateMaterialSet(device);
+    m_ObjectSet = m_Renderer.CreateObjectSet(device);
+
+    m_Mesh.m_VertexBuffer = m_VertexBuffer.get();
+    m_Mesh.m_IndexBuffer = m_IndexBuffer.get();
+    m_Mesh.m_IndexType = IndexType::UInt16;
+    m_Mesh.m_IndexCount = 36;
+
+    m_Material.m_BaseColor = Math::Vec4(1.0f, 1.0f, 1.0f, 1.0f);
+    m_Material.m_AlbedoTextureView = m_TextureView.get();
+    m_Material.m_AlbedoSampler = m_Sampler.get();
+    m_Material.m_ResourceSet = m_MaterialSet.get();
+
+    m_RenderObject.m_Mesh = &m_Mesh;
+    m_RenderObject.m_Material = &m_Material;
+    m_RenderObject.m_ObjectSet = m_ObjectSet.get();
     UpdateShaderParameters();
-
-    ShaderParameterWriter parameterWriter(m_ShaderProgram->GetReflection());
-    parameterWriter.SetTextureView(*m_MaterialSet, "gAlbedoTexture", m_TextureView.get());
-    parameterWriter.SetSampler(*m_MaterialSet, "gAlbedoSampler", m_Sampler.get());
-
-    VertexInputLayoutDesc vertexInputLayoutDesc;
-    vertexInputLayoutDesc.m_Buffers = {{static_cast<uint32_t>(sizeof(TexturedVertex)), false}};
-    vertexInputLayoutDesc.m_Attributes = {
-        {0u, Format::RGBA32F, static_cast<uint32_t>(offsetof(TexturedVertex, m_Position)), 0u},
-        {1u, Format::RG32F, static_cast<uint32_t>(offsetof(TexturedVertex, m_UV)), 0u},
-    };
-    m_VertexInputLayout = device.CreateVertexInputLayout(vertexInputLayoutDesc);
-
-    GraphicsPipelineDesc pipelineDesc;
-    pipelineDesc.m_PipelineLayout = m_PipelineLayout.get();
-    pipelineDesc.m_ShaderProgram = m_ShaderProgram.get();
-    pipelineDesc.m_VertexInput = m_VertexInputLayout.get();
-    pipelineDesc.m_RasterState.m_CullMode = CullMode::None;
-    pipelineDesc.m_DepthStencilState.m_DepthTestEnable = true;
-    pipelineDesc.m_DepthStencilState.m_DepthWriteEnable = true;
-    pipelineDesc.m_DepthStencilState.m_DepthCompareOp = CompareOp::Less;
-    pipelineDesc.m_ColorFormats = {app.GetSwapchain().GetFormat()};
-    pipelineDesc.m_DepthFormat = Format::D32_SFLOAT;
-    m_GraphicsPipeline = device.CreateGraphicsPipeline(pipelineDesc);
 #endif
 }
 
@@ -313,21 +290,23 @@ void TexturedRotatingCubeDemo::UploadPendingResources(CommandList& commandList,
 void TexturedRotatingCubeDemo::UpdateShaderParameters()
 {
 #if defined(GLAB_BACKEND_VULKAN) || defined(GLAB_BACKEND_METAL)
-    RTRLAB_ASSERT_MSG(m_ShaderProgram != nullptr && m_FrameSet != nullptr && m_MaterialSet != nullptr &&
-                          m_ObjectSet != nullptr,
+    RTRLAB_ASSERT_MSG(m_Renderer.IsInitialized() && m_RenderObject.m_Mesh != nullptr &&
+                          m_RenderObject.m_Material != nullptr && m_RenderObject.m_ObjectSet != nullptr,
                       "TexturedRotatingCube parameter updates require initialized shader resources.");
 
     const Math::Mat4 model =
         Math::Rotate(Math::Mat4::Identity(), m_RotationSeconds * 1.15f, Math::Vec3(0.0f, 1.0f, 0.0f)) *
         Math::Rotate(Math::Mat4::Identity(), m_RotationSeconds * 0.70f, Math::Vec3(1.0f, 0.0f, 0.0f));
 
-    ShaderParameterWriter parameterWriter(m_ShaderProgram->GetReflection());
-    parameterWriter.SetMatrix4x4(
-        *m_FrameSet, "gFrame.viewProj", DemoRenderUtils::BuildOrbitViewProjection(m_ViewportWidth, m_ViewportHeight));
-    parameterWriter.SetFloat4(*m_FrameSet, "gFrame.tint", Math::Vec4(1.0f, 1.0f, 1.0f, 1.0f));
-    parameterWriter.SetFloat(*m_FrameSet, "gFrame.time", m_RotationSeconds);
-    parameterWriter.SetFloat4(*m_MaterialSet, "gMaterial.baseColor", Math::Vec4(1.0f, 1.0f, 1.0f, 1.0f));
-    parameterWriter.SetMatrix4x4(*m_ObjectSet, "gObject.model", model);
+    Renderer::FrameGlobals frameGlobals;
+    frameGlobals.m_ViewProjection = DemoRenderUtils::BuildOrbitViewProjection(m_ViewportWidth, m_ViewportHeight);
+    frameGlobals.m_Tint = Math::Vec4(1.0f, 1.0f, 1.0f, 1.0f);
+    frameGlobals.m_Time = m_RotationSeconds;
+
+    m_RenderObject.m_Model = model;
+    m_Renderer.UpdateFrameGlobals(frameGlobals);
+    m_Renderer.UpdateMaterial(m_Material);
+    m_Renderer.UpdateRenderObject(m_RenderObject);
 #endif
 }
 

--- a/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.h
+++ b/Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.h
@@ -8,6 +8,7 @@
 #include "Core/Util/Base.h"
 #include "Demos/DemoBase.h"
 #include "Render/RHI/RHI.h"
+#include "Render/Renderer/ForwardRenderer.h"
 
 class TexturedRotatingCubeDemo : public DemoBase
 {
@@ -45,14 +46,10 @@ private:
     Scope<Texture> m_DepthTexture;
     Scope<TextureView> m_DepthView;
 
-    Scope<ShaderProgram> m_ShaderProgram;
-    Scope<PipelineLayout> m_PipelineLayout;
-    Scope<ResourceSet> m_FrameSet;
-    uint32_t m_FrameSetIndex = 0;
+    Renderer::ForwardRenderer m_Renderer;
+    Renderer::Mesh m_Mesh;
+    Renderer::Material m_Material;
+    Renderer::RenderObject m_RenderObject;
     Scope<ResourceSet> m_MaterialSet;
-    uint32_t m_MaterialSetIndex = 1;
     Scope<ResourceSet> m_ObjectSet;
-    uint32_t m_ObjectSetIndex = 2;
-    Scope<VertexInputLayout> m_VertexInputLayout;
-    Scope<GraphicsPipeline> m_GraphicsPipeline;
 };

--- a/Src/Render/Renderer/ForwardRenderer.cpp
+++ b/Src/Render/Renderer/ForwardRenderer.cpp
@@ -1,7 +1,102 @@
 #include "Render/Renderer/ForwardRenderer.h"
 
+#include <algorithm>
+#include <string>
+#include <utility>
+
+#include "Core/Diagnostics/Assert/Assert.h"
+#include "Render/Shader/ShaderCompiler.h"
+
 namespace Renderer
 {
+namespace
+{
+ShaderCompileRequest BuildGraphicsShaderCompileRequest(const std::filesystem::path& shaderPath)
+{
+    ShaderCompileRequest request;
+
+#if defined(GLAB_BACKEND_VULKAN)
+    request.m_Targets.push_back({BackendType::Vulkan, MetalCodeFormat::MslSource});
+#elif defined(GLAB_BACKEND_METAL)
+    request.m_Targets.push_back({BackendType::Metal, MetalCodeFormat::MslSource});
+#endif
+
+    const std::string shaderModule = shaderPath.generic_string();
+    request.m_Source.m_Entries.push_back({shaderModule, "main_vertex", ShaderStage::Vertex});
+    request.m_Source.m_Entries.push_back({shaderModule, "main_fragment", ShaderStage::Fragment});
+    return request;
+}
+
+CompiledShaderProgramDesc CompileShaderProgramDesc(const ShaderCompileRequest& request, std::string_view debugOwner)
+{
+    Scope<ShaderCompiler> shaderCompiler = CreateShaderCompiler();
+    RTRLAB_ASSERTF(shaderCompiler != nullptr, "{} requires a valid ShaderCompiler instance.", debugOwner);
+
+    ShaderCompileResult compileResult = shaderCompiler->CompileProgram(request);
+    RTRLAB_ASSERTF(compileResult.m_Succeeded,
+                   "{} failed to compile its Slang shader program: {}",
+                   debugOwner,
+                   compileResult.m_ErrorMessage);
+    return std::move(compileResult.m_Program);
+}
+
+uint32_t
+FindRequiredSetIndex(const PipelineLayoutDesc& layoutDesc, std::string_view bindingName, std::string_view debugOwner)
+{
+    const auto it = std::find_if(layoutDesc.m_Bindings.begin(),
+                                 layoutDesc.m_Bindings.end(),
+                                 [bindingName](const BindingInfo& binding) { return binding.m_Name == bindingName; });
+    RTRLAB_ASSERTF(it != layoutDesc.m_Bindings.end(),
+                   "{} failed to find reflected binding '{}' in the PipelineLayout.",
+                   debugOwner,
+                   bindingName);
+    return it->m_SetIndex;
+}
+} // namespace
+
+void ForwardRenderer::Initialize(Device& device, const ForwardRendererDesc& desc)
+{
+    RTRLAB_ASSERTF(!desc.m_ShaderPath.empty(), "{} requires a shader path.", desc.m_DebugName);
+    RTRLAB_ASSERTF(desc.m_ColorFormat != Format::Unknown, "{} requires a color target format.", desc.m_DebugName);
+    RTRLAB_ASSERTF(desc.m_VertexStride > 0, "{} requires a non-zero vertex stride.", desc.m_DebugName);
+
+    Reset();
+
+    m_ShaderProgram = device.CreateShaderProgram(
+        CompileShaderProgramDesc(BuildGraphicsShaderCompileRequest(desc.m_ShaderPath), desc.m_DebugName));
+    m_PipelineLayout = device.CreatePipelineLayout(m_ShaderProgram->DerivePipelineLayoutDesc());
+
+    const PipelineLayoutDesc& pipelineLayoutDesc = m_PipelineLayout->GetDesc();
+    m_SetIndices.m_FrameSet = FindRequiredSetIndex(pipelineLayoutDesc, "gFrame", desc.m_DebugName);
+    m_SetIndices.m_MaterialSet = FindRequiredSetIndex(pipelineLayoutDesc, "gMaterial", desc.m_DebugName);
+    m_SetIndices.m_ObjectSet = FindRequiredSetIndex(pipelineLayoutDesc, "gObject", desc.m_DebugName);
+
+    m_FrameSet = device.CreateResourceSet(m_PipelineLayout.get(), m_SetIndices.m_FrameSet);
+
+    VertexInputLayoutDesc vertexInputLayoutDesc;
+    vertexInputLayoutDesc.m_Buffers = {{desc.m_VertexStride, false}};
+    vertexInputLayoutDesc.m_Attributes = {
+        {0u, Format::RGBA32F, desc.m_PositionOffset, 0u},
+        {1u, Format::RG32F, desc.m_UVOffset, 0u},
+    };
+    m_VertexInputLayout = device.CreateVertexInputLayout(vertexInputLayoutDesc);
+
+    GraphicsPipelineDesc pipelineDesc;
+    pipelineDesc.m_PipelineLayout = m_PipelineLayout.get();
+    pipelineDesc.m_ShaderProgram = m_ShaderProgram.get();
+    pipelineDesc.m_VertexInput = m_VertexInputLayout.get();
+    pipelineDesc.m_RasterState.m_CullMode = CullMode::None;
+    if (desc.m_DepthFormat != Format::Unknown)
+    {
+        pipelineDesc.m_DepthStencilState.m_DepthTestEnable = true;
+        pipelineDesc.m_DepthStencilState.m_DepthWriteEnable = true;
+        pipelineDesc.m_DepthStencilState.m_DepthCompareOp = CompareOp::Less;
+        pipelineDesc.m_DepthFormat = desc.m_DepthFormat;
+    }
+    pipelineDesc.m_ColorFormats = {desc.m_ColorFormat};
+    m_GraphicsPipeline = device.CreateGraphicsPipeline(pipelineDesc);
+}
+
 bool ForwardRenderer::IsInitialized() const
 {
     return m_ShaderProgram != nullptr && m_PipelineLayout != nullptr && m_FrameSet != nullptr &&

--- a/Src/Render/Renderer/ForwardRenderer.cpp
+++ b/Src/Render/Renderer/ForwardRenderer.cpp
@@ -1,0 +1,20 @@
+#include "Render/Renderer/ForwardRenderer.h"
+
+namespace Renderer
+{
+bool ForwardRenderer::IsInitialized() const
+{
+    return m_ShaderProgram != nullptr && m_PipelineLayout != nullptr && m_FrameSet != nullptr &&
+           m_VertexInputLayout != nullptr && m_GraphicsPipeline != nullptr;
+}
+
+void ForwardRenderer::Reset()
+{
+    m_GraphicsPipeline.reset();
+    m_VertexInputLayout.reset();
+    m_FrameSet.reset();
+    m_PipelineLayout.reset();
+    m_ShaderProgram.reset();
+    m_SetIndices = {};
+}
+} // namespace Renderer

--- a/Src/Render/Renderer/ForwardRenderer.cpp
+++ b/Src/Render/Renderer/ForwardRenderer.cpp
@@ -6,6 +6,7 @@
 
 #include "Core/Diagnostics/Assert/Assert.h"
 #include "Render/Shader/ShaderCompiler.h"
+#include "Render/Shader/ShaderParameterWriter.h"
 
 namespace Renderer
 {
@@ -101,6 +102,72 @@ bool ForwardRenderer::IsInitialized() const
 {
     return m_ShaderProgram != nullptr && m_PipelineLayout != nullptr && m_FrameSet != nullptr &&
            m_VertexInputLayout != nullptr && m_GraphicsPipeline != nullptr;
+}
+
+Scope<ResourceSet> ForwardRenderer::CreateMaterialSet(Device& device) const
+{
+    RTRLAB_ASSERT_MSG(m_PipelineLayout != nullptr, "ForwardRenderer material set creation requires a PipelineLayout.");
+    return device.CreateResourceSet(m_PipelineLayout.get(), m_SetIndices.m_MaterialSet);
+}
+
+Scope<ResourceSet> ForwardRenderer::CreateObjectSet(Device& device) const
+{
+    RTRLAB_ASSERT_MSG(m_PipelineLayout != nullptr, "ForwardRenderer object set creation requires a PipelineLayout.");
+    return device.CreateResourceSet(m_PipelineLayout.get(), m_SetIndices.m_ObjectSet);
+}
+
+void ForwardRenderer::UpdateFrameGlobals(const FrameGlobals& frameGlobals) const
+{
+    RTRLAB_ASSERT_MSG(m_ShaderProgram != nullptr && m_FrameSet != nullptr,
+                      "ForwardRenderer frame updates require initialized shader resources.");
+
+    ShaderParameterWriter parameterWriter(m_ShaderProgram->GetReflection());
+    parameterWriter.SetMatrix4x4(*m_FrameSet, "gFrame.viewProj", frameGlobals.m_ViewProjection);
+    parameterWriter.SetFloat4(*m_FrameSet, "gFrame.tint", frameGlobals.m_Tint);
+    parameterWriter.SetFloat(*m_FrameSet, "gFrame.time", frameGlobals.m_Time);
+}
+
+void ForwardRenderer::UpdateMaterial(const Material& material) const
+{
+    RTRLAB_ASSERT_MSG(m_ShaderProgram != nullptr && material.m_ResourceSet != nullptr,
+                      "ForwardRenderer material updates require initialized shader resources.");
+
+    ShaderParameterWriter parameterWriter(m_ShaderProgram->GetReflection());
+    parameterWriter.SetFloat4(*material.m_ResourceSet, "gMaterial.baseColor", material.m_BaseColor);
+    parameterWriter.SetTextureView(*material.m_ResourceSet, "gAlbedoTexture", material.m_AlbedoTextureView);
+    parameterWriter.SetSampler(*material.m_ResourceSet, "gAlbedoSampler", material.m_AlbedoSampler);
+}
+
+void ForwardRenderer::UpdateRenderObject(const RenderObject& object) const
+{
+    RTRLAB_ASSERT_MSG(m_ShaderProgram != nullptr && object.m_ObjectSet != nullptr,
+                      "ForwardRenderer object updates require initialized shader resources.");
+
+    ShaderParameterWriter parameterWriter(m_ShaderProgram->GetReflection());
+    parameterWriter.SetMatrix4x4(*object.m_ObjectSet, "gObject.model", object.m_Model);
+}
+
+void ForwardRenderer::DrawObject(CommandList& commandList, const RenderObject& object) const
+{
+    RTRLAB_ASSERT_MSG(IsInitialized(), "ForwardRenderer draw requires initialized pipeline resources.");
+    RTRLAB_ASSERT_MSG(object.m_Mesh != nullptr && object.m_Material != nullptr,
+                      "ForwardRenderer draw requires a mesh and material.");
+    RTRLAB_ASSERT_MSG(object.m_Material->m_ResourceSet != nullptr && object.m_ObjectSet != nullptr,
+                      "ForwardRenderer draw requires material and object resource sets.");
+    RTRLAB_ASSERT_MSG(object.m_Mesh->m_VertexBuffer != nullptr && object.m_Mesh->m_IndexBuffer != nullptr,
+                      "ForwardRenderer draw requires vertex and index buffers.");
+
+    commandList.BindGraphicsPipeline(m_GraphicsPipeline.get());
+    commandList.BindResourceSet(m_SetIndices.m_FrameSet, m_FrameSet.get());
+    commandList.BindResourceSet(m_SetIndices.m_MaterialSet, object.m_Material->m_ResourceSet);
+    commandList.BindResourceSet(m_SetIndices.m_ObjectSet, object.m_ObjectSet);
+
+    MeshBinding meshBinding;
+    meshBinding.m_VertexBuffers = {object.m_Mesh->m_VertexBuffer};
+    meshBinding.m_IndexBuffer = object.m_Mesh->m_IndexBuffer;
+    meshBinding.m_IndexType = object.m_Mesh->m_IndexType;
+    commandList.BindMesh(meshBinding);
+    commandList.DrawIndexed(object.m_Mesh->m_IndexCount, object.m_Mesh->m_FirstIndex, object.m_Mesh->m_VertexOffset);
 }
 
 void ForwardRenderer::Reset()

--- a/Src/Render/Renderer/ForwardRenderer.h
+++ b/Src/Render/Renderer/ForwardRenderer.h
@@ -4,6 +4,8 @@
 /// @brief Minimal forward-renderer shell for shared demo rendering setup.
 
 #include <cstdint>
+#include <filesystem>
+#include <string_view>
 
 #include "Core/Util/Base.h"
 #include "Render/RHI/RHI.h"
@@ -17,9 +19,22 @@ struct ForwardRendererSetIndices
     uint32_t m_ObjectSet = 0;
 };
 
+struct ForwardRendererDesc
+{
+    std::filesystem::path m_ShaderPath;
+    Format m_ColorFormat = Format::Unknown;
+    Format m_DepthFormat = Format::Unknown;
+    uint32_t m_VertexStride = 0;
+    uint32_t m_PositionOffset = 0;
+    uint32_t m_UVOffset = 0;
+    std::string_view m_DebugName = "ForwardRenderer";
+};
+
 class ForwardRenderer
 {
 public:
+    void Initialize(Device& device, const ForwardRendererDesc& desc);
+
     bool IsInitialized() const;
     void Reset();
 

--- a/Src/Render/Renderer/ForwardRenderer.h
+++ b/Src/Render/Renderer/ForwardRenderer.h
@@ -1,0 +1,41 @@
+#pragma once
+
+/// @file ForwardRenderer.h
+/// @brief Minimal forward-renderer shell for shared demo rendering setup.
+
+#include <cstdint>
+
+#include "Core/Util/Base.h"
+#include "Render/RHI/RHI.h"
+
+namespace Renderer
+{
+struct ForwardRendererSetIndices
+{
+    uint32_t m_FrameSet = 0;
+    uint32_t m_MaterialSet = 0;
+    uint32_t m_ObjectSet = 0;
+};
+
+class ForwardRenderer
+{
+public:
+    bool IsInitialized() const;
+    void Reset();
+
+    ShaderProgram* GetShaderProgram() const { return m_ShaderProgram.get(); }
+    PipelineLayout* GetPipelineLayout() const { return m_PipelineLayout.get(); }
+    ResourceSet* GetFrameSet() const { return m_FrameSet.get(); }
+    VertexInputLayout* GetVertexInputLayout() const { return m_VertexInputLayout.get(); }
+    GraphicsPipeline* GetGraphicsPipeline() const { return m_GraphicsPipeline.get(); }
+    const ForwardRendererSetIndices& GetSetIndices() const { return m_SetIndices; }
+
+private:
+    Scope<ShaderProgram> m_ShaderProgram;
+    Scope<PipelineLayout> m_PipelineLayout;
+    Scope<ResourceSet> m_FrameSet;
+    Scope<VertexInputLayout> m_VertexInputLayout;
+    Scope<GraphicsPipeline> m_GraphicsPipeline;
+    ForwardRendererSetIndices m_SetIndices;
+};
+} // namespace Renderer

--- a/Src/Render/Renderer/ForwardRenderer.h
+++ b/Src/Render/Renderer/ForwardRenderer.h
@@ -9,6 +9,9 @@
 
 #include "Core/Util/Base.h"
 #include "Render/RHI/RHI.h"
+#include "Render/Renderer/FrameGlobals.h"
+#include "Render/Renderer/Material.h"
+#include "Render/Renderer/RenderObject.h"
 
 namespace Renderer
 {
@@ -37,6 +40,13 @@ public:
 
     bool IsInitialized() const;
     void Reset();
+
+    Scope<ResourceSet> CreateMaterialSet(Device& device) const;
+    Scope<ResourceSet> CreateObjectSet(Device& device) const;
+    void UpdateFrameGlobals(const FrameGlobals& frameGlobals) const;
+    void UpdateMaterial(const Material& material) const;
+    void UpdateRenderObject(const RenderObject& object) const;
+    void DrawObject(CommandList& commandList, const RenderObject& object) const;
 
     ShaderProgram* GetShaderProgram() const { return m_ShaderProgram.get(); }
     PipelineLayout* GetPipelineLayout() const { return m_PipelineLayout.get(); }

--- a/Src/Render/Renderer/FrameGlobals.h
+++ b/Src/Render/Renderer/FrameGlobals.h
@@ -1,0 +1,16 @@
+#pragma once
+
+/// @file FrameGlobals.h
+/// @brief Per-frame renderer parameters shared by forward-rendered objects.
+
+#include "Core/Util/Math.h"
+
+namespace Renderer
+{
+struct FrameGlobals
+{
+    Math::Mat4 m_ViewProjection = Math::Mat4::Identity();
+    Math::Vec4 m_Tint = Math::Vec4(1.0f, 1.0f, 1.0f, 1.0f);
+    float m_Time = 0.0f;
+};
+} // namespace Renderer

--- a/Src/Render/Renderer/Material.h
+++ b/Src/Render/Renderer/Material.h
@@ -1,0 +1,18 @@
+#pragma once
+
+/// @file Material.h
+/// @brief Minimal material data consumed by the forward renderer.
+
+#include "Core/Util/Math.h"
+#include "Render/RHI/RHIResources.h"
+
+namespace Renderer
+{
+struct Material
+{
+    Math::Vec4 m_BaseColor = Math::Vec4(1.0f, 1.0f, 1.0f, 1.0f);
+    TextureView* m_AlbedoTextureView = nullptr;
+    Sampler* m_AlbedoSampler = nullptr;
+    ResourceSet* m_ResourceSet = nullptr;
+};
+} // namespace Renderer

--- a/Src/Render/Renderer/Mesh.h
+++ b/Src/Render/Renderer/Mesh.h
@@ -1,0 +1,21 @@
+#pragma once
+
+/// @file Mesh.h
+/// @brief Minimal mesh binding data consumed by the forward renderer.
+
+#include <cstdint>
+
+#include "Render/RHI/RHIPipeline.h"
+
+namespace Renderer
+{
+struct Mesh
+{
+    Buffer* m_VertexBuffer = nullptr;
+    Buffer* m_IndexBuffer = nullptr;
+    IndexType m_IndexType = IndexType::UInt16;
+    uint32_t m_IndexCount = 0;
+    uint32_t m_FirstIndex = 0;
+    int32_t m_VertexOffset = 0;
+};
+} // namespace Renderer

--- a/Src/Render/Renderer/RenderObject.h
+++ b/Src/Render/Renderer/RenderObject.h
@@ -1,0 +1,20 @@
+#pragma once
+
+/// @file RenderObject.h
+/// @brief Minimal render-object data connecting a mesh, material, and transform.
+
+#include "Core/Util/Math.h"
+#include "Render/RHI/RHIResources.h"
+#include "Render/Renderer/Material.h"
+#include "Render/Renderer/Mesh.h"
+
+namespace Renderer
+{
+struct RenderObject
+{
+    const Mesh* m_Mesh = nullptr;
+    Material* m_Material = nullptr;
+    ResourceSet* m_ObjectSet = nullptr;
+    Math::Mat4 m_Model = Math::Mat4::Identity();
+};
+} // namespace Renderer


### PR DESCRIPTION
## Summary
- Added minimal renderer-facing scene data types: `Mesh`, `Material`, `RenderObject`, and `FrameGlobals`.
- Added a `ForwardRenderer` layer under `Src/Render/Renderer`.
- Moved textured forward shader, pipeline layout, frame set, vertex input, and graphics pipeline setup into `ForwardRenderer`.
- Routed `TexturedRotatingCubeDemo` through `ForwardRenderer` for frame/material/object parameter updates and draw submission.
- Kept mesh, texture, upload, and depth resource ownership in the demo for now.

## Why
- The textured cube demo was directly assembling shader, pipeline, resource set, and draw state.
- Moving that renderer-shaped logic out of the demo makes the next multi-object textured scene easier to build and review.
- Keeping the first renderer layer thin avoids introducing a premature render pass or render graph abstraction.

## Affected areas
- `Src/Render/Renderer/FrameGlobals.h`
- `Src/Render/Renderer/Material.h`
- `Src/Render/Renderer/Mesh.h`
- `Src/Render/Renderer/RenderObject.h`
- `Src/Render/Renderer/ForwardRenderer.h`
- `Src/Render/Renderer/ForwardRenderer.cpp`
- `Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.h`
- `Src/Demos/06_TexturedRotatingCube/TexturedRotatingCubeDemo.cpp`
- `CMake/Src/Sources.cmake`

## Documentation
- [x] No documentation needed
- [ ] Documentation updated

## Testing
- Not run; per workflow, compile/runtime validation is left for manual local verification.

## Notes
- This PR intentionally does not introduce a render pass abstraction yet.
- `ForwardRenderer` currently targets the existing textured forward path and leaves resource upload/depth texture management in the demo.